### PR TITLE
companion(node): bump base node 22 → 24 LTS (0.0.12)

### DIFF
--- a/companions/node/Dockerfile
+++ b/companions/node/Dockerfile
@@ -2,11 +2,11 @@
 # plugins). Pinned like every other codefly-built image — no :latest.
 #
 # Version pinning strategy (matches the codefly + python companions):
-#   - Base: node:22.12.0-alpine3.21 — Node LTS + matching Alpine release.
+#   - Base: node:24.16.0-alpine3.22 — Node LTS + matching Alpine release.
 #   - apk packages: not individually pinned; Alpine release freezes repo.
 #   - codefly CLI: copied from the pinned codeflydev/codefly base.
 
-FROM node:22.12.0-alpine3.21
+FROM node:24.16.0-alpine3.22
 
 # Re-install alpine dev tools so the node companion carries the same
 # toolbox as the codefly base.

--- a/companions/node/info.codefly.yaml
+++ b/companions/node/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.0.11
+version: 0.0.12

--- a/companions/scripts/build_companions.sh
+++ b/companions/scripts/build_companions.sh
@@ -10,7 +10,7 @@
 #   codeflydev/codefly:<v>  — alpine base + codefly CLI + common tools
 #   codeflydev/go:<v>       — Go plugin runtime (golang:1.26-alpine + gopls)
 #   codeflydev/python:<v>   — Python plugin runtime (python:3.13.1-alpine3.21 + uv)
-#   codeflydev/node:<v>     — Node plugin runtime (node:22.12.0-alpine3.21)
+#   codeflydev/node:<v>     — Node plugin runtime (node:24.16.0-alpine3.22)
 #   codeflydev/proto:<v>    — proto/buf companion for `codefly generate proto`
 set -e
 cd "$(dirname "$0")/../.."


### PR DESCRIPTION
Bumps the Node runtime companion base from `node:22.12.0-alpine3.21` to **`node:24.16.0-alpine3.22`** (Node 24 LTS) and the companion version 0.0.11 → **0.0.12**.

Coordinated with the nextjs agent (`NodeVersion` 22→24 + `codeflydev/node:0.0.12`) and saas-starter's frontend Dockerfile (`node:24-alpine`), pushed separately.

⚠️ **Requires publishing** `codeflydev/node:0.0.12` (via the companion build/push flow on the codeflydev registry) before nextjs runtime can pull it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime environment to version 24.16.0-alpine, replacing the previous 22.12.0-alpine version. This brings the latest security patches and performance improvements to the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->