### PR TITLE
generated: connect-go handlers for all services

### DIFF
--- a/generated/buf.gen.local.yaml
+++ b/generated/buf.gen.local.yaml
@@ -23,6 +23,8 @@ plugins:
   - name: grpc-gateway
     out: go
     opt: paths=source_relative
+  # Connect-go handlers/clients — lets the CLI serve its gRPC services over the
+  # Connect protocol (consumed by the browser dashboard via Connect-ES).
   - name: connect-go
     out: go
     opt: paths=source_relative

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	buf.build/go/protovalidate v1.2.0
+	connectrpc.com/connect v1.20.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.28.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ buf.build/go/protovalidate v1.2.0 h1:DQVrUWkmGTBij+kOYv/x2LLxwcLaGKMdzShj1/6/3H0
 buf.build/go/protovalidate v1.2.0/go.mod h1:7rYiQEhqvAipoazpVNBBH2S2f8bjG4huMVy1V2Yofn4=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=


### PR DESCRIPTION
Adds `connect-go` codegen (buf.gen.local.yaml) + the generated `*/v0connect/` handlers/clients for every codefly service. Enables serving services over the **Connect** protocol — used by the CLI so the rewritten browser dashboard (Connect-ES) talks to the same impl behind gRPC + REST.

Foundation for the cli-frontend rewrite (Connect, not REST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies by adding `connectrpc.com/connect` v1.20.0
  * Enhanced internal build and vulnerability scanning tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->