### PR TITLE
dockerrun: resolve Docker host via active docker context (#21)

### DIFF
--- a/runners/dockerrun/container_sweep.go
+++ b/runners/dockerrun/container_sweep.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 
 	"github.com/codefly-dev/core/runners/base"
 	"github.com/codefly-dev/core/wool"
@@ -63,7 +62,7 @@ func shouldReapContainer(state string, ownerAlive, ephemeral bool) bool {
 func ReapStaleContainers(ctx context.Context) error {
 	w := wool.Get(ctx).In("base.ReapStaleContainers")
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, _, err := newDockerClient()
 	if err != nil {
 		// Docker not reachable — nothing to reap, not an error.
 		w.Trace("docker client unavailable — skipping container sweep", wool.ErrField(err))

--- a/runners/dockerrun/docker.go
+++ b/runners/dockerrun/docker.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/codefly-dev/core/resources"
-	"github.com/docker/docker/client"
 )
 
 type DockerPortMapping struct {
@@ -18,7 +17,7 @@ type DockerPortMapping struct {
 }
 
 func DockerEngineRunning(ctx context.Context) bool {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, _, err := newDockerClient()
 	if err != nil {
 		return false
 	}
@@ -84,7 +83,7 @@ type DockerContainerInstance struct {
 func GetImageID(im *resources.DockerImage) (string, error) {
 	ctx := context.Background()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, _, err := newDockerClient()
 	if err != nil {
 		return "", fmt.Errorf("failed to create Docker client: %v", err)
 	}

--- a/runners/dockerrun/docker_host.go
+++ b/runners/dockerrun/docker_host.go
@@ -1,0 +1,104 @@
+package dockerrun
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/client"
+)
+
+const defaultDockerHost = "unix:///var/run/docker.sock"
+
+// dockerHost is a resolved Docker daemon endpoint and where it came from.
+// The source is surfaced in "daemon not reachable" errors so a misconfigured
+// context vs a stale DOCKER_HOST is immediately distinguishable.
+type dockerHost struct {
+	Host   string
+	Source string
+}
+
+// resolveDockerHost mirrors how the `docker` CLI picks its endpoint, which the
+// Docker Go SDK's client.FromEnv does NOT: FromEnv honors DOCKER_HOST and
+// otherwise hardcodes the default socket, ignoring the active `docker context`.
+// On OrbStack/colima/Docker-Desktop the daemon is reachable only via the
+// context endpoint, so FromEnv-based detection reports Docker as down.
+//
+// Resolution order, matching the CLI:
+//  1. DOCKER_HOST — explicit override.
+//  2. active docker context (DOCKER_CONTEXT env, else currentContext in
+//     ~/.docker/config.json) → its docker endpoint from
+//     ~/.docker/contexts/meta/<id>/meta.json.
+//  3. the default unix socket.
+func resolveDockerHost() dockerHost {
+	if h := os.Getenv("DOCKER_HOST"); h != "" {
+		return dockerHost{Host: h, Source: "DOCKER_HOST env"}
+	}
+	if name := activeDockerContextName(); name != "" && name != "default" {
+		if h, err := dockerContextHost(name); err == nil && h != "" {
+			return dockerHost{Host: h, Source: fmt.Sprintf("docker context %q", name)}
+		}
+	}
+	return dockerHost{Host: defaultDockerHost, Source: "default socket"}
+}
+
+// newDockerClient builds a Docker client pointed at the resolved endpoint.
+// FromEnv is kept first so TLS material (DOCKER_TLS_VERIFY / DOCKER_CERT_PATH)
+// is still honored; WithHost then overrides the endpoint with the resolved one.
+func newDockerClient() (*client.Client, dockerHost, error) {
+	host := resolveDockerHost()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(host.Host), client.WithAPIVersionNegotiation())
+	return cli, host, err
+}
+
+func activeDockerContextName() string {
+	if c := os.Getenv("DOCKER_CONTEXT"); c != "" {
+		return c
+	}
+	data, err := os.ReadFile(filepath.Join(dockerConfigDir(), "config.json"))
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		CurrentContext string `json:"currentContext"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return ""
+	}
+	return parsed.CurrentContext
+}
+
+// dockerContextHost reads the docker endpoint for a named context. The on-disk
+// directory is keyed by the hex SHA-256 of the context name, matching the
+// docker CLI's context store layout.
+func dockerContextHost(name string) (string, error) {
+	id := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	data, err := os.ReadFile(filepath.Join(dockerConfigDir(), "contexts", "meta", id, "meta.json"))
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		Endpoints struct {
+			Docker struct {
+				Host string `json:"Host"`
+			} `json:"docker"`
+		} `json:"Endpoints"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", err
+	}
+	return parsed.Endpoints.Docker.Host, nil
+}
+
+func dockerConfigDir() string {
+	if d := os.Getenv("DOCKER_CONFIG"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".docker")
+}

--- a/runners/dockerrun/docker_host_test.go
+++ b/runners/dockerrun/docker_host_test.go
@@ -1,0 +1,119 @@
+package dockerrun
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeContext lays out a docker context on disk exactly as the CLI does:
+// contexts/meta/<sha256(name)>/meta.json with the docker endpoint host.
+func writeContext(t *testing.T, configDir, name, host string) {
+	t.Helper()
+	id := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	dir := filepath.Join(configDir, "contexts", "meta", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := map[string]any{
+		"Name": name,
+		"Endpoints": map[string]any{
+			"docker": map[string]any{"Host": host},
+		},
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeCurrentContext(t *testing.T, configDir, name string) {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"currentContext": name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveDockerHost(t *testing.T) {
+	// DOCKER_HOST wins over everything.
+	t.Run("DOCKER_HOST env takes precedence", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "tcp://1.2.3.4:2375")
+		t.Setenv("DOCKER_CONTEXT", "")
+		got := resolveDockerHost()
+		if got.Host != "tcp://1.2.3.4:2375" || got.Source != "DOCKER_HOST env" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	// The OrbStack case from the issue: no DOCKER_HOST, active context points at
+	// a non-default socket — must resolve to that socket, not /var/run/docker.sock.
+	t.Run("active context from config.json", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+		t.Setenv("DOCKER_CONFIG", configDir)
+		writeContext(t, configDir, "orbstack", "unix:///Users/me/.orbstack/run/docker.sock")
+		writeCurrentContext(t, configDir, "orbstack")
+
+		got := resolveDockerHost()
+		if got.Host != "unix:///Users/me/.orbstack/run/docker.sock" {
+			t.Fatalf("host = %q", got.Host)
+		}
+		if got.Source != `docker context "orbstack"` {
+			t.Fatalf("source = %q", got.Source)
+		}
+	})
+
+	// DOCKER_CONTEXT overrides config.json's currentContext.
+	t.Run("DOCKER_CONTEXT env selects the context", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONFIG", configDir)
+		writeContext(t, configDir, "colima", "unix:///Users/me/.colima/docker.sock")
+		writeCurrentContext(t, configDir, "orbstack")
+		t.Setenv("DOCKER_CONTEXT", "colima")
+
+		got := resolveDockerHost()
+		if got.Host != "unix:///Users/me/.colima/docker.sock" {
+			t.Fatalf("host = %q", got.Host)
+		}
+	})
+
+	// The "default" context is DOCKER_HOST-based; it has no meta.json, so we
+	// must fall back to the default socket rather than error.
+	t.Run("default context falls back to default socket", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+		t.Setenv("DOCKER_CONFIG", configDir)
+		writeCurrentContext(t, configDir, "default")
+
+		got := resolveDockerHost()
+		if got.Host != defaultDockerHost || got.Source != "default socket" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	// No env, no config → default socket.
+	t.Run("no config falls back to default socket", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+		t.Setenv("DOCKER_CONFIG", configDir)
+
+		got := resolveDockerHost()
+		if got.Host != defaultDockerHost || got.Source != "default socket" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+}

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -87,7 +87,7 @@ func (docker *DockerEnvironment) WithEphemeral() *DockerEnvironment {
 // nil return). Same defensive close in NewDockerHeadlessEnvironment.
 func NewDockerEnvironment(ctx context.Context, image *resources.DockerImage, dir, name string) (*DockerEnvironment, error) {
 	w := wool.Get(ctx).In("NewDockerEnvironment")
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, host, err := newDockerClient()
 	if err != nil {
 		return nil, w.Wrapf(err, "cannot create docker client")
 	}
@@ -96,9 +96,8 @@ func NewDockerEnvironment(ctx context.Context, image *resources.DockerImage, dir
 	// connection refused" buried inside an unrelated wrap. Ping now
 	// so the message is loud and actionable.
 	if _, pingErr := cli.Ping(ctx); pingErr != nil {
-		host := cli.DaemonHost()
 		_ = cli.Close()
-		return nil, w.NewError("docker daemon at %s not reachable (%v) — is Docker Desktop / dockerd running? Try `docker info` to confirm (or check DOCKER_HOST)", host, pingErr)
+		return nil, w.NewError("docker daemon at %s (from %s) not reachable (%v) — is Docker Desktop / dockerd running? Try `docker info` to confirm", host.Host, host.Source, pingErr)
 	}
 
 	env := &DockerEnvironment{
@@ -121,7 +120,7 @@ func NewDockerEnvironment(ctx context.Context, image *resources.DockerImage, dir
 // NewDockerHeadlessEnvironment creates a new docker runner
 func NewDockerHeadlessEnvironment(ctx context.Context, image *resources.DockerImage, name string) (*DockerEnvironment, error) {
 	w := wool.Get(ctx).In("NewDockerRunner")
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, host, err := newDockerClient()
 	if err != nil {
 		return nil, w.Wrapf(err, "cannot create docker client")
 	}
@@ -130,9 +129,8 @@ func NewDockerHeadlessEnvironment(ctx context.Context, image *resources.DockerIm
 	// connection refused" buried inside an unrelated wrap. Ping now
 	// so the message is loud and actionable.
 	if _, pingErr := cli.Ping(ctx); pingErr != nil {
-		host := cli.DaemonHost()
 		_ = cli.Close()
-		return nil, w.NewError("docker daemon at %s not reachable (%v) — is Docker Desktop / dockerd running? Try `docker info` to confirm (or check DOCKER_HOST)", host, pingErr)
+		return nil, w.NewError("docker daemon at %s (from %s) not reachable (%v) — is Docker Desktop / dockerd running? Try `docker info` to confirm", host.Host, host.Source, pingErr)
 	}
 	env := &DockerEnvironment{
 		client: cli,


### PR DESCRIPTION
Closes #21.

## Summary

- `client.FromEnv` only reads `DOCKER_HOST` and otherwise hardcodes `unix:///var/run/docker.sock` — it never consults the active `docker context`. On OrbStack/colima/Docker-Desktop the daemon is reachable only via the context endpoint, so `DockerEngineRunning` (and every other `dockerrun` client) reported Docker as down even when `docker info` works.
- Adds a shared `resolveDockerHost` helper that mirrors the `docker` CLI: `DOCKER_HOST` → active context (`DOCKER_CONTEXT` env, else `currentContext` in `~/.docker/config.json`, then the endpoint from `~/.docker/contexts/meta/<id>/meta.json`) → default socket. All five `dockerrun` client-construction sites now route through it via `newDockerClient`.
- "daemon not reachable" errors now report the resolved endpoint and its source (env vs context vs default) so misconfig is obvious.

`newDockerClient` keeps `client.FromEnv` first (so `DOCKER_TLS_VERIFY`/`DOCKER_CERT_PATH` stay honored) and layers `client.WithHost(resolved)` on top. Remote-context TLS material under `~/.docker/contexts/tls/` is out of scope — this targets the local-socket contexts named in the issue.

## Test plan

- [x] `go build ./runners/dockerrun/`
- [x] `go vet ./runners/dockerrun/`
- [x] `go test ./runners/dockerrun/ -run TestResolveDockerHost` — covers DOCKER_HOST precedence, config.json context resolution, DOCKER_CONTEXT override, `default` context fallback, and no-config fallback, all against real on-disk context layouts (no mocks)
- [ ] Manual: with OrbStack active and `DOCKER_HOST` unset, `DockerEngineRunning` returns `true` (requires a machine with a non-default context — cannot run in CI without Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker-based runs now better detect the active Docker endpoint, including `DOCKER_HOST`, Docker contexts, and the default local socket.

* **Bug Fixes**
  * Improved Docker client setup to handle more environment configurations consistently.
  * Connection errors now include the resolved Docker endpoint, making it easier to understand which daemon was unreachable.
  * Docker-related checks and cleanup now reuse a shared connection setup path for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->