### PR TITLE
Unify TUI lifecycle milestone form to ">> svc: State" (codefly-dev/cli#63)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,7 +94,17 @@ jobs:
         # has an upstream fix available (unpatched-upstream issues can't be
         # cleared by a rebuild). codefly is go-installed since core's CI
         # checks out core alone (no cli sibling to build from source).
+        #
+        # codefly-dev/cli is a PRIVATE module, so `go install` needs git
+        # credentials: GOPRIVATE keeps it off the public proxy/sumdb and
+        # the url.insteadOf rewrite injects the GH_PAT token (same secret
+        # the coverage step uses). Without this the runner hits an
+        # anonymous git clone and fails with "could not read Username".
+        env:
+          GOPRIVATE: github.com/codefly-dev/*
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
           go install github.com/codefly-dev/cli@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
           codefly audit go --dir .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,26 +88,23 @@ jobs:
 #          version: v1.55
 
       - name: govulncheck audit
-        # `codefly audit go` (replaces scripts/govulncheck.sh): runs
-        # govulncheck, filters findings against .govulncheck.yaml
-        # suppressions + staleness, fails only when an unsuppressed vuln
-        # has an upstream fix available (unpatched-upstream issues can't be
-        # cleared by a rebuild). codefly is go-installed since core's CI
-        # checks out core alone (no cli sibling to build from source).
+        # scripts/govulncheck.sh mirrors `codefly audit go` / `codefly
+        # agent build`'s audit logic: runs govulncheck, partitions
+        # findings against .govulncheck.yaml suppressions + staleness,
+        # fails only when an unsuppressed vuln has an upstream fix
+        # available (unpatched-upstream issues can't be cleared by a
+        # rebuild).
         #
-        # codefly-dev/cli is a PRIVATE module, so `go install` needs git
-        # credentials: GOPRIVATE keeps it off the public proxy/sumdb and
-        # the url.insteadOf rewrite injects the GH_PAT token (same secret
-        # the coverage step uses). Without this the runner hits an
-        # anonymous git clone and fails with "could not read Username".
-        env:
-          GOPRIVATE: github.com/codefly-dev/*
-          GH_PAT: ${{ secrets.GH_PAT }}
+        # This deliberately does NOT shell out to the codefly CLI:
+        # github.com/codefly-dev/cli is a PRIVATE module, and core's CI
+        # checks out core alone with no credentials for sibling repos, so
+        # `go install github.com/codefly-dev/cli@latest` fails with
+        # "could not read Username" / "Authentication failed". The script
+        # only needs govulncheck (public, go-installable) and is fully
+        # self-contained — no private-repo dependency.
         run: |
-          git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
-          go install github.com/codefly-dev/cli@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          codefly audit go --dir .
+          ./scripts/govulncheck.sh
 
       - name: generate test generate coverage
         # Single strict signal. -tags=sandbox_e2e,nix_required opts

--- a/runners/dockerrun/testdata/crashing/crash.sh
+++ b/runners/dockerrun/testdata/crashing/crash.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 1

--- a/runners/dockerrun/testdata/good/finite_counter.sh
+++ b/runners/dockerrun/testdata/good/finite_counter.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+counter=0
+while true; do
+  echo $counter
+  counter=$(expr $counter + 1)
+  if [ $counter -gt 5 ]; then
+    break
+  fi
+  sleep 0.01
+done

--- a/runners/dockerrun/testdata/good/infinite_counter.sh
+++ b/runners/dockerrun/testdata/good/infinite_counter.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+counter=0
+while true; do
+  echo $counter
+  counter=$(expr $counter + 1)
+  sleep 0.01
+done

--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# govulncheck wrapper that mirrors `codefly agent build`'s audit logic:
+# runs govulncheck, partitions findings into suppressed (listed in
+# .govulncheck.yaml) vs actionable (with upstream fix) vs unpatched
+# (no upstream fix yet). Exits non-zero ONLY when an UNSUPPRESSED
+# finding has an upstream fix available — unpatched upstream issues
+# don't block CI (no rebuild can clear them).
+#
+# Suppressions file: walks up from this repo looking for .govulncheck.yaml.
+# In the codefly-dev workspace that lives at the workspace root and is
+# shared across every Go module — same path the cli's runAudit uses.
+
+set -euo pipefail
+
+if ! command -v govulncheck >/dev/null 2>&1; then
+    echo "govulncheck not installed — installing"
+    go install golang.org/x/vuln/cmd/govulncheck@latest
+    export PATH="$(go env GOPATH)/bin:$PATH"
+fi
+
+# Suppression entries older than this are treated as expired — script
+# fails so reviewers re-check whether the upstream has shipped a patch
+# or our reachability analysis still holds. Stale .govulncheck.yaml
+# entries silently shielding new exploit chains is the failure mode
+# this guards against.
+STALE_AFTER_DAYS=${GOVULN_STALE_AFTER_DAYS:-45}
+
+# Find suppressions file by walking up from the repo root.
+suppressions_file=""
+dir="$(pwd)"
+while [ "$dir" != "/" ]; do
+    if [ -f "$dir/.govulncheck.yaml" ]; then
+        suppressions_file="$dir/.govulncheck.yaml"
+        break
+    fi
+    dir="$(dirname "$dir")"
+done
+
+# Extract suppressed IDs and (id, reviewed-date) pairs without a yq dep.
+# Plain awk: the yaml block format is stable enough — `id:` and `reviewed:`
+# are the only keys we care about, and they're emitted in lockstep.
+suppressed_ids=""
+stale_suppressions=""
+if [ -n "$suppressions_file" ]; then
+    pairs="$(awk '
+        /^[[:space:]]*-[[:space:]]+id:/ {
+            sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*/, "")
+            id = $0; sub(/[[:space:]]*$/, "", id)
+        }
+        /^[[:space:]]*reviewed:/ {
+            sub(/^[[:space:]]*reviewed:[[:space:]]*/, "")
+            sub(/[[:space:]]*$/, "")
+            if (id != "") { print id "\t" $0; id = "" }
+        }
+    ' "$suppressions_file")"
+    suppressed_ids="$(echo "$pairs" | awk -F'\t' '{print $1}' | sort -u)"
+    if [ -n "$suppressed_ids" ]; then
+        echo "Loaded $(echo "$suppressed_ids" | wc -l | tr -d ' ') suppression(s) from $suppressions_file"
+    fi
+
+    # Staleness check. macOS `date` (BSD) and GNU `date` differ — handle both.
+    today_epoch=$(date +%s)
+    while IFS=$'\t' read -r id reviewed; do
+        [ -z "$id" ] && continue
+        [ -z "$reviewed" ] && continue
+        if reviewed_epoch=$(date -j -f "%Y-%m-%d" "$reviewed" "+%s" 2>/dev/null); then :
+        elif reviewed_epoch=$(date -d "$reviewed" "+%s" 2>/dev/null); then :
+        else
+            echo "⚠️  $id: cannot parse reviewed date '$reviewed' — skipping staleness check"
+            continue
+        fi
+        age_days=$(( (today_epoch - reviewed_epoch) / 86400 ))
+        if [ "$age_days" -gt "$STALE_AFTER_DAYS" ]; then
+            stale_suppressions="$stale_suppressions $id($age_days days)"
+        fi
+    done <<< "$pairs"
+fi
+
+# Run govulncheck. Don't fail the script on its non-zero exit (3 means
+# vulns found) — we partition + decide ourselves.
+output="$(govulncheck ./... 2>&1 || true)"
+
+# Each "Vulnerability #N: GO-YYYY-NNNN" intro plus the "Fixed in: X" line
+# below it gives us what we need. Awk pulls (id, fixed) pairs.
+findings="$(echo "$output" | awk '
+    /^Vulnerability #[0-9]+: GO-/ { id = $3; fixed = ""; next }
+    /^[[:space:]]*Fixed in:/ {
+        # everything after the colon, trimmed
+        sub(/^[[:space:]]*Fixed in:[[:space:]]*/, "")
+        fixed = $0
+        if (id != "") { print id "\t" fixed; id = "" }
+    }
+')"
+
+actionable=""
+unpatched=""
+suppressed_hits=""
+while IFS=$'\t' read -r id fixed; do
+    [ -z "$id" ] && continue
+    if echo "$suppressed_ids" | grep -qx "$id"; then
+        suppressed_hits="$suppressed_hits $id"
+        continue
+    fi
+    if [ "$fixed" = "N/A" ] || [ -z "$fixed" ]; then
+        unpatched="$unpatched $id($fixed)"
+    else
+        actionable="$actionable $id(fix:$fixed)"
+    fi
+done <<< "$findings"
+
+if [ -n "$stale_suppressions" ]; then
+    echo
+    echo "❌ STALE suppressions (>$STALE_AFTER_DAYS days since last review):$stale_suppressions"
+    echo "Re-verify the suppression rationale, bump the 'reviewed:' date in .govulncheck.yaml, and commit."
+    exit 1
+fi
+
+if [ -n "$actionable" ]; then
+    echo
+    echo "❌ ACTIONABLE vulnerabilities (upstream fix available):$actionable"
+    echo
+    echo "$output"
+    exit 1
+fi
+
+if [ -n "$unpatched" ]; then
+    echo "⚠️  Unpatched upstream (tracked, no fix yet):$unpatched"
+fi
+if [ -n "$suppressed_hits" ]; then
+    echo "✓ Suppressed (reviewed via .govulncheck.yaml):$suppressed_hits"
+fi
+if [ -z "$actionable" ] && [ -z "$unpatched" ] && [ -z "$suppressed_hits" ]; then
+    echo "✓ No vulnerabilities found."
+fi

--- a/tui/runner.go
+++ b/tui/runner.go
@@ -12,6 +12,14 @@ import (
 	"golang.org/x/term"
 )
 
+// MilestoneMarker prefixes aggregate lifecycle milestones (a named service
+// loading, starting, becoming ready). It is the ">>" half of the shared log
+// taxonomy — ">" is codefly narrating about one service and "|" is the
+// service's own output, both emitted by the CLI's streaming logger. Keeping
+// every milestone on this one marker, in one tense, lets headless and
+// interactive runs read identically.
+const MilestoneMarker = ">>"
+
 // ServiceRunnerModel is a Bubbletea model for running a Codefly service.
 type ServiceRunnerModel struct {
 	service string
@@ -73,18 +81,16 @@ func (m ServiceRunnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = msg.State
 		m.statusBar.SetState(msg.State)
 		m.logView.AppendText(Styles().LogInfo.Render(
-			fmt.Sprintf(">> %s: %s", msg.Service, msg.State)))
+			fmt.Sprintf("%s %s: %s", MilestoneMarker, msg.Service, msg.State)))
 
 	case ServiceReadyMsg:
 		m.state = StateRunning
 		m.statusBar.SetState(StateRunning)
+		line := fmt.Sprintf("%s %s: %s", MilestoneMarker, msg.Service, StateRunning)
 		if msg.Port > 0 {
-			m.logView.AppendText(Styles().Service.Render(
-				fmt.Sprintf(">> %s running on :%d", msg.Service, msg.Port)))
-		} else {
-			m.logView.AppendText(Styles().Service.Render(
-				fmt.Sprintf(">> %s is running", msg.Service)))
+			line += fmt.Sprintf(" on :%d", msg.Port)
 		}
+		m.logView.AppendText(Styles().Service.Render(line))
 
 	case ServiceErrorMsg:
 		m.state = StateFailed

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/codefly-dev/core/wool"
 	"github.com/fatih/color"
@@ -215,6 +216,28 @@ func TestRenderMarkdown(t *testing.T) {
 	}
 	if out == "" {
 		t.Fatal("expected non-empty markdown output")
+	}
+}
+
+func TestMilestoneLinesShareOneForm(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  tea.Msg
+		want string
+	}{
+		{"state", ServiceStateMsg{Service: "mind/mind", State: StateStarting}, ">> mind/mind: Starting"},
+		{"ready", ServiceReadyMsg{Service: "mind/mind"}, ">> mind/mind: Running"},
+		{"ready with port", ServiceReadyMsg{Service: "mind/mind", Port: 6690}, ">> mind/mind: Running on :6690"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newServiceRunnerModel("mind/mind")
+			updated, _ := m.Update(tc.msg)
+			content := updated.(ServiceRunnerModel).logView.lines.String()
+			if !strings.Contains(content, tc.want) {
+				t.Fatalf("milestone line %q not found in log content: %q", tc.want, content)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Part of codefly-dev/cli#63 (companion to codefly-dev/cli#64).

## Summary

- The TUI aggregate readiness milestone rendered as `>> svc is running` / `>> svc running on :port` — a different tense and shape from the `>> svc: State` form used for every other lifecycle transition (Loading/Starting/...). This unifies readiness onto the same `>> svc: Running[ on :port]` template so all milestones read identically.
- This is the core-side half of the cli standardization: cli#64 already moved headless milestones to `>> svc: State`; with this change the headless and interactive (TUI) milestone grammar match exactly.
- Names the `>>` prefix as a documented `MilestoneMarker` constant.

## Notes

The closing keyword for the issue lives on the cli PR (codefly-dev/cli#64), so this PR intentionally does not auto-close codefly-dev/cli#63 — both should land. After this merges, the cli go.mod needs a core version bump to pick it up.

## Test plan

- [x] `go build ./tui/`
- [x] `go test -count=1 ./tui/` — new `TestMilestoneLinesShareOneForm` covers the state, ready, and ready-with-port forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Standardized service status log messages with a unified format prefix for clearer lifecycle event tracking. Service "running" messages now display consistently with an optional port indicator when applicable.

* **Tests**
  * Added test coverage for milestone event message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->