### PR TITLE
core: correctness fixes from the cross-cutting audit (#23)

### DIFF
--- a/resources/endpoint.go
+++ b/resources/endpoint.go
@@ -206,6 +206,9 @@ func IsRest(_ context.Context, endpoint *basev0.Endpoint) *basev0.RestAPI {
 	if endpoint.Api != standards.REST {
 		return nil
 	}
+	if endpoint.ApiDetails == nil {
+		return nil
+	}
 	switch v := endpoint.ApiDetails.Value.(type) {
 	case *basev0.API_Rest:
 		return v.Rest
@@ -219,6 +222,9 @@ func IsGRPC(_ context.Context, endpoint *basev0.Endpoint) *basev0.GrpcAPI {
 		return nil
 	}
 	if endpoint.Api != standards.GRPC {
+		return nil
+	}
+	if endpoint.ApiDetails == nil {
 		return nil
 	}
 	switch v := endpoint.ApiDetails.Value.(type) {
@@ -236,6 +242,9 @@ func IsHTTP(_ context.Context, endpoint *basev0.Endpoint) *basev0.HttpAPI {
 	if endpoint.Api != standards.HTTP {
 		return nil
 	}
+	if endpoint.ApiDetails == nil {
+		return nil
+	}
 	switch v := endpoint.ApiDetails.Value.(type) {
 	case *basev0.API_Http:
 		return v.Http
@@ -249,6 +258,9 @@ func IsTCP(_ context.Context, endpoint *basev0.Endpoint) *basev0.TcpAPI {
 		return nil
 	}
 	if endpoint.Api != standards.TCP {
+		return nil
+	}
+	if endpoint.ApiDetails == nil {
 		return nil
 	}
 	switch v := endpoint.ApiDetails.Value.(type) {

--- a/resources/endpoint_isapi_test.go
+++ b/resources/endpoint_isapi_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"context"
+	"testing"
+
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/standards"
+	"github.com/stretchr/testify/require"
+)
+
+// Endpoint.Proto() sets Api but leaves ApiDetails nil, so the Is* helpers must
+// tolerate a nil ApiDetails on an endpoint whose Api matches, rather than panic.
+func TestIsAPIHelpersTolerateNilDetails(t *testing.T) {
+	ctx := context.Background()
+
+	require.Nil(t, resources.IsGRPC(ctx, &basev0.Endpoint{Api: standards.GRPC}))
+	require.Nil(t, resources.IsRest(ctx, &basev0.Endpoint{Api: standards.REST}))
+	require.Nil(t, resources.IsHTTP(ctx, &basev0.Endpoint{Api: standards.HTTP}))
+	require.Nil(t, resources.IsTCP(ctx, &basev0.Endpoint{Api: standards.TCP}))
+
+	grpc := &basev0.GrpcAPI{}
+	ep := &basev0.Endpoint{Api: standards.GRPC, ApiDetails: resources.ToGrpcAPI(grpc)}
+	require.Same(t, grpc, resources.IsGRPC(ctx, ep))
+}

--- a/resources/service.go
+++ b/resources/service.go
@@ -503,7 +503,7 @@ func (s *Service) EndpointsFromNames(endpoints []string) ([]*Endpoint, error) {
 
 func (s *Service) ExistsDependency(requirement *ServiceIdentity) (*ServiceDependency, bool) {
 	for _, dep := range s.ServiceDependencies {
-		if dep.Name == requirement.Name {
+		if dep.Name == requirement.Name && dep.Module == requirement.Module {
 			return dep, true
 		}
 	}

--- a/resources/service_dependency_test.go
+++ b/resources/service_dependency_test.go
@@ -1,0 +1,29 @@
+package resources_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// Services sharing a name across different modules must be tracked as distinct
+// dependencies — ExistsDependency keys on Module as well as Name.
+func TestAddDependencySameNameDifferentModule(t *testing.T) {
+	ctx := context.Background()
+	svc := &resources.Service{Name: "consumer"}
+
+	require.NoError(t, svc.AddDependency(ctx, &resources.ServiceIdentity{Name: "foo", Module: "module-a"}, nil))
+	require.NoError(t, svc.AddDependency(ctx, &resources.ServiceIdentity{Name: "foo", Module: "module-b"}, nil))
+
+	require.Len(t, svc.ServiceDependencies, 2)
+
+	_, okA := svc.ExistsDependency(&resources.ServiceIdentity{Name: "foo", Module: "module-a"})
+	_, okB := svc.ExistsDependency(&resources.ServiceIdentity{Name: "foo", Module: "module-b"})
+	require.True(t, okA)
+	require.True(t, okB)
+
+	require.NoError(t, svc.AddDependency(ctx, &resources.ServiceIdentity{Name: "foo", Module: "module-a"}, nil))
+	require.Len(t, svc.ServiceDependencies, 2)
+}

--- a/shared/uuid.go
+++ b/shared/uuid.go
@@ -15,8 +15,7 @@ func ShortLowerUUID() (string, error) {
 		return "", err
 	}
 
-	uuidInt := big.NewInt(0)
-	uuidInt.SetString(id.String(), 16)
+	uuidInt := new(big.Int).SetBytes(id[:])
 
 	base26UUID := ""
 	for i := 0; i < 10; i++ {

--- a/shared/uuid_test.go
+++ b/shared/uuid_test.go
@@ -1,0 +1,23 @@
+package shared_test
+
+import (
+	"testing"
+
+	"github.com/codefly-dev/core/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortLowerUUID(t *testing.T) {
+	seen := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		id, err := shared.ShortLowerUUID()
+		require.NoError(t, err)
+		require.Len(t, id, 10)
+		for _, c := range id {
+			require.True(t, c >= 'a' && c <= 'z', "unexpected character %q", c)
+		}
+		_, dup := seen[id]
+		require.False(t, dup, "duplicate id %q generated after %d iterations", id, i)
+		seen[id] = struct{}{}
+	}
+}

--- a/shared/uuid_test.go
+++ b/shared/uuid_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestShortLowerUUID(t *testing.T) {
 	seen := make(map[string]struct{})
+	firstChars := make(map[byte]struct{})
 	for i := 0; i < 1000; i++ {
 		id, err := shared.ShortLowerUUID()
 		require.NoError(t, err)
@@ -19,5 +20,9 @@ func TestShortLowerUUID(t *testing.T) {
 		_, dup := seen[id]
 		require.False(t, dup, "duplicate id %q generated after %d iterations", id, i)
 		seen[id] = struct{}{}
+		firstChars[id[0]] = struct{}{}
 	}
+	// The full 128 bits must reach the high-order base26 digits. If only the
+	// low 32 bits were used (the pre-fix bug), every id would start with 'a'.
+	require.Greater(t, len(firstChars), 1, "leading character never varies — high-order entropy is being dropped")
 }

--- a/templates/replacer.go
+++ b/templates/replacer.go
@@ -7,20 +7,16 @@ import (
 )
 
 type ServiceReplacer struct {
-	replacements map[string]string
+	replacements []generation.Replacement
 }
 
 func NewServiceReplacer(gen *generation.Service) *ServiceReplacer {
-	replacements := make(map[string]string)
-	for _, replacement := range gen.Replacements {
-		replacements[replacement.From] = replacement.To
-	}
-	return &ServiceReplacer{replacements: replacements}
+	return &ServiceReplacer{replacements: gen.Replacements}
 }
 
 func (r *ServiceReplacer) Do(content []byte) ([]byte, error) {
-	for old, to := range r.replacements {
-		content = bytes.ReplaceAll(content, []byte(old), []byte(to))
+	for _, replacement := range r.replacements {
+		content = bytes.ReplaceAll(content, []byte(replacement.From), []byte(replacement.To))
 	}
 	return content, nil
 }

--- a/templates/replacer_test.go
+++ b/templates/replacer_test.go
@@ -1,0 +1,26 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/codefly-dev/core/generation"
+	"github.com/codefly-dev/core/templates"
+	"github.com/stretchr/testify/require"
+)
+
+// Overlapping replacements where one entry's output feeds a later entry's
+// input must be applied in declaration order, deterministically.
+func TestServiceReplacerAppliesInOrder(t *testing.T) {
+	gen := &generation.Service{
+		Replacements: []generation.Replacement{
+			{From: "app", To: "myapp"},
+			{From: "myapp", To: "acme"},
+		},
+	}
+	replacer := templates.NewServiceReplacer(gen)
+	for i := 0; i < 100; i++ {
+		out, err := replacer.Do([]byte("app"))
+		require.NoError(t, err)
+		require.Equal(t, "acme", string(out))
+	}
+}


### PR DESCRIPTION
Closes #23.

## Summary

A cross-cutting audit of `core` — seven package-cluster reviewers (resources, agents, network/config, runners, sdk/architecture/graph, companions/builders/services/shared, wool/generation/templates/tui), each with adversarial verification of every finding. This PR lands the four verified, self-contained correctness bugs that could be fixed and unit-tested against real inputs with no infra; every other verified finding is filed as its own follow-up issue (below) per the audit's "spin out dedicated work" directive. No mocks introduced.

### Fixed here (with tests)

- **`resources.Is{Rest,GRPC,HTTP,TCP}` panicked on nil `ApiDetails`** — `resources/endpoint.go`. An endpoint whose `Api` matched but had `ApiDetails == nil` (exactly what `Endpoint.Proto()` produces, since it sets `Api` but not `ApiDetails`) hit `endpoint.ApiDetails.Value` → nil deref. Added the nil guard the sibling `EndpointRestAPI` already has. Test reproduces the panic pre-fix.
- **`Service.ExistsDependency` conflated same-named services across modules** — `resources/service.go`. It matched by `Name` only while `AddDependency` populates `Name`+`Module` and `DeleteServiceDependencies` matches on both; a dependency on `module-b/foo` was silently merged onto an existing `module-a/foo`. Now keyed on `Module` too.
- **`ShortLowerUUID` discarded ~96 bits of entropy** — `shared/uuid.go`. `big.Int.SetString(id.String(), 16)` fails on the UUID's dashes; the ignored `ok=false` left only the 32-bit `time_low` field in play (collides ~every 7 min). Now derives from all 16 UUID bytes via `SetBytes`.
- **`ServiceReplacer.Do` applied replacements in nondeterministic map order** — `templates/replacer.go`. Overlapping rules (one entry's output feeding another's input) produced run-to-run-different scaffolding. Now iterates the declared `[]Replacement` slice in order.

## Verified findings spun out as follow-up issues

Ranked most severe first:

| # | Severity | Finding |
|---|----------|---------|
| #32 | High | `sdk.WithDependencies` leaks the spawned CLI process group on four post-spawn error paths (no `proc.Kill()`) |
| #24 | High | `DockerProc.Run` doesn't kill the in-container exec on ctx cancel → process/goroutine/FD leak + `forwarderWG.Wait()` hang |
| #25 | Med | `NixProc.Wait` / `DockerProc.Wait` discard the exit error, violating the `Proc.Wait` contract (crashes read as clean exits) |
| #26 | Med | agents logger: `io.Pipe` writer never closed → `ForwardLogs` goroutine+pipe leak; `processors` slice data race |
| #27 | Med | `SetupWatcher` debounce goroutine + `Events` channel leak on context cancel |
| #28 | Med | `network.CLIServerPort` collapses to ~990 buckets → cross-workspace CLI bind collisions |
| #29 | Med | `forwardLines` discards `scanner.Err()` → silent output truncation on a >1 MiB line |
| #30 | Med | golang/rust runners commit `UpdateCache` before `go mod`/`cargo fetch` → cache poisoned on a failed download |
| #31 | Med | `ClearAgents` clears `connCache` but not the `instances` cache → stale `Instance` over a closed conn (panic/RPC failure) |

Lower-severity items also surfaced and verified but not filed individually (documented here for the record): `sdk` `Kill()`/`Release()` racing `close(sigCh)`; `architecture` emits a phantom `SERVICE` node for an unresolved dependency; `resources.ExtractRestRoutes` raw `Access.Kind`/`Endpoint` derefs (same nil-safety class as the fixed `Is*` helpers); `NewDockerImage` mis-parses registry-with-port refs; `FindWorkspaceConfiguration` only inspects `Infos[0]`; `configurations.Manager` maps unguarded vs the hardened `RuntimeManager`; `builders.Dependency.Hash` ignores file names (rename-with-same-content missed); Go companion has two version-source files that can drift; `wool.BufferedProcessor.Process` can send-on-closed-channel racing `Flush`; `NewMessageConsole`/`AddProcessor` unlocked global reads; `tui.PumpLogs` per-run goroutine/processor leak; `templates.WalkAndVisit` logs "copied" before checking the error and passes a `%s` to non-formatting `Trace`; `downloader` temp file never `Close()`d.

Reviewers confirmed **no** violations of the project invariants in these areas: readiness uses real gRPC health checks (not raw TCP); port allocation routes through `ToNamedPort`/`RuntimeManager` with working, lock-protected dedup; no hardcoded runtime ports; graph cycle detection is correct in both graph implementations; `SecretField` redaction holds across all sinks; per-scope log-level resolution is correct.

## Test plan

- [x] `go build ./...`
- [x] `go test ./resources/ ./shared/ ./templates/` (pass)
- [x] New tests fail without their fix (verified: `TestIsAPIHelpersTolerateNilDetails` panics on pre-fix `endpoint.go`)
- [x] `go vet` on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when endpoint type details are missing.
  * Improved dependency tracking so items with the same name in different modules are treated separately.
  * Made replacement handling consistent and deterministic when multiple changes overlap.

* **Tests**
  * Added coverage for missing endpoint details, module-aware dependency checks, unique short IDs, and ordered replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->