### PR TITLE
runners: advance dep cache only after successful download (#30)

### DIFF
--- a/runners/golang/runner.go
+++ b/runners/golang/runner.go
@@ -348,11 +348,6 @@ func (r *GoRunnerEnvironment) GoModuleHandling(ctx context.Context) error {
 		w.Trace("go modules have been cached")
 		return nil
 	}
-	err = req.UpdateCache(ctx)
-	if err != nil {
-		return w.Wrapf(err, "cannot update go mod cache")
-	}
-
 	proc, err := r.Env().NewProcess("go", "mod", "download")
 	if err != nil {
 		return w.Wrapf(err, "cannot go mod download process")
@@ -366,6 +361,10 @@ func (r *GoRunnerEnvironment) GoModuleHandling(ctx context.Context) error {
 	err = proc.Run(ctx)
 	if err != nil {
 		return w.Wrapf(err, "cannot run go mod download")
+	}
+
+	if err = req.UpdateCache(ctx); err != nil {
+		return w.Wrapf(err, "cannot update go mod cache")
 	}
 	return nil
 }

--- a/runners/golang/runner_test.go
+++ b/runners/golang/runner_test.go
@@ -96,6 +96,53 @@ func testOutput(t *testing.T, data *shared.SliceWriter) {
 	require.Contains(t, snap[len(snap)-1], "signal received")
 }
 
+// TestGoModuleHandlingCacheAdvancesOnlyOnDownloadSuccess pins the ordering
+// invariant: the dependency hash must be persisted only after `go mod
+// download` succeeds. If it were advanced first, a failed download would be
+// masked on the next run (Updated() == false → fetch skipped, modules
+// missing). GOPROXY=off forces the subprocess offline so the failure path is
+// deterministic and network-free.
+func TestGoModuleHandlingCacheAdvancesOnlyOnDownloadSuccess(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("GOPROXY", "off")
+
+	newEnv := func(t *testing.T, gomod string) (*golang.GoRunnerEnvironment, string) {
+		t.Helper()
+		root := t.TempDir()
+		cacheDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte(gomod), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644))
+		env, err := golang.NewNativeGoRunner(ctx, root, ".")
+		require.NoError(t, err)
+		env.WithLocalCacheDir(cacheDir)
+		env.Setup(ctx)
+		return env, filepath.Join(cacheDir, "native", "gomod.hash")
+	}
+
+	t.Run("failure leaves cache unadvanced", func(t *testing.T) {
+		// Requires a module that cannot be resolved offline, so `go mod
+		// download` fails.
+		env, hashFile := newEnv(t, "module example.com/faildl\n\ngo 1.21\n\nrequire example.com/does-not-exist v0.0.1\n")
+		defer func() { require.NoError(t, env.Shutdown(ctx)) }()
+
+		require.Error(t, env.GoModuleHandling(ctx))
+
+		_, statErr := os.Stat(hashFile)
+		require.True(t, os.IsNotExist(statErr), "cache hash was advanced despite failed download")
+	})
+
+	t.Run("success advances cache", func(t *testing.T) {
+		// No external requires: `go mod download` succeeds even offline.
+		env, hashFile := newEnv(t, "module example.com/okdl\n\ngo 1.21\n")
+		defer func() { require.NoError(t, env.Shutdown(ctx)) }()
+
+		require.NoError(t, env.GoModuleHandling(ctx))
+
+		_, statErr := os.Stat(hashFile)
+		require.NoError(t, statErr, "cache hash was not persisted after successful download")
+	})
+}
+
 func TestNativeRunWithMod(t *testing.T) {
 	wool.SetGlobalLogLevel(wool.DEBUG)
 	ctx := context.Background()

--- a/runners/rust/runner.go
+++ b/runners/rust/runner.go
@@ -296,10 +296,6 @@ func (r *RustRunnerEnvironment) CargoDependencyHandling(ctx context.Context) err
 		w.Trace("cargo dependencies have been cached")
 		return nil
 	}
-	if err = req.UpdateCache(ctx); err != nil {
-		return w.Wrapf(err, "cannot update cargo cache")
-	}
-
 	proc, err := r.Env().NewProcess("cargo", "fetch")
 	if err != nil {
 		return w.Wrapf(err, "cannot create cargo fetch process")
@@ -310,6 +306,10 @@ func (r *RustRunnerEnvironment) CargoDependencyHandling(ctx context.Context) err
 	proc.WithDir(moduleDir)
 	if err = proc.Run(ctx); err != nil {
 		return w.Wrapf(err, "cannot run cargo fetch")
+	}
+
+	if err = req.UpdateCache(ctx); err != nil {
+		return w.Wrapf(err, "cannot update cargo cache")
 	}
 	return nil
 }

--- a/runners/rust/runner_test.go
+++ b/runners/rust/runner_test.go
@@ -52,6 +52,57 @@ func writeProject(t *testing.T) string {
 	return root
 }
 
+// TestCargoDependencyHandlingCacheAdvancesOnlyOnFetchSuccess pins the
+// ordering invariant: the dependency hash must be persisted only after
+// `cargo fetch` succeeds. If it were advanced first, a failed fetch would be
+// masked on the next run (Updated() == false → fetch skipped, crates
+// missing). CARGO_NET_OFFLINE=true forces the subprocess offline so the
+// failure path is deterministic and network-free.
+func TestCargoDependencyHandlingCacheAdvancesOnlyOnFetchSuccess(t *testing.T) {
+	if _, err := exec.LookPath("cargo"); err != nil {
+		t.Skip("cargo not available")
+	}
+	ctx := context.Background()
+	t.Setenv("CARGO_NET_OFFLINE", "true")
+
+	newEnv := func(t *testing.T, toml string) (*rust.RustRunnerEnvironment, string) {
+		t.Helper()
+		root := t.TempDir()
+		code := filepath.Join(root, "code")
+		require.NoError(t, os.MkdirAll(filepath.Join(code, "src"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(code, "Cargo.toml"), []byte(toml), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(code, "src", "main.rs"), []byte(mainRs), 0o644))
+		cacheDir := filepath.Join(root, "cache")
+		env, err := rust.NewNativeRustRunner(ctx, root, "code")
+		require.NoError(t, err)
+		env.WithLocalCacheDir(cacheDir)
+		env.Setup(ctx)
+		return env, filepath.Join(cacheDir, "native", "cargo.hash")
+	}
+
+	t.Run("failure leaves cache unadvanced", func(t *testing.T) {
+		// A dependency that cannot be resolved offline makes `cargo fetch` fail.
+		env, hashFile := newEnv(t, cargoToml+"\n[dependencies]\ndoes-not-exist-xyz = \"9999.0.0\"\n")
+		defer func() { _ = env.Shutdown(ctx) }()
+
+		require.Error(t, env.CargoDependencyHandling(ctx))
+
+		_, statErr := os.Stat(hashFile)
+		require.True(t, os.IsNotExist(statErr), "cache hash was advanced despite failed fetch")
+	})
+
+	t.Run("success advances cache", func(t *testing.T) {
+		// No dependencies: `cargo fetch` succeeds even offline.
+		env, hashFile := newEnv(t, cargoToml)
+		defer func() { _ = env.Shutdown(ctx) }()
+
+		require.NoError(t, env.CargoDependencyHandling(ctx))
+
+		_, statErr := os.Stat(hashFile)
+		require.NoError(t, statErr, "cache hash was not persisted after successful fetch")
+	})
+}
+
 // TestNativeBuildAndTest exercises the native RustRunnerEnvironment
 // end-to-end: init, build (with hashed-cache short-circuit on rebuild), and
 // `cargo test` result parsing. Skipped when cargo is unavailable.


### PR DESCRIPTION
Closes #30.

> **Note on this issue:** #30's title ("forwardLines discards scanner.Err → silent output truncation") and its body describe two different, both-real bugs. This PR implements the **body** — the one with the explicit "Fix direction". The scanner.Err/`forwardLines` bug named in the title is real too (`runners/base/pgid.go` never checks `scanner.Err()`), but it's unrelated and left for a separate PR.

## Summary
- `runners/golang/runner.go` and `runners/rust/runner.go` persisted the dependency hash (`req.UpdateCache`) *before* running `go mod download` / `cargo fetch`. When the download failed, the hash was already advanced, so the next run saw `Updated() == false`, skipped the fetch, and ran with modules undownloaded.
- Moved `UpdateCache` to after a successful download in both runners, matching the correct order already used in `companions/proto/proto.go`.

## Test plan
- [x] `TestGoModuleHandlingCacheAdvancesOnlyOnDownloadSuccess` — `GOPROXY=off` forces `go mod download` to fail offline; asserts the cache hash is *not* written on failure and *is* written on success. Verified it fails against the pre-fix ordering.
- [x] `TestCargoDependencyHandlingCacheAdvancesOnlyOnFetchSuccess` — `CARGO_NET_OFFLINE=true` equivalent for the rust runner (skips when `cargo` is absent).
- [x] `go vet ./runners/golang/ ./runners/rust/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)