### PR TITLE
Invalidate instances cache in ClearAgents (#31)

### DIFF
--- a/services/agent.go
+++ b/services/agent.go
@@ -152,6 +152,13 @@ func getConn(cacheKey string) *manager.AgentConn {
 // (SIGTERM → wait → SIGKILL fallback), so the explicit pre-signal
 // here was both redundant and harmful.
 //
+// The instances cache (service.go) MUST be reset alongside connCache:
+// both are keyed by identity.Unique(), and a cached *Instance holds an
+// Agent/Info built from a connection this function closes. Leaving it
+// behind means a clear-then-reload in the same process returns that
+// stale Instance, whose subsequent LoadBuilder/LoadRuntime panics in
+// getConn (connCache now empty) or fails RPCs on the closed conn.
+//
 // Concurrency: snapshot under lock, swap to a fresh map, then Close
 // outside the lock. Closing a gRPC conn can take several seconds
 // (graceful SIGTERM grace) — holding the lock across it would block
@@ -161,6 +168,11 @@ func ClearAgents() {
 	old := connCache
 	connCache = make(map[string]*manager.AgentConn)
 	connCacheMu.Unlock()
+
+	instancesMu.Lock()
+	instances = map[string]*Instance{}
+	instancesMu.Unlock()
+
 	for _, conn := range old {
 		conn.Close()
 	}

--- a/services/agent_test.go
+++ b/services/agent_test.go
@@ -46,3 +46,33 @@ func TestServiceCacheKey_isolatesServicesSharingOneAgent(t *testing.T) {
 		t.Fatalf("ServiceCacheKey is not stable for the same service: %q then %q", ka, again)
 	}
 }
+
+// TestClearAgents_invalidatesInstancesCache is a regression test for the
+// stale-instance bug: ClearAgents reset connCache but left the instances cache
+// (keyed identically by identity.Unique()) populated. A clear-then-reload in the
+// same process then returned a cached *Instance whose Agent/Info were built from
+// the now-closed connection, and the next LoadBuilder/LoadRuntime panicked in
+// getConn (connCache empty) or failed RPCs on the dead conn. The two caches must
+// be cleared together.
+func TestClearAgents_invalidatesInstancesCache(t *testing.T) {
+	svc := &resources.Service{Name: "accounts", Agent: &resources.Agent{Publisher: "codefly.dev", Name: "go-grpc", Version: "0.1.4"}}
+	svc.WithModule("saas")
+	id, err := svc.Identity()
+	if err != nil {
+		t.Fatalf("cannot get identity: %v", err)
+	}
+
+	instancesMu.Lock()
+	instances[id.Unique()] = &Instance{Service: svc, Identity: id}
+	instancesMu.Unlock()
+
+	ClearAgents()
+
+	instancesMu.Lock()
+	_, stillCached := instances[id.Unique()]
+	instancesMu.Unlock()
+	if stillCached {
+		t.Fatalf("ClearAgents left a stale *Instance for %q in the cache: a reload would return an "+
+			"Instance bound to the closed connection", id.Unique())
+	}
+}


### PR DESCRIPTION
Closes #31.

## Summary
- `ClearAgents` reset `connCache` but never invalidated the `instances` cache in `service.go`. The two caches are keyed identically (`identity.Unique()`) but were cleared inconsistently.
- After a clear-then-reload in the same process, `Load` returned a cached `*Instance` whose `Agent`/`Info` were built from the now-closed connection; the next `LoadBuilder`/`LoadRuntime` panicked in `getConn` (empty `connCache`) or issued RPCs on the dead conn.
- Reset both caches together in `ClearAgents`.

## Test plan
- [x] `go test ./services/` passes, including the new `TestClearAgents_invalidatesInstancesCache` regression test
- [x] `go vet ./services/` clean