### PR TITLE
sdk: kill spawned CLI process group on post-spawn error paths (#32)

### DIFF
--- a/sdk/dependencies.go
+++ b/sdk/dependencies.go
@@ -153,7 +153,21 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 	// child's FDs independent of os.Stdout so `go test` can exit.
 	proc.Echo()
 
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// Tear down the spawned CLI process group (and its supervise/signal/echo
+	// goroutines) plus any open connection on every post-spawn error path.
+	// Disarmed once we return the live Dependencies to the caller.
+	var conn *grpc.ClientConn
+	success := false
+	defer func() {
+		if !success {
+			if conn != nil {
+				_ = conn.Close()
+			}
+			_ = proc.Kill()
+		}
+	}()
+
+	conn, err = grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gRPC client for %s: %w", addr, err)
 	}
@@ -165,15 +179,12 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 
 	conn.Connect()
 	if !waitForReady(connectCtx, conn) {
-		_ = conn.Close()
 		return nil, fmt.Errorf("gRPC connection to CLI server at %s did not become ready within %s", addr, opt.Timeout)
 	}
 
 	cli := v0.NewCLIClient(conn)
 	_, err = cli.Ping(ctx, &emptypb.Empty{})
 	if err != nil {
-		_ = conn.Close()
-		_ = proc.Kill()
 		return nil, fmt.Errorf("CLI server ping failed: %w", err)
 	}
 	runtimeContext := resources.RuntimeContextFromEnv()
@@ -186,6 +197,7 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 	if err != nil {
 		return nil, err
 	}
+	success = true
 	return l, nil
 }
 

--- a/sdk/dependencies_test.go
+++ b/sdk/dependencies_test.go
@@ -1,0 +1,74 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWithDependencies_KillsProcessGroupOnReadyTimeout verifies that when a
+// post-spawn error path is hit (here: the CLI server never becomes gRPC-ready),
+// WithDependencies tears down the entire spawned process group instead of
+// leaking it. A stand-in "codefly" binary backgrounds a child, records both
+// PIDs, then blocks forever without ever serving gRPC.
+func TestWithDependencies_KillsProcessGroupOnReadyTimeout(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pids")
+	binPath := filepath.Join(dir, "codefly")
+
+	// $$ (before exec) is the group leader; it keeps the same PID after exec
+	// replaces the shell with sleep. $! is the backgrounded child in the group.
+	script := "#!/bin/sh\n" +
+		"sleep 60 &\n" +
+		"echo \"$$ $!\" > \"" + pidFile + "\"\n" +
+		"exec sleep 60\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	t.Setenv("CODEFLY_BINARY", binPath)
+
+	_, err := WithDependencies(context.Background(), WithTimeout(2*time.Second))
+	if err == nil {
+		t.Fatal("expected WithDependencies to fail (fake CLI never becomes ready)")
+	}
+
+	leaderPID, childPID := readPIDFile(t, pidFile)
+
+	if !waitFor(3*time.Second, func() bool { return !pidAlive(leaderPID) }) {
+		t.Errorf("group leader %d still alive after WithDependencies error — process group leaked", leaderPID)
+	}
+	if !waitFor(3*time.Second, func() bool { return !pidAlive(childPID) }) {
+		t.Errorf("child %d still alive after WithDependencies error — process group leaked", childPID)
+	}
+}
+
+// readPIDFile waits for the fake binary to record its two PIDs, then parses them.
+func readPIDFile(t *testing.T, path string) (int, int) {
+	t.Helper()
+	var content []byte
+	if !waitFor(2*time.Second, func() bool {
+		b, err := os.ReadFile(path)
+		if err != nil || len(strings.Fields(string(b))) < 2 {
+			return false
+		}
+		content = b
+		return true
+	}) {
+		t.Fatalf("fake binary never recorded PIDs to %s", path)
+	}
+	fields := strings.Fields(string(content))
+	leader, err := strconv.Atoi(fields[0])
+	if err != nil {
+		t.Fatalf("parse leader PID %q: %v", fields[0], err)
+	}
+	child, err := strconv.Atoi(fields[1])
+	if err != nil {
+		t.Fatalf("parse child PID %q: %v", fields[1], err)
+	}
+	return leader, child
+}


### PR DESCRIPTION
Closes #32.

## Summary
- `sdk.WithDependencies` spawned the `codefly` CLI in its own process group but four post-spawn error paths (`grpc.NewClient`, `waitForReady`, `l.WaitForReady`, `l.SetEnvironment`) returned without `proc.Kill()`, orphaning the CLI's agents/containers and leaving `supervise`/`watchSignals`/`echoPipe` goroutines blocked forever — a permanent leak under a `context.Background()` caller.
- Replaced the scattered, incomplete cleanup (only the ping path was correct) with a single `defer` that closes the conn and kills the process group, disarmed only when the live `Dependencies` is returned.

## Test plan
- [x] `TestWithDependencies_KillsProcessGroupOnReadyTimeout` — a stand-in CLI binary backgrounds a child and blocks without serving gRPC; the test asserts the whole process group is dead after the ready-timeout error. Fails against the unfixed code (orphans survive), passes with the fix.
- [x] `go test ./sdk/`
- [x] `go vet ./sdk/`