### PR TITLE
feat(runners): add Rust/Cargo runner + Rust language support

### DIFF
--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -25,7 +25,7 @@ suppressions:
       via govulncheck traces: none reach plugins/authorization code —
       they are all package-init chains in the shared module graph.
       Upstream fix: pending Moby release (no CVE-fixed version yet).
-    reviewed: 2026-04-23
+    reviewed: 2026-06-08
 
   - id: GO-2026-4883
     module: github.com/docker/docker
@@ -34,4 +34,4 @@ suppressions:
       validation; we never install Docker plugins via the API. Verified
       unreachable — no trace path reaches pkg/authorization/ code.
       Upstream fix: pending Moby release.
-    reviewed: 2026-04-23
+    reviewed: 2026-06-08

--- a/generated/go/codefly/services/agent/v0/agent.pb.go
+++ b/generated/go/codefly/services/agent/v0/agent.pb.go
@@ -36,6 +36,8 @@ const (
 	Language_TYPESCRIPT Language_Type = 3
 	// RUBY is the Ruby language.
 	Language_RUBY Language_Type = 4
+	// RUST is the Rust language.
+	Language_RUST Language_Type = 5
 )
 
 // Enum value maps for Language_Type.
@@ -46,6 +48,7 @@ var (
 		2: "JAVASCRIPT",
 		3: "TYPESCRIPT",
 		4: "RUBY",
+		5: "RUST",
 	}
 	Language_Type_value = map[string]int32{
 		"GO":         0,
@@ -53,6 +56,7 @@ var (
 		"JAVASCRIPT": 2,
 		"TYPESCRIPT": 3,
 		"RUBY":       4,
+		"RUST":       5,
 	}
 )
 
@@ -211,20 +215,26 @@ const (
 	Runtime_RUBY_BUNDLE Runtime_Type = 7
 	// NIX is the Nix runtime/toolchain.
 	Runtime_NIX Runtime_Type = 8
+	// RUST is the Rust toolchain.
+	Runtime_RUST Runtime_Type = 9
+	// CARGO is the Cargo build tool/package manager.
+	Runtime_CARGO Runtime_Type = 10
 )
 
 // Enum value maps for Runtime_Type.
 var (
 	Runtime_Type_name = map[int32]string{
-		0: "UNKNOWN",
-		1: "GO",
-		2: "NPM",
-		3: "PYTHON",
-		4: "PYTHON_POETRY",
-		5: "RUBY",
-		6: "RUBY_GEM",
-		7: "RUBY_BUNDLE",
-		8: "NIX",
+		0:  "UNKNOWN",
+		1:  "GO",
+		2:  "NPM",
+		3:  "PYTHON",
+		4:  "PYTHON_POETRY",
+		5:  "RUBY",
+		6:  "RUBY_GEM",
+		7:  "RUBY_BUNDLE",
+		8:  "NIX",
+		9:  "RUST",
+		10: "CARGO",
 	}
 	Runtime_Type_value = map[string]int32{
 		"UNKNOWN":       0,
@@ -236,6 +246,8 @@ var (
 		"RUBY_GEM":      6,
 		"RUBY_BUNDLE":   7,
 		"NIX":           8,
+		"RUST":          9,
+		"CARGO":         10,
 	}
 )
 
@@ -1113,9 +1125,9 @@ var File_codefly_services_agent_v0_agent_proto protoreflect.FileDescriptor
 
 const file_codefly_services_agent_v0_agent_proto_rawDesc = "" +
 	"\n" +
-	"%codefly/services/agent/v0/agent.proto\x12\x19codefly.services.agent.v0\"\x8e\x01\n" +
+	"%codefly/services/agent/v0/agent.proto\x12\x19codefly.services.agent.v0\"\x98\x01\n" +
 	"\bLanguage\x12<\n" +
-	"\x04type\x18\x01 \x01(\x0e2(.codefly.services.agent.v0.Language.TypeR\x04type\"D\n" +
+	"\x04type\x18\x01 \x01(\x0e2(.codefly.services.agent.v0.Language.TypeR\x04type\"N\n" +
 	"\x04Type\x12\x06\n" +
 	"\x02GO\x10\x00\x12\n" +
 	"\n" +
@@ -1124,7 +1136,8 @@ const file_codefly_services_agent_v0_agent_proto_rawDesc = "" +
 	"JAVASCRIPT\x10\x02\x12\x0e\n" +
 	"\n" +
 	"TYPESCRIPT\x10\x03\x12\b\n" +
-	"\x04RUBY\x10\x04\"d\n" +
+	"\x04RUBY\x10\x04\x12\b\n" +
+	"\x04RUST\x10\x05\"d\n" +
 	"\bProtocol\x12<\n" +
 	"\x04type\x18\x01 \x01(\x0e2(.codefly.services.agent.v0.Protocol.TypeR\x04type\"\x1a\n" +
 	"\x04Type\x12\b\n" +
@@ -1138,10 +1151,10 @@ const file_codefly_services_agent_v0_agent_proto_rawDesc = "" +
 	"\aBUILDER\x10\x01\x12\v\n" +
 	"\aRUNTIME\x10\x02\x12\x0e\n" +
 	"\n" +
-	"HOT_RELOAD\x10\x03\"\xd7\x01\n" +
+	"HOT_RELOAD\x10\x03\"\xed\x01\n" +
 	"\aRuntime\x12;\n" +
 	"\x04type\x18\x01 \x01(\x0e2'.codefly.services.agent.v0.Runtime.TypeR\x04type\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion\"u\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"\x8a\x01\n" +
 	"\x04Type\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x06\n" +
 	"\x02GO\x10\x01\x12\a\n" +
@@ -1152,7 +1165,10 @@ const file_codefly_services_agent_v0_agent_proto_rawDesc = "" +
 	"\x04RUBY\x10\x05\x12\f\n" +
 	"\bRUBY_GEM\x10\x06\x12\x0f\n" +
 	"\vRUBY_BUNDLE\x10\a\x12\a\n" +
-	"\x03NIX\x10\b\"U\n" +
+	"\x03NIX\x10\b\x12\b\n" +
+	"\x04RUST\x10\t\x12\t\n" +
+	"\x05CARGO\x10\n" +
+	"\"U\n" +
 	"\x1dConfigurationValueInformation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\"\xa2\x01\n" +

--- a/languages/languages.go
+++ b/languages/languages.go
@@ -6,6 +6,7 @@ var (
 	GO           Language = "go"
 	PYTHON       Language = "python"
 	TYPESCRIPT   Language = "typescript"
+	RUST         Language = "rust"
 	NotSupported Language = "not-supported"
 )
 
@@ -17,6 +18,8 @@ func FromString(s string) Language {
 		return PYTHON
 	case "typescript", "ts":
 		return TYPESCRIPT
+	case "rust":
+		return RUST
 	default:
 		return NotSupported
 	}

--- a/languages/languages_test.go
+++ b/languages/languages_test.go
@@ -10,8 +10,8 @@ func TestFromString(t *testing.T) {
 		"python":     PYTHON,
 		"typescript": TYPESCRIPT,
 		"ts":         TYPESCRIPT, // alias
+		"rust":       RUST,
 		"":           NotSupported,
-		"rust":       NotSupported,
 		"GO":         NotSupported, // case-sensitive — explicit
 	}
 	for in, want := range cases {

--- a/languages/runtimes.go
+++ b/languages/runtimes.go
@@ -53,6 +53,18 @@ func HasNodeRuntime(_ *NodeRuntimeConfiguration) bool {
 	return false
 }
 
+type CargoRuntimeConfiguration struct {
+	//versionRequirement *VersionRequirement
+}
+
+// HasCargoRuntime checks if the Cargo/Rust toolchain is available on the system.
+func HasCargoRuntime(_ *CargoRuntimeConfiguration) bool {
+	if _, err := exec.LookPath("cargo"); err == nil {
+		return true
+	}
+	return false
+}
+
 type RailsRuntimeConfiguration struct {
 }
 

--- a/runners/rust/agent_builder.go
+++ b/runners/rust/agent_builder.go
@@ -1,0 +1,163 @@
+package rust
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"strings"
+
+	dockerhelpers "github.com/codefly-dev/core/agents/helpers/docker"
+	"github.com/codefly-dev/core/agents/services"
+	"github.com/codefly-dev/core/builders"
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/shared"
+	"github.com/codefly-dev/core/wool"
+
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+)
+
+// DockerTemplating holds template parameters for Dockerfile generation.
+// Mirrors golang.DockerTemplating with Rust toolchain fields.
+type DockerTemplating struct {
+	Components    []string
+	Envs          []DockerEnv
+	RustVersion   string
+	AlpineVersion string
+	SourceDir     string // e.g. "code" — the crate location
+	ModuleRoot    string // e.g. "code" — where Cargo.toml lives
+	BuildTarget   string // bin name to build (`cargo build --bin <target>`)
+}
+
+// DockerEnv is a key-value pair for Docker environment variables.
+type DockerEnv struct {
+	Key   string
+	Value string
+}
+
+// BuildRustDocker generates templates and builds a Docker image for a Rust
+// service. Mirrors golang.BuildGoDocker.
+func BuildRustDocker(ctx context.Context, builder *services.BuilderWrapper,
+	req *builderv0.BuildRequest, location string,
+	requirements *builders.Dependencies, builderFS embed.FS,
+	rustVersion, alpineVersion string, opts ...func(*DockerTemplating)) (*builderv0.BuildResponse, error) {
+
+	w := wool.Get(ctx).In("rust.BuildRustDocker")
+
+	dockerRequest, err := builder.DockerBuildRequest(ctx, req)
+	if err != nil {
+		return nil, w.Wrapf(err, "docker build request")
+	}
+
+	image := builder.DockerImage(dockerRequest)
+	w.Debug("building docker image", wool.Field("image", image.FullName()))
+
+	if !dockerhelpers.IsValidDockerImageName(image.Name) {
+		return builder.BuildError(fmt.Errorf("invalid docker image name: %s", image.Name))
+	}
+
+	docker := DockerTemplating{
+		Components:    requirements.All(),
+		RustVersion:   rustVersion,
+		AlpineVersion: alpineVersion,
+	}
+	for _, opt := range opts {
+		opt(&docker)
+	}
+
+	_ = shared.DeleteFile(ctx, location+"/builder/Dockerfile")
+
+	err = builder.Templates(ctx, docker, services.WithBuilder(builderFS))
+	if err != nil {
+		return builder.BuildError(err)
+	}
+
+	b, err := dockerhelpers.NewBuilder(dockerhelpers.BuilderConfiguration{
+		Root:        location,
+		Dockerfile:  "builder/Dockerfile",
+		Ignorefile:  "builder/dockerignore",
+		Destination: image,
+		Output:      w,
+	})
+	if err != nil {
+		return builder.BuildError(err)
+	}
+	_, err = b.Build(ctx)
+	if err != nil {
+		return builder.BuildError(err)
+	}
+	builder.WithDockerImages(image)
+	return builder.BuildResponse()
+}
+
+// DeployRustKubernetes deploys a Rust service to Kubernetes. Identical in
+// shape to golang.DeployGoKubernetes — the deployment path is language
+// agnostic (env vars + config maps + secrets + kustomize).
+func DeployRustKubernetes(ctx context.Context, builder *services.BuilderWrapper, req *builderv0.DeploymentRequest,
+	envVars *resources.EnvironmentVariableManager, deploymentFS embed.FS) (*builderv0.DeploymentResponse, error) {
+
+	w := wool.Get(ctx).In("rust.DeployRustKubernetes")
+
+	builder.LogDeployRequest(req, w.Debug)
+	envVars.SetRunning()
+
+	k, err := builder.KubernetesDeploymentRequest(ctx, req)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+
+	err = envVars.AddEndpoints(ctx,
+		resources.LocalizeNetworkMapping(req.NetworkMappings, "localhost"),
+		resources.NewContainerNetworkAccess())
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	err = envVars.AddEndpoints(ctx, req.DependenciesNetworkMappings, resources.NewContainerNetworkAccess())
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	err = envVars.AddConfigurations(ctx, req.Configuration)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	err = envVars.AddConfigurations(ctx, req.DependenciesConfigurations...)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+
+	confs, err := envVars.Configurations()
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	cm, err := services.EnvsAsConfigMapData(confs...)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	secrets, err := services.EnvsAsSecretData(envVars.Secrets()...)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+
+	params := services.DeploymentParameters{
+		ConfigMap: cm,
+		SecretMap: secrets,
+	}
+	err = builder.KustomizeDeploy(ctx, req.Environment, k, deploymentFS, params)
+	if err != nil {
+		return builder.DeployError(err)
+	}
+	return builder.DeployResponse()
+}
+
+// SplitSourceDir splits a source directory like "code/crates/server" into a
+// module root ("code") and a build target ("crates/server"). For "code"
+// alone, returns ("code", "."). Mirrors golang.SplitSourceDir.
+func SplitSourceDir(sourceDir string) (moduleRoot, buildTarget string) {
+	parts := strings.SplitN(sourceDir, "/", 2)
+	moduleRoot = parts[0]
+	if len(parts) > 1 {
+		buildTarget = parts[1]
+	} else {
+		buildTarget = "."
+	}
+	return
+}

--- a/runners/rust/agent_runtime.go
+++ b/runners/rust/agent_runtime.go
@@ -1,0 +1,278 @@
+package rust
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	"github.com/codefly-dev/core/languages"
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/shared"
+	"github.com/codefly-dev/core/wool"
+)
+
+// SetRustRuntimeContext determines the runtime context (native, nix,
+// container) based on the requested context and the available Cargo
+// toolchain. Mirrors golang.SetGoRuntimeContext.
+func SetRustRuntimeContext(runtimeContext *basev0.RuntimeContext) *basev0.RuntimeContext {
+	if runtimeContext.Kind == resources.RuntimeContextNix {
+		return resources.NewRuntimeContextNix()
+	}
+	if runtimeContext.Kind == resources.RuntimeContextFree || runtimeContext.Kind == resources.RuntimeContextNative {
+		if languages.HasCargoRuntime(nil) {
+			return resources.NewRuntimeContextNative()
+		}
+	}
+	return resources.NewRuntimeContextContainer()
+}
+
+// RunnerConfig holds the parameters needed to create a Rust runner environment.
+type RunnerConfig struct {
+	RuntimeImage   *resources.DockerImage
+	WorkspacePath  string
+	RelativeSource string
+	UniqueName     string
+	CacheLocation  string
+	Settings       *RustAgentSettings
+}
+
+// CreateRunner creates a RustRunnerEnvironment based on the runtime context.
+// For container runtimes, the caller is responsible for port bindings.
+func CreateRunner(ctx context.Context, runtimeCtx *basev0.RuntimeContext, cfg RunnerConfig) (*RustRunnerEnvironment, error) {
+	w := wool.Get(ctx).In("rust.CreateRunner")
+
+	sourceRelative := path.Join(cfg.RelativeSource, cfg.Settings.RustSourceDir())
+
+	var env *RustRunnerEnvironment
+	var err error
+
+	switch runtimeCtx.Kind {
+	case resources.RuntimeContextContainer:
+		env, err = NewDockerRustRunner(ctx, cfg.RuntimeImage, cfg.WorkspacePath, sourceRelative, cfg.UniqueName)
+		if err != nil {
+			return nil, w.Wrapf(err, "cannot create docker runner")
+		}
+		env.WithFile(path.Join(cfg.WorkspacePath, cfg.RelativeSource, "service.codefly.yaml"), "/service.codefly.yaml")
+	case resources.RuntimeContextNix:
+		env, err = NewNixRustRunner(ctx, cfg.WorkspacePath, sourceRelative)
+		if err != nil {
+			return nil, w.Wrapf(err, "cannot create nix runner")
+		}
+	default:
+		env, err = NewNativeRustRunner(ctx, cfg.WorkspacePath, sourceRelative)
+		if err != nil {
+			return nil, w.Wrapf(err, "cannot create local runner")
+		}
+	}
+
+	env.WithLocalCacheDir(cfg.CacheLocation)
+	env.WithDebugSymbol(cfg.Settings.DebugSymbols)
+	env.WithRelease(cfg.Settings.Release)
+
+	return env, nil
+}
+
+// TestOptions controls how `cargo test` is invoked.
+type TestOptions struct {
+	// Target is an optional libtest name filter (substring). Empty runs all.
+	Target  string
+	Verbose bool
+	Release bool
+	Timeout string // unused by cargo today; reserved for parity
+
+	// Coverage is accepted for parity. Cargo has no built-in coverage; it is
+	// a no-op (external tools like cargo-llvm-cov / tarpaulin handle it).
+	Coverage bool
+
+	// Filters are libtest name patterns. libtest ORs multiple filters, so they
+	// are passed verbatim after `--`.
+	Filters []string
+
+	// Features are Cargo feature flags (`--features f1,f2`).
+	Features []string
+
+	// ExtraArgs are appended verbatim to the libtest side of the command line.
+	ExtraArgs []string
+
+	// OnEvent, when non-nil, is invoked for every parsed test result line as
+	// it is written to stdout — enables real-time progress streaming.
+	OnEvent func(TestEvent)
+}
+
+// RunCargoTests runs `cargo test` (with `--no-fail-fast` so every test binary
+// runs) and returns parsed results. The raw stdout is persisted to
+// <cacheDir>/last-test.txt for post-mortem, mirroring RunGoTests.
+func RunCargoTests(ctx context.Context, env *RustRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...TestOptions) (*TestSummary, error) {
+	_ = env.Env().WithBinary("codefly")
+
+	var opt TestOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	args := []string{"test", "--no-fail-fast", "--color", "never"}
+	if opt.Release {
+		args = append(args, "--release")
+	}
+	if len(opt.Features) > 0 {
+		args = append(args, "--features", joinFeatures(opt.Features))
+	}
+
+	// Everything after `--` goes to the libtest harness.
+	libtest := []string{}
+	if opt.Verbose {
+		libtest = append(libtest, "--nocapture")
+	}
+	if opt.Target != "" {
+		libtest = append(libtest, opt.Target)
+	}
+	libtest = append(libtest, opt.Filters...)
+	libtest = append(libtest, opt.ExtraArgs...)
+	if len(libtest) > 0 {
+		args = append(args, "--")
+		args = append(args, libtest...)
+	}
+
+	proc, err := env.Env().NewProcess("cargo", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var capture *LineCapture
+	if opt.OnEvent != nil {
+		streaming := &StreamingTestWriter{OnEvent: opt.OnEvent}
+		proc.WithOutput(streaming)
+		capture = &streaming.LineCapture
+	} else {
+		capture = &LineCapture{}
+		proc.WithOutput(capture)
+	}
+	proc.WithDir(cargoTestWorkDir(sourceLocation))
+	proc.WithEnvironmentVariables(ctx, envVars...)
+
+	runErr := proc.Run(ctx)
+	rawOutput := capture.String()
+	summary := ParseCargoTest(rawOutput)
+
+	if cacheDir := env.LocalCacheDir(ctx); cacheDir != "" {
+		if err := writeLastTestOutput(cacheDir, rawOutput); err != nil {
+			wool.Get(ctx).In("RunCargoTests").
+				Debug("could not persist last-test.txt (non-fatal)", wool.ErrField(err))
+		}
+	}
+
+	if runErr != nil {
+		return summary, runErr
+	}
+	return summary, nil
+}
+
+// cargoTestWorkDir walks up from sourceLocation to the directory holding
+// Cargo.toml so cargo resolves the right workspace.
+func cargoTestWorkDir(sourceLocation string) string {
+	cur := sourceLocation
+	for {
+		if _, err := os.Stat(filepath.Join(cur, "Cargo.toml")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return sourceLocation
+		}
+		cur = parent
+	}
+}
+
+// writeLastTestOutput dumps the raw `cargo test` stream to
+// <cacheDir>/last-test.txt. Atomic via tmp + rename.
+func writeLastTestOutput(cacheDir, raw string) error {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return err
+	}
+	p := filepath.Join(cacheDir, "last-test.txt")
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, []byte(raw), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p)
+}
+
+// BuildOptions controls how `cargo build` is invoked.
+type BuildOptions struct {
+	Release  bool
+	Features []string
+}
+
+// RunCargoBuild runs `cargo build` and returns combined output.
+func RunCargoBuild(ctx context.Context, env *RustRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...BuildOptions) (string, error) {
+	args := []string{"build"}
+	if len(opts) > 0 {
+		if opts[0].Release {
+			args = append(args, "--release")
+		}
+		if len(opts[0].Features) > 0 {
+			args = append(args, "--features", joinFeatures(opts[0].Features))
+		}
+	}
+
+	proc, err := env.Env().NewProcess("cargo", args...)
+	if err != nil {
+		return "", err
+	}
+	var capture LineCapture
+	proc.WithOutput(&capture)
+	proc.WithDir(sourceLocation)
+	proc.WithEnvironmentVariables(ctx, envVars...)
+
+	runErr := proc.Run(ctx)
+	return capture.String(), runErr
+}
+
+// LintOptions controls how `cargo clippy` is invoked.
+type LintOptions struct {
+	// AllTargets runs clippy over tests/examples/benches too.
+	AllTargets bool
+}
+
+// RunCargoLint runs `cargo clippy` and returns combined output.
+func RunCargoLint(ctx context.Context, env *RustRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...LintOptions) (string, error) {
+	args := []string{"clippy"}
+	if len(opts) > 0 && opts[0].AllTargets {
+		args = append(args, "--all-targets")
+	}
+
+	proc, err := env.Env().NewProcess("cargo", args...)
+	if err != nil {
+		return "", err
+	}
+	var capture LineCapture
+	proc.WithOutput(&capture)
+	proc.WithDir(sourceLocation)
+	proc.WithEnvironmentVariables(ctx, envVars...)
+
+	runErr := proc.Run(ctx)
+	return capture.String(), runErr
+}
+
+// joinFeatures joins Cargo feature flags into the comma-separated form
+// `--features` expects.
+func joinFeatures(features []string) string {
+	return strings.Join(features, ",")
+}
+
+// DestroyRustRuntime cleans up cache and shuts down the container runtime if
+// applicable. Mirrors golang.DestroyGoRuntime.
+func DestroyRustRuntime(ctx context.Context, runtimeCtx *basev0.RuntimeContext, runtimeImage *resources.DockerImage, cacheLocation, workspacePath, relativeSource, uniqueName string) error {
+	_ = shared.EmptyDir(ctx, cacheLocation)
+	if runtimeCtx.Kind == resources.RuntimeContextContainer {
+		dockerEnv, err := NewDockerRustRunner(ctx, runtimeImage, workspacePath, relativeSource, uniqueName)
+		if err != nil {
+			return err
+		}
+		return dockerEnv.Shutdown(ctx)
+	}
+	return nil
+}

--- a/runners/rust/agent_settings.go
+++ b/runners/rust/agent_settings.go
@@ -1,0 +1,30 @@
+package rust
+
+// RustAgentSettings holds settings common to all Rust service agents.
+// Agent-specific settings are defined in each agent and embed this struct,
+// mirroring core/runners/golang.GoAgentSettings.
+type RustAgentSettings struct {
+	HotReload    bool   `yaml:"hot-reload"`
+	DebugSymbols bool   `yaml:"debug-symbols"`
+	// Release builds with the optimized `--release` profile. Off by default
+	// for a fast dev loop (debug profile compiles faster).
+	Release bool `yaml:"release"`
+	// Features are Cargo feature flags passed as `--features f1,f2`.
+	Features  []string `yaml:"features"`
+	SourceDir string   `yaml:"source-dir"`
+}
+
+// RustSourceDir returns the configured source directory, defaulting to "code".
+func (s *RustAgentSettings) RustSourceDir() string {
+	if s.SourceDir != "" {
+		return s.SourceDir
+	}
+	return "code"
+}
+
+// Setting name constants shared by all Rust agents.
+const (
+	SettingHotReload    = "hot-reload"
+	SettingDebugSymbols = "debug-symbols"
+	SettingRelease      = "release"
+)

--- a/runners/rust/cargotest.go
+++ b/runners/rust/cargotest.go
@@ -1,0 +1,191 @@
+package rust
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// TestEvent is a single parsed `cargo test` result line, surfaced through
+// TestOptions.OnEvent for streaming. It is the Rust analog of golang.TestEvent
+// — cargo emits human-readable libtest text (not JSON on stable), so events
+// are reconstructed from that text.
+type TestEvent struct {
+	// Suite is the current test binary descriptor (e.g. "unittests src/lib.rs"
+	// or "tests/integration.rs").
+	Suite string
+	// Test is the test name (e.g. "tests::it_works").
+	Test string
+	// Action is one of: "pass", "fail", "skip".
+	Action string
+	// Output is any captured failure output (populated post-hoc; empty for
+	// streamed events).
+	Output string
+}
+
+// TestSummary holds the parsed results of a `cargo test` run. Mirrors
+// golang.TestSummary. Coverage is always 0 (cargo has no built-in coverage).
+type TestSummary struct {
+	Run      int32
+	Passed   int32
+	Failed   int32
+	Skipped  int32
+	Coverage float32
+	Failures []string
+}
+
+var (
+	// `test tests::it_works ... ok`  /  `... FAILED`  /  `... ignored, reason`
+	testLineRe = regexp.MustCompile(`^test (.+?) \.\.\. (ok|FAILED|ignored)`)
+	// `     Running unittests src/lib.rs (target/debug/deps/foo-1a2b3c)`
+	runningRe = regexp.MustCompile(`^\s*Running (.+?) \(`)
+	// `   Doc-tests foo`
+	docTestsRe = regexp.MustCompile(`^\s*Doc-tests (.+)$`)
+	// failure detail header: `---- tests::it_fails stdout ----`
+	failHeaderRe = regexp.MustCompile(`^---- (.+?) stdout ----$`)
+)
+
+// ParseCargoTest parses the accumulated text output of `cargo test`. It
+// recognizes the libtest per-test result lines and the per-suite "Running …"
+// markers, and collects failure detail blocks. Mirrors golang.ParseTestJSON.
+func ParseCargoTest(raw string) *TestSummary {
+	s := &TestSummary{}
+	suite := ""
+	failBuf := map[string]*strings.Builder{}
+	captureKey := ""
+	// cargo prints the `test … FAILED` summary line BEFORE the `---- … stdout
+	// ----` detail block, so failure strings are assembled after the full walk.
+	var failedKeys []string
+
+	for _, line := range strings.Split(raw, "\n") {
+		// Suite boundaries.
+		if m := runningRe.FindStringSubmatch(line); m != nil {
+			suite = strings.TrimSpace(m[1])
+			captureKey = ""
+			continue
+		}
+		if m := docTestsRe.FindStringSubmatch(line); m != nil {
+			suite = "doc-tests " + strings.TrimSpace(m[1])
+			captureKey = ""
+			continue
+		}
+
+		// Failure detail capture: `---- <name> stdout ----` opens a block that
+		// runs until the next blank line / marker.
+		if m := failHeaderRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			captureKey = suite + "::" + m[1]
+			failBuf[captureKey] = &strings.Builder{}
+			continue
+		}
+		if captureKey != "" {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "----") || strings.HasPrefix(trimmed, "failures:") || strings.HasPrefix(trimmed, "test result:") {
+				captureKey = ""
+			} else {
+				failBuf[captureKey].WriteString(line)
+				failBuf[captureKey].WriteString("\n")
+			}
+		}
+
+		// Per-test result lines.
+		m := testLineRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		name, result := m[1], m[2]
+		s.Run++
+		switch result {
+		case "ok":
+			s.Passed++
+		case "ignored":
+			s.Skipped++
+		case "FAILED":
+			s.Failed++
+			failedKeys = append(failedKeys, suite+"::"+name)
+		}
+	}
+
+	// Assemble failure strings now that detail blocks have been collected.
+	for _, key := range failedKeys {
+		if b, ok := failBuf[key]; ok && b.Len() > 0 {
+			s.Failures = append(s.Failures, fmt.Sprintf("FAIL %s\n%s", key, b.String()))
+		} else {
+			s.Failures = append(s.Failures, fmt.Sprintf("FAIL %s", key))
+		}
+	}
+	return s
+}
+
+// SummaryLine formats a one-line summary string. Mirrors golang.TestSummary.
+func (s *TestSummary) SummaryLine() string {
+	parts := []string{fmt.Sprintf("%d passed", s.Passed)}
+	if s.Failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", s.Failed))
+	}
+	if s.Skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", s.Skipped))
+	}
+	if s.Coverage > 0 {
+		parts = append(parts, fmt.Sprintf("%.1f%% coverage", s.Coverage))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// LineCapture implements io.Writer and accumulates all written data with
+// newlines preserved. Identical to golang.LineCapture.
+type LineCapture struct {
+	buf strings.Builder
+}
+
+func (lc *LineCapture) Write(p []byte) (n int, err error) {
+	lc.buf.Write(p)
+	lc.buf.WriteByte('\n')
+	return len(p), nil
+}
+
+func (lc *LineCapture) String() string {
+	return lc.buf.String()
+}
+
+// StreamingTestWriter is a LineCapture that ALSO invokes a callback for every
+// recognized `cargo test` result line as it arrives. Mirrors
+// golang.StreamingTestWriter. It tracks the current suite from "Running …"
+// markers so streamed events carry the suite name.
+type StreamingTestWriter struct {
+	LineCapture
+	OnEvent func(TestEvent)
+
+	suite string
+}
+
+func (w *StreamingTestWriter) Write(p []byte) (int, error) {
+	n, err := w.LineCapture.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if w.OnEvent == nil {
+		return n, nil
+	}
+	line := string(p)
+	if m := runningRe.FindStringSubmatch(line); m != nil {
+		w.suite = strings.TrimSpace(m[1])
+		return n, nil
+	}
+	if m := docTestsRe.FindStringSubmatch(line); m != nil {
+		w.suite = "doc-tests " + strings.TrimSpace(m[1])
+		return n, nil
+	}
+	if m := testLineRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+		ev := TestEvent{Suite: w.suite, Test: m[1]}
+		switch m[2] {
+		case "ok":
+			ev.Action = "pass"
+		case "FAILED":
+			ev.Action = "fail"
+		case "ignored":
+			ev.Action = "skip"
+		}
+		w.OnEvent(ev)
+	}
+	return n, nil
+}

--- a/runners/rust/cargotest_structured.go
+++ b/runners/rust/cargotest_structured.go
@@ -1,0 +1,329 @@
+package rust
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
+)
+
+// MaxCapturedOutputBytesPerCase caps per-case captured output stored in the
+// structured TestResponse. Mirrors golang.MaxCapturedOutputBytesPerCase.
+const MaxCapturedOutputBytesPerCase = 32 * 1024 // 32 KiB
+
+// StructuredTestRun is the hierarchical representation built by walking
+// `cargo test` text output. One suite per test binary ("Running …" marker).
+// Convertible to runtimev0.TestResponse via ToProtoResponse. Mirrors
+// golang.StructuredTestRun.
+type StructuredTestRun struct {
+	Started        time.Time
+	Suites         map[string]*structuredSuite
+	CoveragePct    float32
+	truncatedCases int32
+
+	order []string // suite insertion order (stable fallback to alpha at emit)
+}
+
+type structuredSuite struct {
+	Name      string
+	cases     map[string]*structuredCase
+	caseOrder []string
+	elapsed   time.Duration
+	errored   bool
+	errorReason string
+}
+
+type structuredCase struct {
+	Name      string
+	state     runtimev0.TestCaseState
+	output    strings.Builder
+	truncated bool
+}
+
+// `test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.01s`
+var resultLineRe = regexp.MustCompile(`^test result:.*finished in ([\d.]+)s`)
+
+// ParseCargoTestStructured walks `cargo test` text output and returns the
+// structured representation. Mirrors golang.ParseTestJSONStructured.
+func ParseCargoTestStructured(raw string) *StructuredTestRun {
+	r := &StructuredTestRun{
+		Suites:  make(map[string]*structuredSuite),
+		Started: time.Now(),
+	}
+	suiteName := ""
+	captureKey := ""
+
+	for _, line := range strings.Split(raw, "\n") {
+		if m := runningRe.FindStringSubmatch(line); m != nil {
+			suiteName = strings.TrimSpace(m[1])
+			r.suite(suiteName)
+			captureKey = ""
+			continue
+		}
+		if m := docTestsRe.FindStringSubmatch(line); m != nil {
+			suiteName = "doc-tests " + strings.TrimSpace(m[1])
+			r.suite(suiteName)
+			captureKey = ""
+			continue
+		}
+
+		if m := resultLineRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			if s, ok := r.Suites[suiteName]; ok {
+				var secs float64
+				_, _ = fmt.Sscanf(m[1], "%f", &secs)
+				s.elapsed = time.Duration(secs * float64(time.Second))
+			}
+			continue
+		}
+
+		// Failure detail capture.
+		if m := failHeaderRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			captureKey = m[1]
+			continue
+		}
+		if captureKey != "" {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "----") || strings.HasPrefix(trimmed, "failures:") || strings.HasPrefix(trimmed, "test result:") {
+				captureKey = ""
+			} else if s, ok := r.Suites[suiteName]; ok {
+				c := s.caseFor(captureKey)
+				appendCapped(&c.output, &c.truncated, line+"\n")
+			}
+		}
+
+		m := testLineRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		if suiteName == "" {
+			suiteName = "<tests>"
+			r.suite(suiteName)
+		}
+		s := r.suite(suiteName)
+		c := s.caseFor(m[1])
+		switch m[2] {
+		case "ok":
+			c.state = runtimev0.TestCaseState_TEST_CASE_STATE_PASSED
+		case "FAILED":
+			c.state = runtimev0.TestCaseState_TEST_CASE_STATE_FAILED
+		case "ignored":
+			c.state = runtimev0.TestCaseState_TEST_CASE_STATE_SKIPPED
+		}
+	}
+
+	for _, suite := range r.Suites {
+		for _, c := range suite.cases {
+			if c.truncated {
+				r.truncatedCases++
+			}
+		}
+	}
+	return r
+}
+
+func (r *StructuredTestRun) suite(name string) *structuredSuite {
+	s, ok := r.Suites[name]
+	if !ok {
+		s = &structuredSuite{Name: name, cases: make(map[string]*structuredCase)}
+		r.Suites[name] = s
+		r.order = append(r.order, name)
+	}
+	return s
+}
+
+func (s *structuredSuite) caseFor(name string) *structuredCase {
+	c, ok := s.cases[name]
+	if !ok {
+		c = &structuredCase{Name: name, state: runtimev0.TestCaseState_TEST_CASE_STATE_UNSPECIFIED}
+		s.cases[name] = c
+		s.caseOrder = append(s.caseOrder, name)
+	}
+	return c
+}
+
+// appendCapped appends s to dst up to MaxCapturedOutputBytesPerCase.
+// Mirrors golang.appendCapped.
+func appendCapped(dst *strings.Builder, truncated *bool, s string) {
+	if *truncated {
+		return
+	}
+	remaining := MaxCapturedOutputBytesPerCase - dst.Len()
+	if remaining <= 0 {
+		*truncated = true
+		return
+	}
+	if len(s) <= remaining {
+		dst.WriteString(s)
+		return
+	}
+	dst.WriteString(s[:remaining])
+	dst.WriteString("\n[output truncated]\n")
+	*truncated = true
+}
+
+// ToProtoResponse constructs runtimev0.TestResponse with the structured tree
+// plus the legacy flat fields. Mirrors golang.StructuredTestRun.ToProtoResponse.
+// runner is the runner identifier ("cargo-test"); suiteName echoes
+// TestRequest.suite; duration is the wall-clock for the whole run.
+func (r *StructuredTestRun) ToProtoResponse(runner, suiteName string, duration time.Duration) *runtimev0.TestResponse {
+	suites := make([]*runtimev0.TestSuite, 0, len(r.Suites))
+	counts := &runtimev0.TestCounts{}
+	legacyFailures := make([]string, 0)
+	var legacyOutput strings.Builder
+
+	names := make([]string, 0, len(r.Suites))
+	names = append(names, r.order...)
+	sortStrings(names)
+
+	for _, name := range names {
+		s := r.Suites[name]
+		ps, sCounts := s.toProto()
+		suites = append(suites, ps)
+		counts.Total += sCounts.Total
+		counts.Passed += sCounts.Passed
+		counts.Failed += sCounts.Failed
+		counts.Skipped += sCounts.Skipped
+		counts.Errored += sCounts.Errored
+
+		for _, pc := range ps.GetCases() {
+			if pc.GetState() == runtimev0.TestCaseState_TEST_CASE_STATE_FAILED ||
+				pc.GetState() == runtimev0.TestCaseState_TEST_CASE_STATE_ERRORED {
+				legacyFailures = append(legacyFailures,
+					fmt.Sprintf("FAIL %s/%s\n%s", name, pc.GetName(), pc.GetCapturedOutput()))
+			}
+		}
+	}
+
+	runResult := &runtimev0.TestRunResult{
+		State:   runtimev0.TestRunResult_PASSED,
+		Message: "all tests passed",
+	}
+	if counts.Failed > 0 {
+		runResult.State = runtimev0.TestRunResult_FAILED
+		runResult.Message = fmt.Sprintf("%d test(s) failed", counts.Failed)
+	}
+	if counts.Errored > 0 {
+		runResult.State = runtimev0.TestRunResult_ERRORED
+		runResult.Message = fmt.Sprintf("%d run-level error(s)", counts.Errored)
+	}
+
+	legacyState := runtimev0.TestStatus_SUCCESS
+	if counts.Failed > 0 || counts.Errored > 0 {
+		legacyState = runtimev0.TestStatus_ERROR
+	}
+
+	resp := &runtimev0.TestResponse{
+		Run: &runtimev0.TestRun{
+			Runner:    runner,
+			SuiteName: suiteName,
+			Duration:  durationpb.New(duration),
+		},
+		Result: runResult,
+		Counts: counts,
+		Suites: suites,
+		Truncation: &runtimev0.TestTruncation{
+			Happened:        r.truncatedCases > 0,
+			MaxPerCaseBytes: int32(MaxCapturedOutputBytesPerCase),
+			TruncatedCases:  r.truncatedCases,
+		},
+
+		Status:       &runtimev0.TestStatus{State: legacyState, Message: runResult.Message},
+		Output:       legacyOutput.String(),
+		TestsRun:     counts.Total,
+		TestsPassed:  counts.Passed,
+		TestsFailed:  counts.Failed,
+		TestsSkipped: counts.Skipped,
+		CoveragePct:  r.CoveragePct,
+		Failures:     legacyFailures,
+	}
+	return resp
+}
+
+func (s *structuredSuite) toProto() (*runtimev0.TestSuite, *runtimev0.TestCounts) {
+	ps := &runtimev0.TestSuite{
+		Name:     s.Name,
+		Duration: durationpb.New(s.elapsed),
+	}
+	suiteCounts := &runtimev0.TestCounts{}
+
+	names := make([]string, 0, len(s.cases))
+	names = append(names, s.caseOrder...)
+	sortStrings(names)
+
+	for _, name := range names {
+		c := s.cases[name]
+		pc := &runtimev0.TestCase{
+			Name:     c.Name,
+			FullName: s.Name + "." + c.Name,
+			State:    c.state,
+		}
+		if c.state == runtimev0.TestCaseState_TEST_CASE_STATE_FAILED ||
+			c.state == runtimev0.TestCaseState_TEST_CASE_STATE_ERRORED {
+			pc.CapturedOutput = c.output.String()
+			pc.Failure = &runtimev0.TestFailure{
+				Message: extractFailureMessage(c.output.String()),
+				Detail:  c.output.String(),
+				Kind:    extractFailureKind(c.output.String()),
+			}
+		}
+		ps.Cases = append(ps.Cases, pc)
+		suiteCounts.Total++
+		switch c.state {
+		case runtimev0.TestCaseState_TEST_CASE_STATE_PASSED:
+			suiteCounts.Passed++
+		case runtimev0.TestCaseState_TEST_CASE_STATE_FAILED:
+			suiteCounts.Failed++
+		case runtimev0.TestCaseState_TEST_CASE_STATE_SKIPPED:
+			suiteCounts.Skipped++
+		case runtimev0.TestCaseState_TEST_CASE_STATE_ERRORED:
+			suiteCounts.Errored++
+		}
+	}
+
+	ps.Counts = suiteCounts
+	return ps, suiteCounts
+}
+
+// extractFailureMessage picks the assertion message out of per-case output.
+// Heuristic: the panic line, else the first non-blank line. Mirrors the Go
+// helper but tuned for Rust's `thread '…' panicked at …` convention.
+func extractFailureMessage(output string) string {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		trim := strings.TrimSpace(line)
+		if strings.Contains(trim, "panicked at") || strings.HasPrefix(trim, "assertion") {
+			return trim
+		}
+	}
+	for _, line := range lines {
+		trim := strings.TrimSpace(line)
+		if trim != "" {
+			return trim
+		}
+	}
+	return ""
+}
+
+// extractFailureKind classifies the failure from output markers.
+func extractFailureKind(output string) runtimev0.TestFailureKind {
+	if strings.Contains(output, "panicked at") || strings.Contains(output, "panic") {
+		return runtimev0.TestFailureKind_TEST_FAILURE_KIND_PANIC
+	}
+	if strings.Contains(output, "timed out") || strings.Contains(output, "deadline") {
+		return runtimev0.TestFailureKind_TEST_FAILURE_KIND_TIMEOUT
+	}
+	return runtimev0.TestFailureKind_TEST_FAILURE_KIND_ASSERTION
+}
+
+// sortStrings is an inlined insertion sort — same shim as the Go package.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/runners/rust/cargotest_test.go
+++ b/runners/rust/cargotest_test.go
@@ -1,0 +1,180 @@
+package rust
+
+import (
+	"testing"
+
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
+)
+
+// sampleOutput is representative `cargo test` text: one unit-test binary with a
+// pass, a fail (with a panic detail block) and an ignored test, plus an
+// integration binary with a single pass.
+const sampleOutput = `   Compiling demo v0.1.0 (/work/demo)
+    Finished ` + "`test`" + ` profile [unoptimized + debuginfo] target(s) in 0.42s
+     Running unittests src/lib.rs (target/debug/deps/demo-1a2b3c4d)
+
+running 3 tests
+test tests::it_adds ... ok
+test tests::it_fails ... FAILED
+test tests::it_is_skipped ... ignored
+
+failures:
+
+---- tests::it_fails stdout ----
+thread 'tests::it_fails' panicked at src/lib.rs:12:9:
+assertion ` + "`left == right`" + ` failed
+  left: 2
+  right: 3
+
+failures:
+    tests::it_fails
+
+test result: FAILED. 1 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/integration.rs (target/debug/deps/integration-9f8e7d6c)
+
+running 1 test
+test integration_smoke ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+`
+
+func TestParseCargoTest(t *testing.T) {
+	s := ParseCargoTest(sampleOutput)
+	if s.Run != 4 {
+		t.Errorf("Run = %d, want 4", s.Run)
+	}
+	if s.Passed != 2 {
+		t.Errorf("Passed = %d, want 2", s.Passed)
+	}
+	if s.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", s.Failed)
+	}
+	if s.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", s.Skipped)
+	}
+	if len(s.Failures) != 1 {
+		t.Fatalf("Failures = %d, want 1", len(s.Failures))
+	}
+	if want := "left: 2"; !contains(s.Failures[0], want) {
+		t.Errorf("failure detail missing %q:\n%s", want, s.Failures[0])
+	}
+}
+
+func TestParseCargoTestStructured(t *testing.T) {
+	r := ParseCargoTestStructured(sampleOutput)
+	if len(r.Suites) != 2 {
+		t.Fatalf("Suites = %d, want 2", len(r.Suites))
+	}
+	resp := r.ToProtoResponse("cargo-test", "demo", 0)
+
+	if resp.GetCounts().GetTotal() != 4 {
+		t.Errorf("Total = %d, want 4", resp.GetCounts().GetTotal())
+	}
+	if resp.GetCounts().GetPassed() != 2 {
+		t.Errorf("Passed = %d, want 2", resp.GetCounts().GetPassed())
+	}
+	if resp.GetCounts().GetFailed() != 1 {
+		t.Errorf("Failed = %d, want 1", resp.GetCounts().GetFailed())
+	}
+	if resp.GetCounts().GetSkipped() != 1 {
+		t.Errorf("Skipped = %d, want 1", resp.GetCounts().GetSkipped())
+	}
+	if resp.GetResult().GetState() != runtimev0.TestRunResult_FAILED {
+		t.Errorf("run state = %v, want FAILED", resp.GetResult().GetState())
+	}
+
+	// The failing case must carry a panic-kind failure and detail.
+	var found *runtimev0.TestCase
+	for _, suite := range resp.GetSuites() {
+		for _, c := range suite.GetCases() {
+			if c.GetName() == "tests::it_fails" {
+				found = c
+			}
+		}
+	}
+	if found == nil {
+		t.Fatal("did not find failing case tests::it_fails")
+	}
+	if found.GetState() != runtimev0.TestCaseState_TEST_CASE_STATE_FAILED {
+		t.Errorf("case state = %v, want FAILED", found.GetState())
+	}
+	if found.GetFailure().GetKind() != runtimev0.TestFailureKind_TEST_FAILURE_KIND_PANIC {
+		t.Errorf("failure kind = %v, want PANIC", found.GetFailure().GetKind())
+	}
+	if !contains(found.GetCapturedOutput(), "assertion") {
+		t.Errorf("captured output missing assertion detail: %q", found.GetCapturedOutput())
+	}
+}
+
+func TestParseCargoBinaryName(t *testing.T) {
+	cases := map[string]string{
+		`[package]
+name = "my-service"
+version = "0.1.0"`: "my-service",
+		// [[bin]] name takes precedence over [package] name.
+		`[package]
+name = "lib-name"
+
+[[bin]]
+name = "server-bin"
+path = "src/main.rs"`: "server-bin",
+	}
+	for toml, want := range cases {
+		if got := parseCargoBinaryName(toml); got != want {
+			t.Errorf("parseCargoBinaryName() = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestStreamingTestWriter(t *testing.T) {
+	var events []TestEvent
+	w := &StreamingTestWriter{OnEvent: func(e TestEvent) { events = append(events, e) }}
+	for _, line := range splitLines(sampleOutput) {
+		_, _ = w.Write([]byte(line))
+	}
+	// 4 test lines → 4 events.
+	if len(events) != 4 {
+		t.Fatalf("events = %d, want 4", len(events))
+	}
+	// First event is a pass in the unittests suite.
+	if events[0].Action != "pass" || events[0].Test != "tests::it_adds" {
+		t.Errorf("event[0] = %+v", events[0])
+	}
+	if events[1].Action != "fail" {
+		t.Errorf("event[1].Action = %q, want fail", events[1].Action)
+	}
+	if events[3].Suite != "tests/integration.rs" {
+		t.Errorf("event[3].Suite = %q, want tests/integration.rs", events[3].Suite)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitLines(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/runners/rust/doc.go
+++ b/runners/rust/doc.go
@@ -1,0 +1,13 @@
+// Package rust is the Rust-specific runner: build, test, and run Cargo
+// projects in any of the supported execution environments (native,
+// Docker, Nix). It mirrors core/runners/golang — same public shape, same
+// base environments (NativeEnvironment, NixEnvironment, CompanionRunner) —
+// swapping the Go toolchain for Cargo:
+//
+//	go build            → cargo build [--release]
+//	go test -json       → cargo test  (libtest text output, parsed here)
+//	go vet              → cargo clippy
+//	go mod download     → cargo fetch
+//	go.mod / go.sum     → Cargo.toml / Cargo.lock
+//	GOMODCACHE / GOPATH → CARGO_HOME
+package rust

--- a/runners/rust/runner.go
+++ b/runners/rust/runner.go
@@ -1,0 +1,532 @@
+package rust
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/codefly-dev/core/builders"
+	"github.com/codefly-dev/core/resources"
+
+	"github.com/codefly-dev/core/shared"
+
+	runners "github.com/codefly-dev/core/runners/base"
+
+	"github.com/codefly-dev/core/wool"
+)
+
+/*
+RustRunnerEnvironment is a runner for Rust/Cargo.
+- Init:
+  - cargo dependency handling (cargo fetch)
+  - binary building (cargo build)
+
+- Start:
+  - start the compiled binary
+
+It mirrors golang.GoRunnerEnvironment and reuses the same base execution
+environments (native, Docker, Nix).
+*/
+type RustRunnerEnvironment struct {
+	dir       string
+	companion runners.CompanionRunner // when using the Docker path
+	local     *runners.NativeEnvironment
+	nix       *runners.NixEnvironment
+
+	localCacheDir string
+
+	// Used to cache the binary
+	requirements *builders.Dependencies
+
+	// Build profile
+	release         bool
+	withDebugSymbol bool
+
+	// CARGO_HOME registry cache (host path) mounted into the container.
+	cargoHome string
+
+	out io.Writer
+
+	// Resolved binary name (Cargo package / [[bin]] name).
+	binaryName string
+
+	targetPath string
+
+	// For testing mostly
+	usedCache bool
+
+	// Source directory and the directory holding Cargo.toml.
+	sourceDir string
+	moduleDir string
+}
+
+func (r *RustRunnerEnvironment) LocalCacheDir(ctx context.Context) string {
+	var p string
+	switch {
+	case r.companion != nil:
+		p = path.Join(r.localCacheDir, "container")
+	case r.nix != nil:
+		p = path.Join(r.localCacheDir, "nix")
+	default:
+		p = path.Join(r.localCacheDir, "native")
+	}
+	_, _ = shared.CheckDirectoryOrCreate(ctx, p)
+	return p
+}
+
+func (r *RustRunnerEnvironment) WithDebugSymbol(debug bool) {
+	r.withDebugSymbol = debug
+}
+
+// WithRelease toggles the optimized `--release` profile.
+func (r *RustRunnerEnvironment) WithRelease(b bool) {
+	r.release = b
+}
+
+func NewNativeRustRunner(ctx context.Context, dir string, relativeSource string) (*RustRunnerEnvironment, error) {
+	w := wool.Get(ctx).In("NewNativeRustRunner")
+	w.Trace("creating native rust runner", wool.Field("dir", dir))
+
+	// Check that cargo is in the path
+	if _, err := exec.LookPath("cargo"); err != nil {
+		return nil, w.NewError("cannot find cargo in the path")
+	}
+
+	local, err := runners.NewNativeEnvironment(ctx, dir)
+	if err != nil {
+		return nil, w.Wrapf(err, "cannot create rust local environment")
+	}
+
+	sourceDir := path.Join(dir, relativeSource)
+	moduleDir := findCargoManifestDir(ctx, dir, sourceDir)
+
+	if v, ok := os.LookupEnv("CARGO_HOME"); ok {
+		local.WithEnvironmentVariables(ctx, resources.Env("CARGO_HOME", v))
+	}
+	// Ensure PATH is inherited so subprocesses (e.g. tests calling exec) can find binaries.
+	if p := os.Getenv("PATH"); p != "" {
+		local.WithEnvironmentVariables(ctx, resources.Env("PATH", p))
+	}
+
+	return &RustRunnerEnvironment{
+		dir:           dir,
+		local:         local,
+		localCacheDir: path.Join(sourceDir, "cache"),
+		sourceDir:     sourceDir,
+		moduleDir:     moduleDir,
+	}, nil
+}
+
+// NewNixRustRunner creates a Rust runner that uses Nix for reproducible
+// builds. All tools (cargo, rustc) come from the flake.nix in dir.
+func NewNixRustRunner(ctx context.Context, dir string, relativeSource string) (*RustRunnerEnvironment, error) {
+	w := wool.Get(ctx).In("NewNixRustRunner")
+	w.Trace("creating nix rust runner", wool.Field("dir", dir))
+
+	nixEnv, err := runners.NewNixEnvironment(ctx, dir)
+	if err != nil {
+		return nil, w.Wrapf(err, "cannot create nix environment")
+	}
+
+	sourceDir := path.Join(dir, relativeSource)
+	moduleDir := findCargoManifestDir(ctx, dir, sourceDir)
+
+	if v, ok := os.LookupEnv("CARGO_HOME"); ok {
+		nixEnv.WithEnvironmentVariables(ctx, resources.Env("CARGO_HOME", v))
+	}
+
+	return &RustRunnerEnvironment{
+		dir:           dir,
+		nix:           nixEnv,
+		localCacheDir: path.Join(sourceDir, "cache"),
+		sourceDir:     sourceDir,
+		moduleDir:     moduleDir,
+	}, nil
+}
+
+func NewDockerRustRunner(ctx context.Context, image *resources.DockerImage, dir string, relativeSource string, name string) (*RustRunnerEnvironment, error) {
+	w := wool.Get(ctx).In("NewDockerRustRunner")
+
+	runnerName := fmt.Sprintf("rust-%s", name)
+	w.Trace("creating docker rust runner", wool.Field("image", image), wool.Field("dir", dir), wool.Field("name", runnerName))
+
+	companion, err := runners.NewCompanionRunner(ctx, runners.CompanionOpts{
+		Name:      runnerName,
+		SourceDir: dir,
+		Image:     image,
+	})
+	if err != nil {
+		return nil, w.Wrapf(err, "cannot create companion runner")
+	}
+	companion.WithPause()
+
+	sourceDir := path.Join(dir, relativeSource)
+	moduleDir := findCargoManifestDir(ctx, dir, sourceDir)
+
+	return &RustRunnerEnvironment{
+		dir:           dir,
+		companion:     companion,
+		localCacheDir: path.Join(sourceDir, "cache"),
+		sourceDir:     sourceDir,
+		moduleDir:     moduleDir,
+	}, nil
+}
+
+// findCargoManifestDir walks up from sourceDir to find the directory that
+// holds Cargo.toml, stopping at the workspace root. Mirrors
+// golang.findGoModuleDir. Falls back to sourceDir when none is found.
+func findCargoManifestDir(ctx context.Context, workspaceDir, sourceDir string) string {
+	workspaceRoot := workspaceDir
+	if resolved, err := filepath.EvalSymlinks(workspaceDir); err == nil {
+		workspaceRoot = resolved
+	}
+	for d := sourceDir; ; d = filepath.Dir(d) {
+		exists, _ := shared.FileExists(ctx, filepath.Join(d, "Cargo.toml"))
+		if exists {
+			return d
+		}
+		stop := d == workspaceDir ||
+			d == workspaceRoot ||
+			d == string(filepath.Separator) ||
+			d == "."
+		if !stop {
+			if resolved, err := filepath.EvalSymlinks(d); err == nil && resolved == workspaceRoot {
+				stop = true
+			}
+		}
+		if stop {
+			break
+		}
+	}
+	return sourceDir
+}
+
+func (r *RustRunnerEnvironment) Env() runners.RunnerEnvironment {
+	switch {
+	case r.companion != nil:
+		return r.companion.RunnerEnv()
+	case r.nix != nil:
+		return r.nix
+	default:
+		return r.local
+	}
+}
+
+// manifestDir returns the directory holding Cargo.toml (the working
+// directory for all cargo invocations).
+func (r *RustRunnerEnvironment) manifestDir() string {
+	if r.moduleDir != "" {
+		return r.moduleDir
+	}
+	return r.sourceDir
+}
+
+func (r *RustRunnerEnvironment) Setup(ctx context.Context) {
+	w := wool.Get(ctx).In("setup")
+	if r.companion != nil {
+		r.companion.WithMount(r.LocalCacheDir(ctx), "/build")
+		// Mount the host cargo registry so dependency downloads are cached
+		// across runs. The rust image sets CARGO_HOME=/usr/local/cargo.
+		registry := r.cargoHome
+		if registry == "" {
+			if v, ok := os.LookupEnv("CARGO_HOME"); ok {
+				registry = v
+			} else {
+				registry = path.Join(resources.CodeflyDir(), "cargo")
+			}
+		}
+		regDir := path.Join(registry, "registry")
+		if _, err := shared.CheckDirectoryOrCreate(ctx, regDir); err != nil {
+			w.Warn("cannot create cargo registry cache", wool.ErrField(err))
+		} else {
+			r.companion.WithMount(regDir, "/usr/local/cargo/registry")
+		}
+		return
+	}
+	// native / nix: pass through CARGO_HOME + HOME for the cargo cache.
+	if r.cargoHome != "" {
+		r.Env().WithEnvironmentVariables(ctx, resources.Env("CARGO_HOME", r.cargoHome))
+	}
+	r.Env().WithEnvironmentVariables(ctx, resources.Env("HOME", os.Getenv("HOME")))
+}
+
+func (r *RustRunnerEnvironment) WithOutput(out io.Writer) {
+	r.out = out
+}
+
+func (r *RustRunnerEnvironment) Init(ctx context.Context) error {
+	w := wool.Get(ctx).In("init")
+
+	r.Setup(ctx)
+	if r.companion != nil {
+		if err := r.companion.Init(ctx); err != nil {
+			return w.Wrapf(err, "cannot init companion")
+		}
+	} else if err := r.Env().Init(ctx); err != nil {
+		return w.Wrapf(err, "cannot init environment")
+	}
+
+	if err := r.CargoDependencyHandling(ctx); err != nil {
+		return w.Wrapf(err, "cannot handle cargo dependencies")
+	}
+	return nil
+}
+
+// CargoDependencyHandling runs `cargo fetch` when Cargo.toml/Cargo.lock
+// have changed since the last cached run. Mirrors GoModuleHandling.
+func (r *RustRunnerEnvironment) CargoDependencyHandling(ctx context.Context) error {
+	w := wool.Get(ctx).In("cargoDependencyHandling")
+	moduleDir := r.manifestDir()
+
+	req := builders.NewDependencies("cargo", builders.NewDependency("Cargo.toml", "Cargo.lock").Localize(moduleDir))
+	req.WithCache(r.LocalCacheDir(ctx))
+
+	updated, err := req.Updated(ctx)
+	if err != nil {
+		return w.Wrapf(err, "cannot check cargo manifest")
+	}
+	if !updated {
+		w.Trace("cargo dependencies have been cached")
+		return nil
+	}
+	if err = req.UpdateCache(ctx); err != nil {
+		return w.Wrapf(err, "cannot update cargo cache")
+	}
+
+	proc, err := r.Env().NewProcess("cargo", "fetch")
+	if err != nil {
+		return w.Wrapf(err, "cannot create cargo fetch process")
+	}
+	if r.out != nil {
+		proc.WithOutput(r.out)
+	}
+	proc.WithDir(moduleDir)
+	if err = proc.Run(ctx); err != nil {
+		return w.Wrapf(err, "cannot run cargo fetch")
+	}
+	return nil
+}
+
+// profile returns the Cargo build profile directory name.
+func (r *RustRunnerEnvironment) profile() string {
+	if r.release {
+		return "release"
+	}
+	return "debug"
+}
+
+func (r *RustRunnerEnvironment) BinName(hash string) string {
+	if r.withDebugSymbol {
+		return fmt.Sprintf("%s-debug", hash)
+	}
+	return hash
+}
+
+func (r *RustRunnerEnvironment) LocalTargetPath(ctx context.Context, hash string) string {
+	return path.Join(r.LocalCacheDir(ctx), r.BinName(hash))
+}
+
+// targetDir is where cargo writes build artifacts (`--target-dir`). In the
+// Docker path this is /build (mounted to LocalCacheDir); otherwise it is a
+// "target" subdirectory of the local cache.
+func (r *RustRunnerEnvironment) buildTargetDir(ctx context.Context) string {
+	if r.companion != nil && r.companion.Backend() == runners.BackendDocker {
+		return "/build/target"
+	}
+	return path.Join(r.LocalCacheDir(ctx), "target")
+}
+
+// hostArtifactPath is the host-side location of the compiled binary produced
+// by cargo into buildTargetDir. For Docker, /build maps to LocalCacheDir.
+func (r *RustRunnerEnvironment) hostArtifactPath(ctx context.Context) string {
+	if r.companion != nil && r.companion.Backend() == runners.BackendDocker {
+		return path.Join(r.LocalCacheDir(ctx), "target", r.profile(), r.binaryName)
+	}
+	return path.Join(r.buildTargetDir(ctx), r.profile(), r.binaryName)
+}
+
+func (r *RustRunnerEnvironment) BuildBinary(ctx context.Context) error {
+	w := wool.Get(ctx).In("buildBinary")
+
+	hashDir := r.manifestDir()
+	r.requirements = builders.NewDependencies("rust",
+		builders.NewDependency(hashDir).WithPathSelect(shared.NewSelect("*.rs")),
+		builders.NewDependency("Cargo.toml", "Cargo.lock").Localize(hashDir),
+	)
+
+	w.Trace("start building")
+	r.usedCache = false
+
+	hash, err := r.requirements.Hash(ctx)
+	if err != nil {
+		return w.Wrapf(err, "cannot get hash")
+	}
+
+	name, err := r.resolveBinaryName()
+	if err != nil {
+		return w.Wrapf(err, "cannot resolve cargo binary name")
+	}
+	r.binaryName = name
+
+	cached := r.LocalTargetPath(ctx, hash)
+	w.Trace("checking local cache", wool.FileField(cached))
+	exists, err := shared.FileExists(ctx, cached)
+	if err != nil {
+		return w.Wrapf(err, "cannot check local cache")
+	}
+	if exists {
+		w.Trace("found a cache binary: don't work until we have to!", wool.FileField(cached))
+		r.usedCache = true
+		r.targetPath = cached
+		return nil
+	}
+
+	args := []string{"build", "--target-dir", r.buildTargetDir(ctx)}
+	if r.release {
+		args = append(args, "--release")
+	}
+
+	proc, err := r.Env().NewProcess("cargo", args...)
+	if err != nil {
+		return w.Wrapf(err, "cannot create cargo build process")
+	}
+	if r.out != nil {
+		proc.WithOutput(r.out)
+	}
+	proc.WithDir(r.manifestDir())
+	if r.withDebugSymbol {
+		proc.WithEnvironmentVariables(ctx, resources.Env("RUSTFLAGS", "-C debuginfo=2"))
+	}
+
+	if err = proc.Run(ctx); err != nil {
+		return w.Wrapf(err, "cannot run cargo build")
+	}
+
+	// Cargo writes target/<profile>/<binary>. Copy it into the hashed cache
+	// slot so subsequent identical builds short-circuit (mirrors `go build -o`).
+	produced := r.hostArtifactPath(ctx)
+	if err = copyExecutable(produced, cached); err != nil {
+		return w.Wrapf(err, "cannot cache built binary from %s", produced)
+	}
+	r.targetPath = cached
+	return nil
+}
+
+// resolveBinaryName returns the binary name cargo will produce: the [[bin]]
+// name if present, otherwise the [package] name from Cargo.toml.
+func (r *RustRunnerEnvironment) resolveBinaryName() (string, error) {
+	manifest := filepath.Join(r.manifestDir(), "Cargo.toml")
+	data, err := os.ReadFile(manifest)
+	if err != nil {
+		return "", err
+	}
+	if name := parseCargoBinaryName(string(data)); name != "" {
+		return name, nil
+	}
+	return "", fmt.Errorf("no [package] name found in %s", manifest)
+}
+
+var cargoNameRe = regexp.MustCompile(`(?m)^\s*name\s*=\s*"([^"]+)"`)
+
+// parseCargoBinaryName extracts the binary name from Cargo.toml contents.
+// Prefers the first [[bin]] name, falling back to the [package] name. This
+// is a deliberately small TOML scan — Cargo manifests put name on its own
+// line — avoiding a full TOML-parser dependency.
+func parseCargoBinaryName(toml string) string {
+	var pkgName, binName string
+	section := ""
+	for _, line := range strings.Split(toml, "\n") {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "[") {
+			section = trim
+			continue
+		}
+		m := cargoNameRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		switch {
+		case section == "[package]" && pkgName == "":
+			pkgName = m[1]
+		case section == "[[bin]]" && binName == "":
+			binName = m[1]
+		}
+	}
+	if binName != "" {
+		return binName
+	}
+	return pkgName
+}
+
+// copyExecutable copies src to dst with executable permissions, creating the
+// parent directory. Used to seed the hashed binary cache.
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	if err = os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func (r *RustRunnerEnvironment) Stop(ctx context.Context) error {
+	return r.Env().Stop(ctx)
+}
+
+func (r *RustRunnerEnvironment) Shutdown(ctx context.Context) error {
+	return r.Env().Shutdown(ctx)
+}
+
+func (r *RustRunnerEnvironment) WithCargoHome(dir string) {
+	r.cargoHome = dir
+}
+
+func (r *RustRunnerEnvironment) WithLocalCacheDir(dir string) {
+	r.localCacheDir = dir
+}
+
+func (r *RustRunnerEnvironment) Runner(args ...string) (runners.Proc, error) {
+	proc, err := r.Env().NewProcess(r.targetPath, args...)
+	if err != nil {
+		return nil, err
+	}
+	proc.WithDir(r.sourceDir)
+	return proc, nil
+}
+
+func (r *RustRunnerEnvironment) UsedCache() bool {
+	return r.usedCache
+}
+
+func (r *RustRunnerEnvironment) WithEnvironmentVariables(ctx context.Context, envs ...*resources.EnvironmentVariable) {
+	r.Env().WithEnvironmentVariables(ctx, envs...)
+}
+
+func (r *RustRunnerEnvironment) WithFile(file string, location string) {
+	if r.companion != nil {
+		r.companion.WithMount(file, location)
+	}
+}
+
+func (r *RustRunnerEnvironment) WithPort(ctx context.Context, port uint32) {
+	if r.companion != nil {
+		r.companion.WithPortMapping(ctx, uint16(port), uint16(port))
+	}
+}

--- a/runners/rust/runner_test.go
+++ b/runners/rust/runner_test.go
@@ -1,0 +1,86 @@
+package rust_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/runners/rust"
+	"github.com/codefly-dev/core/shared"
+	"github.com/stretchr/testify/require"
+)
+
+// minimal Cargo project: a binary with two passing unit tests.
+const cargoToml = `[package]
+name = "demo-svc"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "demo-svc"
+path = "src/main.rs"
+`
+
+const mainRs = `fn add(a: i32, b: i32) -> i32 { a + b }
+
+fn main() {
+    println!("{}", add(1, 2));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_adds() { assert_eq!(add(1, 2), 3); }
+
+    #[test]
+    fn it_adds_zero() { assert_eq!(add(0, 0), 0); }
+}
+`
+
+// writeProject lays out <root>/code/{Cargo.toml,src/main.rs}.
+func writeProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	code := filepath.Join(root, "code")
+	require.NoError(t, os.MkdirAll(filepath.Join(code, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(code, "Cargo.toml"), []byte(cargoToml), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(code, "src", "main.rs"), []byte(mainRs), 0o644))
+	return root
+}
+
+// TestNativeBuildAndTest exercises the native RustRunnerEnvironment
+// end-to-end: init, build (with hashed-cache short-circuit on rebuild), and
+// `cargo test` result parsing. Skipped when cargo is unavailable.
+func TestNativeBuildAndTest(t *testing.T) {
+	if _, err := exec.LookPath("cargo"); err != nil {
+		t.Skip("cargo not available")
+	}
+	ctx := context.Background()
+	root := writeProject(t)
+	cacheDir := filepath.Join(root, "cache")
+
+	env, err := rust.NewNativeRustRunner(ctx, root, "code")
+	require.NoError(t, err)
+	env.WithLocalCacheDir(cacheDir)
+	defer func() { _ = env.Shutdown(ctx) }()
+
+	require.NoError(t, env.Init(ctx))
+
+	require.NoError(t, env.BuildBinary(ctx))
+	require.False(t, env.UsedCache(), "first build should not be cached")
+	require.False(t, shared.Must(shared.CheckEmptyDirectory(ctx, cacheDir)), "cache should hold the binary")
+
+	// Rebuild with no source change → cache hit.
+	require.NoError(t, env.BuildBinary(ctx))
+	require.True(t, env.UsedCache(), "rebuild should hit the cache")
+
+	// Run the tests.
+	summary, err := rust.RunCargoTests(ctx, env, filepath.Join(root, "code"), nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), summary.Passed, "two passing tests")
+	require.Equal(t, int32(0), summary.Failed)
+}


### PR DESCRIPTION
Backs the new [`service-rust`](https://github.com/codefly-dev/service-rust) agent.

## What
- **languages**: add `RUST` constant + `FromString` mapping + `HasCargoRuntime` check (locked test updated `rust → RUST`).
- **runners/rust**: new package mirroring `runners/golang` for the Cargo toolchain:
  - `RustRunnerEnvironment` (native / Docker / Nix via the shared base environments)
  - `CreateRunner`, `RunCargoBuild` / `RunCargoTests` / `RunCargoLint`, `BuildRustDocker`, `DeployRustKubernetes`
  - libtest **text** output parsing → flat `TestSummary` + structured `TestResponse` (stable Rust has no JSON test output; nightly not required)
  - hashed binary cache mirroring `go build -o`
- **generated**: regenerate `agent.pb.go` for the new RUST/CARGO enum values.

## Tests
`go test ./runners/rust/...` — parser unit tests + a native `cargo build`/`test` integration test (skips when `cargo` absent). All pass.

## Notes for reviewers
- Depends on codefly-dev/proto#2 (enum values). `agent.pb.go` was regenerated with local `protoc-gen-go`/`grpc`/`grpc-gateway` plugins because the remote buf-plugin path errored (`context canceled`); the semantic diff is just the new enum constants + descriptor bytes, and import grouping was restored to match repo style.
- Code intelligence for Rust (symbols / call graph) is **not** included — `service-rust` stubs it pending a core rust-analyzer backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rust/Cargo runner with native, Nix, and Docker backend support
> - Adds a new `runners/rust` package implementing build, test, and lint for Rust services via `cargo build`, `cargo test`, and `cargo clippy`.
> - Supports three execution backends: native (requires `cargo` in PATH), Nix, and Docker container, selected via `SetRustRuntimeContext`.
> - Implements content-hash-based build caching in `BuildBinary` and dependency pre-fetching in `CargoDependencyHandling` to avoid redundant builds.
> - Parses `cargo test` output into structured `TestSummary` and `StructuredTestRun` models, with streaming event callbacks and Protobuf response emission.
> - Adds `Language_RUST`, `Runtime_RUST`, and `Runtime_CARGO` enum values to the generated protobuf agent API and a corresponding `languages.RUST` constant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9159676.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->