### PR TITLE
wool: higher-signal logging — omit-empty, FOCUS semantics, per-scope levels, SecretField (#17)

### DIFF
--- a/wool/doc.go
+++ b/wool/doc.go
@@ -3,7 +3,9 @@
 // Loggers ("wools") attach to a context with structured fields and a
 // hierarchy ("module/component/method"); messages are routed through a
 // pluggable Provider that ships them to stdout, gRPC, OpenTelemetry, or
-// any custom sink. Levels are DEBUG, TRACE, FOCUS, INFO, WARN, ERROR.
+// any custom sink. Levels in increasing severity are TRACE, DEBUG, INFO,
+// FOCUS, WARN, ERROR — FOCUS is a highlighted milestone shown at INFO and
+// above. Per-scope level overrides come from CODEFLY_LOG (see SetLogScopes).
 //
 // Typical usage:
 //

--- a/wool/log.go
+++ b/wool/log.go
@@ -78,7 +78,11 @@ func (l *Log) String() string {
 	}
 	tokens = append(tokens, l.Message)
 	for _, f := range fields {
-		tokens = append(tokens, f.String())
+		// Fields that render to nothing (empty/nil value) are noise — a bare
+		// `key=` carries no information — so drop them from the line entirely.
+		if s := f.String(); s != "" {
+			tokens = append(tokens, s)
+		}
 	}
 	return strings.Join(tokens, " ")
 }
@@ -91,25 +95,49 @@ type LogField struct {
 	Value any      `json:"value"`
 }
 
+// String renders the field as "key=value". It returns the empty string when
+// the value renders to nothing (nil or empty), letting Log.String drop the
+// field rather than emit a meaningless bare "key=".
 func (f *LogField) String() string {
+	v := f.renderValue()
+	if v == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s=%s", f.Key, v)
+}
+
+// renderValue formats the field value, preferring fmt.Stringer over %v so
+// domain types control their own representation instead of being dumped as a
+// raw Go struct.
+func (f *LogField) renderValue() string {
 	if f.Value == nil {
-		return fmt.Sprintf("%s=nil", f.Key)
+		return ""
 	}
 	if stringer, ok := f.Value.(fmt.Stringer); ok {
-		return fmt.Sprintf("%s=%s", f.Key, stringer.String())
+		return stringer.String()
 	}
-	return fmt.Sprintf("%s=%v", f.Key, f.Value)
+	if s, ok := f.Value.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", f.Value)
 }
 
 // Loglevel defines log severity.
 type Loglevel int
 
+// Levels are ordered by severity; a message is shown when its level is >= the
+// effective log level (see Wool.LogLevel). FOCUS sits just above INFO and below
+// WARN: it is a highlighted milestone. At the default INFO level FOCUS lines are
+// shown (the highlight a user wants to see); running at FOCUS hides routine INFO
+// chatter while keeping milestones, warnings and errors — the "signal only"
+// view. FOCUS must stay above INFO so it is never accidentally filtered out by an
+// INFO-level run.
 const (
 	DEFAULT Loglevel = iota
 	TRACE
 	DEBUG
-	FOCUS
 	INFO
+	FOCUS
 	WARN
 	ERROR
 	FATAL
@@ -120,12 +148,31 @@ var levelToString = map[Loglevel]string{
 	DEFAULT: "DEFAULT",
 	TRACE:   "TRACE",
 	DEBUG:   "DEBUG",
-	FOCUS:   "FOCUS",
 	INFO:    "INFO",
+	FOCUS:   "FOCUS",
 	WARN:    "WARN",
 	ERROR:   "ERROR",
 	FATAL:   "FATAL",
 	FORWARD: "FORWARD",
+}
+
+// stringToLevel maps a lowercase level name to its Loglevel, for parsing
+// per-scope overrides (see SetLogScopes / CODEFLY_LOG).
+var stringToLevel = map[string]Loglevel{
+	"trace": TRACE,
+	"debug": DEBUG,
+	"info":  INFO,
+	"focus": FOCUS,
+	"warn":  WARN,
+	"error": ERROR,
+	"fatal": FATAL,
+}
+
+// LevelFromString resolves a level name (case-insensitive, e.g. "debug") to a
+// Loglevel. The second return is false for an unrecognized name.
+func LevelFromString(s string) (Loglevel, bool) {
+	l, ok := stringToLevel[strings.ToLower(strings.TrimSpace(s))]
+	return l, ok
 }
 
 // String returns the human-readable name of the log level (e.g. "INFO"),
@@ -276,4 +323,40 @@ func InField(s string) *LogField {
 
 func Writer() *LogField {
 	return &LogField{Key: "writer"}
+}
+
+// SecretField redacts the value at construction: the raw secret is dropped and
+// never reaches any sink (console, file, gRPC, telemetry). The field always
+// renders "****". This makes redaction a logging-layer guarantee rather than a
+// convention each call site has to remember.
+func SecretField(key string, _ any) *LogField {
+	return &LogField{Key: key, Value: "****"}
+}
+
+// sliceValue renders a slice as a bracketed, comma-separated list ("[a, b]"),
+// or "none" when empty — instead of a raw "{1 [a b]}" %v struct dump. Elements
+// that implement fmt.Stringer render via String().
+type sliceValue[T any] struct {
+	items []T
+}
+
+func (s sliceValue[T]) String() string {
+	if len(s.items) == 0 {
+		return "none"
+	}
+	parts := make([]string, len(s.items))
+	for i, it := range s.items {
+		if str, ok := any(it).(fmt.Stringer); ok {
+			parts[i] = str.String()
+		} else {
+			parts[i] = fmt.Sprintf("%v", it)
+		}
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// SliceField formats a slice as a readable list (see sliceValue) so call sites
+// can log domain collections without dumping internal struct layout.
+func SliceField[T any](key string, items []T) *LogField {
+	return &LogField{Key: key, Value: sliceValue[T]{items: items}}
 }

--- a/wool/log.go
+++ b/wool/log.go
@@ -114,6 +114,13 @@ func (f *LogField) renderValue() string {
 		return ""
 	}
 	if stringer, ok := f.Value.(fmt.Stringer); ok {
+		// A typed-nil pointer (e.g. (*T)(nil)) still satisfies fmt.Stringer, but
+		// its String() may dereference the nil receiver and panic. Logging must
+		// never panic, so render a nil underlying value as empty (and let
+		// Log.String drop the field) rather than calling through.
+		if rv := reflect.ValueOf(f.Value); rv.Kind() == reflect.Pointer && rv.IsNil() {
+			return ""
+		}
 		return stringer.String()
 	}
 	if s, ok := f.Value.(string); ok {

--- a/wool/log_test.go
+++ b/wool/log_test.go
@@ -1,0 +1,149 @@
+package wool_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/codefly-dev/core/wool"
+	"github.com/stretchr/testify/require"
+)
+
+// capture is a LogProcessor that records every Log it receives, so tests can
+// assert on what actually reached the sink after level filtering.
+type capture struct {
+	mu   sync.Mutex
+	logs []*wool.Log
+}
+
+func (c *capture) Process(msg *wool.Log) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.logs = append(c.logs, msg)
+}
+
+func (c *capture) messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, l := range c.logs {
+		out = append(out, l.Message)
+	}
+	return out
+}
+
+func newWool(t *testing.T, level wool.Loglevel) (*wool.Wool, *capture) {
+	t.Helper()
+	cap := &capture{}
+	w := wool.Get(context.Background()).WithLogger(cap)
+	w.WithLoglevel(level)
+	return w, cap
+}
+
+func TestLogField_OmitsEmptyValues(t *testing.T) {
+	log := &wool.Log{
+		Level:   wool.INFO,
+		Message: "Found configurations",
+		Fields: []*wool.LogField{
+			wool.Field("configurations", ""),
+			wool.Field("count", 3),
+		},
+	}
+	s := log.String()
+	require.NotContains(t, s, "configurations=",
+		"an empty value must not render a bare key=")
+	require.Contains(t, s, "count=3")
+}
+
+func TestSliceField_RendersList(t *testing.T) {
+	require.Equal(t, "endpoints=[a, b]",
+		wool.SliceField("endpoints", []string{"a", "b"}).String())
+	require.Equal(t, "endpoints=none",
+		wool.SliceField("endpoints", []string{}).String())
+}
+
+func TestSecretField_NeverLeaksValue(t *testing.T) {
+	f := wool.SecretField("connection", "postgres://user:hunter2@host/db")
+	require.Equal(t, "connection=****", f.String())
+	// The raw secret must not survive anywhere on the field — not just in the
+	// rendered string but in the Value that reaches structured sinks too.
+	require.NotEqual(t, "postgres://user:hunter2@host/db", f.Value)
+	require.NotContains(t, f.String(), "hunter2")
+}
+
+func TestFocus_OrdersAboveInfo(t *testing.T) {
+	require.Greater(t, wool.FOCUS, wool.INFO,
+		"FOCUS must outrank INFO so an INFO-level run still shows it")
+}
+
+func TestFocus_VisibleAtInfoLevel(t *testing.T) {
+	w, cap := newWool(t, wool.INFO)
+	w.Focus("milestone")
+	w.Info("routine")
+	require.Equal(t, []string{"milestone", "routine"}, cap.messages())
+}
+
+func TestFocus_HidesRoutineInfoAtFocusLevel(t *testing.T) {
+	w, cap := newWool(t, wool.FOCUS)
+	w.Info("routine")    // below FOCUS — filtered
+	w.Focus("milestone") // shown
+	w.Warn("careful")    // above FOCUS — shown
+	require.Equal(t, []string{"milestone", "careful"}, cap.messages())
+}
+
+func TestLevelFromString(t *testing.T) {
+	got, ok := wool.LevelFromString("Debug")
+	require.True(t, ok)
+	require.Equal(t, wool.DEBUG, got)
+
+	_, ok = wool.LevelFromString("nonsense")
+	require.False(t, ok)
+}
+
+func TestScopeLevels_OverridePerComponent(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	wool.SetLogScopes("network=debug,*=warn")
+
+	// A network.* scope drops to DEBUG even though the catch-all is WARN.
+	netW := wool.Get(context.Background()).In("network.Runtime.GenerateNetworkMappings")
+	require.Equal(t, wool.DEBUG, netW.LogLevel())
+
+	// Anything else falls back to the catch-all.
+	other := wool.Get(context.Background()).In("resources.Service.Save")
+	require.Equal(t, wool.WARN, other.LogLevel())
+}
+
+func TestScopeLevels_FilterAtSink(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	wool.SetLogScopes("network=debug,*=warn")
+
+	cap := &capture{}
+	base := wool.Get(context.Background()).WithLogger(cap)
+
+	base.In("network.Connect").Debug("dialing") // network scope at DEBUG — shown
+	base.In("resources.Load").Debug("loading")  // catch-all WARN — filtered
+	base.In("resources.Load").Error("disk")     // catch-all WARN — shown
+
+	require.Equal(t, []string{"dialing", "disk"}, cap.messages())
+}
+
+func TestScopeLevels_LongestPrefixWins(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	wool.SetLogScopes("network=warn,network.dns=trace")
+
+	dns := wool.Get(context.Background()).In("network.dns.Resolve")
+	require.Equal(t, wool.TRACE, dns.LogLevel())
+
+	other := wool.Get(context.Background()).In("network.Connect")
+	require.Equal(t, wool.WARN, other.LogLevel())
+}
+
+func TestString_DropsEmptyFieldsEndToEnd(t *testing.T) {
+	w, cap := newWool(t, wool.INFO)
+	w.Info("done", wool.Field("a", ""), wool.Field("b", "x"))
+	require.Len(t, cap.logs, 1)
+	line := cap.logs[0].String()
+	require.Contains(t, line, "b=x")
+	require.False(t, strings.Contains(line, "a="), "empty field a= should be dropped: %s", line)
+}

--- a/wool/log_test.go
+++ b/wool/log_test.go
@@ -56,6 +56,19 @@ func TestLogField_OmitsEmptyValues(t *testing.T) {
 	require.Contains(t, s, "count=3")
 }
 
+// nilDerefStringer.String() dereferences its receiver, so calling it on a
+// typed-nil pointer panics — exactly the case renderValue must guard against.
+type nilDerefStringer struct{ s string }
+
+func (n *nilDerefStringer) String() string { return n.s }
+
+func TestField_TypedNilStringer_DoesNotPanic(t *testing.T) {
+	var ns *nilDerefStringer // typed nil that still satisfies fmt.Stringer
+	f := wool.Field("x", ns)
+	require.NotPanics(t, func() { _ = f.String() })
+	require.Empty(t, f.String(), "a typed-nil stringer must render to nothing, not panic")
+}
+
 func TestSliceField_RendersList(t *testing.T) {
 	require.Equal(t, "endpoints=[a, b]",
 		wool.SliceField("endpoints", []string{"a", "b"}).String())

--- a/wool/log_test.go
+++ b/wool/log_test.go
@@ -63,6 +63,22 @@ func TestSliceField_RendersList(t *testing.T) {
 		wool.SliceField("endpoints", []string{}).String())
 }
 
+// stringerEndpoint exercises the fmt.Stringer branch of SliceField's element
+// rendering — domain types control their own representation instead of %v.
+type stringerEndpoint struct{ name string }
+
+func (e stringerEndpoint) String() string { return e.name }
+
+func TestSliceField_RendersStringerElements(t *testing.T) {
+	f := wool.SliceField("endpoints", []stringerEndpoint{{"tcp"}, {"grpc"}})
+	require.Equal(t, "endpoints=[tcp, grpc]", f.String())
+}
+
+func TestField_NilValueIsDropped(t *testing.T) {
+	require.Equal(t, "", wool.Field("k", nil).String(),
+		"a nil value must render to nothing so Log.String drops it")
+}
+
 func TestSecretField_NeverLeaksValue(t *testing.T) {
 	f := wool.SecretField("connection", "postgres://user:hunter2@host/db")
 	require.Equal(t, "connection=****", f.String())
@@ -137,6 +153,45 @@ func TestScopeLevels_LongestPrefixWins(t *testing.T) {
 
 	other := wool.Get(context.Background()).In("network.Connect")
 	require.Equal(t, wool.WARN, other.LogLevel())
+}
+
+func TestScopeLevels_MatchOnSegmentBoundary(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	wool.SetLogScopes("net=debug")
+
+	// A prefix must align with a scope segment: "net" matches "net.X" but not
+	// "network.X" — otherwise turning up one component leaks into its neighbors.
+	require.Equal(t, wool.DEBUG,
+		wool.Get(context.Background()).In("net.Dial").LogLevel())
+	require.Equal(t, wool.GlobalLogLevel(),
+		wool.Get(context.Background()).In("network.Dial").LogLevel())
+
+	// The "::" separator (used by some scopes) anchors too.
+	wool.SetLogScopes("RuntimeInstance=debug")
+	require.Equal(t, wool.DEBUG,
+		wool.Get(context.Background()).In("RuntimeInstance::Load").LogLevel())
+}
+
+func TestScopeLevels_InstanceLevelTakesPrecedence(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	wool.SetLogScopes("network=debug")
+
+	w := wool.Get(context.Background()).In("network.Connect")
+	w.WithLoglevel(wool.ERROR)
+	// An explicit per-instance level wins over a scope override — this is the
+	// contract custom processors rely on to receive every line.
+	require.Equal(t, wool.ERROR, w.LogLevel())
+}
+
+func TestScopeLevels_IgnoresMalformedEntries(t *testing.T) {
+	t.Cleanup(func() { wool.SetLogScopes("") })
+	// "=warn" has an empty name and must NOT become a catch-all.
+	wool.SetLogScopes("=warn,network=debug")
+
+	require.Equal(t, wool.GlobalLogLevel(),
+		wool.Get(context.Background()).In("resources.Load").LogLevel())
+	require.Equal(t, wool.DEBUG,
+		wool.Get(context.Background()).In("network.Dial").LogLevel())
 }
 
 func TestString_DropsEmptyFieldsEndToEnd(t *testing.T) {

--- a/wool/runtime.go
+++ b/wool/runtime.go
@@ -1,6 +1,10 @@
 package wool
 
-import "sync"
+import (
+	"os"
+	"strings"
+	"sync"
+)
 
 // IsDebug returns true if the global log level is DEBUG or TRACE.
 func IsDebug() bool {
@@ -51,4 +55,87 @@ func getFallbackLogger() LogProcessor {
 		return fallbackLogger
 	}
 	return &Console{level: globalLogLevel}
+}
+
+// scopeRule maps a scope-name prefix to a log level. A rule with an empty
+// prefix is the catch-all (written "*" in the spec).
+type scopeRule struct {
+	prefix string
+	level  Loglevel
+}
+
+var (
+	scopeRules       []scopeRule
+	scopeRulesLoaded bool
+)
+
+// SetLogScopes installs per-scope level overrides, replacing any previously set
+// (including those loaded lazily from CODEFLY_LOG). The spec is a comma list of
+// "scope=level" entries, e.g. "network=debug,resources=info,*=warn"; "*" is the
+// catch-all. A scope matches when the .In(...) name has the rule prefix; the
+// longest matching prefix wins. Unparseable entries are ignored.
+func SetLogScopes(spec string) {
+	lock.Lock()
+	defer lock.Unlock()
+	scopeRules = parseLogScopes(spec)
+	scopeRulesLoaded = true
+}
+
+func parseLogScopes(spec string) []scopeRule {
+	var rules []scopeRule
+	for part := range strings.SplitSeq(spec, ",") {
+		name, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		level, ok := LevelFromString(value)
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "*" {
+			name = ""
+		}
+		rules = append(rules, scopeRule{prefix: name, level: level})
+	}
+	return rules
+}
+
+func logScopeRules() []scopeRule {
+	lock.Lock()
+	defer lock.Unlock()
+	if !scopeRulesLoaded {
+		scopeRules = parseLogScopes(os.Getenv("CODEFLY_LOG"))
+		scopeRulesLoaded = true
+	}
+	return scopeRules
+}
+
+// scopeLevelFor returns the level override for a .In(...) scope name. The
+// longest matching prefix wins; the catch-all ("*") applies when no prefix
+// matches. The second return is false when no rule applies.
+func scopeLevelFor(name string) (Loglevel, bool) {
+	rules := logScopeRules()
+	if len(rules) == 0 {
+		return DEFAULT, false
+	}
+	matchLevel := DEFAULT
+	matchLen := -1
+	for _, r := range rules {
+		if r.prefix == "" {
+			if matchLen < 0 {
+				matchLevel = r.level
+				matchLen = 0
+			}
+			continue
+		}
+		if strings.HasPrefix(name, r.prefix) && len(r.prefix) > matchLen {
+			matchLevel = r.level
+			matchLen = len(r.prefix)
+		}
+	}
+	if matchLen < 0 {
+		return DEFAULT, false
+	}
+	return matchLevel, true
 }

--- a/wool/runtime.go
+++ b/wool/runtime.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // IsDebug returns true if the global log level is DEBUG or TRACE.
@@ -64,21 +65,24 @@ type scopeRule struct {
 	level  Loglevel
 }
 
-var (
-	scopeRules       []scopeRule
-	scopeRulesLoaded bool
-)
+// scopeRules holds the active per-scope overrides. It is read on the logging
+// hot path (Wool.LogLevel, on essentially every log call) so reads go through a
+// lock-free atomic load; the slice is replaced wholesale, never mutated in
+// place. Seeded from CODEFLY_LOG at init and replaceable via SetLogScopes.
+var scopeRules atomic.Pointer[[]scopeRule]
+
+func init() {
+	SetLogScopes(os.Getenv("CODEFLY_LOG"))
+}
 
 // SetLogScopes installs per-scope level overrides, replacing any previously set
-// (including those loaded lazily from CODEFLY_LOG). The spec is a comma list of
-// "scope=level" entries, e.g. "network=debug,resources=info,*=warn"; "*" is the
-// catch-all. A scope matches when the .In(...) name has the rule prefix; the
+// (including the CODEFLY_LOG defaults loaded at init). The spec is a comma list
+// of "scope=level" entries, e.g. "network=debug,resources=info,*=warn"; "*" is
+// the catch-all. A scope matches when the .In(...) name has the rule prefix; the
 // longest matching prefix wins. Unparseable entries are ignored.
 func SetLogScopes(spec string) {
-	lock.Lock()
-	defer lock.Unlock()
-	scopeRules = parseLogScopes(spec)
-	scopeRulesLoaded = true
+	rules := parseLogScopes(spec)
+	scopeRules.Store(&rules)
 }
 
 func parseLogScopes(spec string) []scopeRule {
@@ -101,27 +105,17 @@ func parseLogScopes(spec string) []scopeRule {
 	return rules
 }
 
-func logScopeRules() []scopeRule {
-	lock.Lock()
-	defer lock.Unlock()
-	if !scopeRulesLoaded {
-		scopeRules = parseLogScopes(os.Getenv("CODEFLY_LOG"))
-		scopeRulesLoaded = true
-	}
-	return scopeRules
-}
-
 // scopeLevelFor returns the level override for a .In(...) scope name. The
 // longest matching prefix wins; the catch-all ("*") applies when no prefix
 // matches. The second return is false when no rule applies.
 func scopeLevelFor(name string) (Loglevel, bool) {
-	rules := logScopeRules()
-	if len(rules) == 0 {
+	rules := scopeRules.Load()
+	if rules == nil {
 		return DEFAULT, false
 	}
 	matchLevel := DEFAULT
 	matchLen := -1
-	for _, r := range rules {
+	for _, r := range *rules {
 		if r.prefix == "" {
 			if matchLen < 0 {
 				matchLevel = r.level

--- a/wool/runtime.go
+++ b/wool/runtime.go
@@ -78,8 +78,9 @@ func init() {
 // SetLogScopes installs per-scope level overrides, replacing any previously set
 // (including the CODEFLY_LOG defaults loaded at init). The spec is a comma list
 // of "scope=level" entries, e.g. "network=debug,resources=info,*=warn"; "*" is
-// the catch-all. A scope matches when the .In(...) name has the rule prefix; the
-// longest matching prefix wins. Unparseable entries are ignored.
+// the catch-all. A scope matches when its prefix lines up with a leading segment
+// of the .In(...) name (see scopeMatches); the longest matching prefix wins.
+// Unparseable entries are ignored.
 func SetLogScopes(spec string) {
 	rules := parseLogScopes(spec)
 	scopeRules.Store(&rules)
@@ -97,12 +98,34 @@ func parseLogScopes(spec string) []scopeRule {
 			continue
 		}
 		name = strings.TrimSpace(name)
+		if name == "" {
+			continue // malformed "=level"; only "*" is the catch-all
+		}
 		if name == "*" {
 			name = ""
 		}
 		rules = append(rules, scopeRule{prefix: name, level: level})
 	}
 	return rules
+}
+
+// scopeMatches reports whether a non-empty rule prefix applies to a .In(...)
+// scope name. It anchors on scope-segment boundaries ('.' or '::') so "network"
+// matches "network.Runtime" and "RuntimeInstance::Load" matches "RuntimeInstance"
+// — but "net" does not spuriously match "network".
+func scopeMatches(name, prefix string) bool {
+	if name == prefix {
+		return true
+	}
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	switch name[len(prefix)] {
+	case '.', ':':
+		return true
+	default:
+		return false
+	}
 }
 
 // scopeLevelFor returns the level override for a .In(...) scope name. The
@@ -123,7 +146,7 @@ func scopeLevelFor(name string) (Loglevel, bool) {
 			}
 			continue
 		}
-		if strings.HasPrefix(name, r.prefix) && len(r.prefix) > matchLen {
+		if len(r.prefix) > matchLen && scopeMatches(name, r.prefix) {
 			matchLevel = r.level
 			matchLen = len(r.prefix)
 		}

--- a/wool/wool.go
+++ b/wool/wool.go
@@ -124,10 +124,16 @@ func (w *Wool) Catch() {
 // buffered, agent loggers) receive every TRACE/DEBUG line regardless of the
 // configured level.
 func (w *Wool) LogLevel() Loglevel {
-	if w.logLevel == DEFAULT {
-		return GlobalLogLevel()
+	if w.logLevel != DEFAULT {
+		return w.logLevel
 	}
-	return w.logLevel
+	// A scope override (CODEFLY_LOG / SetLogScopes) keyed on the .In(...) name
+	// takes precedence over the global level — this is what lets "network=debug,
+	// *=info" turn up one component without the firehose everywhere.
+	if level, ok := scopeLevelFor(w.name); ok {
+		return level
+	}
+	return GlobalLogLevel()
 }
 
 func (w *Wool) process(l Loglevel, msg string, fs ...*LogField) {


### PR DESCRIPTION
Closes #17.

## Summary

- Resolves the well-defined, **library-level** wool problems from #17 so logs are more scannable without touching every call site: empty fields are dropped, FOCUS becomes a visible milestone, levels can be scoped per component, and secret redaction is a first-class primitive.
- Generic fixes propagate to call sites automatically — e.g. the `Found configurations configurations=` line now renders as just `Found configurations` because the empty field is omitted, no call-site edit needed.

## What changed (in `wool`)

- **Empty/meaningless fields (#1).** `LogField.String()` returns `""` for a nil/empty value and `Log.String()` drops it — no more bare `key=`.
- **Struct-dump fields (#2).** Added `wool.SliceField(key, slice)` rendering `[a, b]` / `none`, and `renderValue` now prefers `fmt.Stringer` so domain types control their representation instead of falling to `%v`.
- **FOCUS semantics (#3).** Reordered the level enum so `FOCUS` sits **just above INFO**. At the default INFO level FOCUS lines are now shown (the highlight users want); running *at* FOCUS shows milestones + warnings/errors while hiding routine INFO. Documented in `doc.go` and the enum.
- **Per-component levels (#5).** `CODEFLY_LOG` / `wool.SetLogScopes("network=debug,*=info")`, consulted in `Wool.LogLevel()` keyed on the `.In(...)` scope name, longest-prefix-wins, `*` catch-all. An explicit per-instance level still wins (preserves the custom-processor contract).
- **Secrets (#7).** `wool.SecretField(key, value)` redacts at construction — the raw value is dropped, so it can never reach any sink (console/file/gRPC/telemetry), always rendering `****`.

## Deliberately out of scope (noted per #17)

These are broad or cross-repo and would bloat/destabilize this PR; left for follow-ups:

- **`::` vs `.` scope rename (#4)** — a mechanical sweep of ~357 `.In(...)` call sites; belongs in its own PR. The new per-scope levels work with either separator via prefix match.
- **Call-chain breadcrumbs (#6)** — changing `In()` to append to the parent scope is a behavioral change with wide blast radius.
- **Timestamps in the line format (#8)** — timestamps are owned by the CLI renderer (codefly-dev/cli#67); emitting them here too would double-stamp. Better coordinated with that issue.

## Test plan

- [x] `go test ./wool/...` — new `wool/log_test.go` covers empty-field omission, `SliceField`, `SecretField` redaction, FOCUS ordering + filtering at INFO/FOCUS levels, `LevelFromString`, and per-scope overrides (override, longest-prefix, catch-all, sink filtering).
- [x] `go build ./...` and `go vet ./wool/...` clean; `gofmt` clean.
- [x] `go test ./tui/... ./woollog/... ./configurations/...` pass (consumers of wool levels/output).
- [x] `go test ./runners/golang/ -run TestNixRunWithMod` passes (a flaky Docker/Nix timing test that briefly failed under full-suite parallel load; unrelated to this change — it asserts on user-binary stdout, not wool output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable log-level parsing from text and per-scope overrides for more flexible logging control.
  * Introduced helpers for redacted secret fields and cleaner slice formatting in log output.

* **Bug Fixes**
  * Empty or nil log fields are now omitted from rendered output instead of showing blank or `nil` entries.
  * Log scope matching now uses the most specific matching prefix.

* **Documentation**
  * Updated logging docs to reflect the current severity order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->