### PR TITLE
Forward oversized process lines without truncation (#29)

### DIFF
--- a/runners/base/forward_lines_internal_test.go
+++ b/runners/base/forward_lines_internal_test.go
@@ -1,0 +1,92 @@
+package base
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestForwardLines_PreservesNewlinesPerLine proves each newline-terminated
+// line is written as its own Write with the separator intact — the boundary
+// wool's per-line prefixing relies on.
+func TestForwardLines_PreservesNewlinesPerLine(t *testing.T) {
+	src := "alpha\nbeta\ngamma\n"
+	w := &recordingWriter{}
+	forwardLines(strings.NewReader(src), w)
+
+	if got := w.buf.String(); got != src {
+		t.Fatalf("content mismatch:\n got %q\nwant %q", got, src)
+	}
+	want := []string{"alpha\n", "beta\n", "gamma\n"}
+	if len(w.writes) != len(want) {
+		t.Fatalf("expected %d per-line writes, got %d: %q", len(want), len(w.writes), w.writes)
+	}
+	for i, ln := range want {
+		if w.writes[i] != ln {
+			t.Fatalf("write %d = %q, want %q", i, w.writes[i], ln)
+		}
+	}
+}
+
+// TestForwardLines_OversizedLineNotTruncated is the regression guard for #29:
+// a single line larger than bufio.Scanner's 1MiB token cap used to make the
+// forwarder drop that line AND everything after it. ReadBytes forwards the
+// whole stream regardless of line length.
+func TestForwardLines_OversizedLineNotTruncated(t *testing.T) {
+	huge := strings.Repeat("x", 4*1024*1024) // 4MiB, well past the old 1MiB cap
+	src := huge + "\n" + "after-the-blob\n"
+	var w bytes.Buffer
+	forwardLines(strings.NewReader(src), &w)
+
+	if w.String() != src {
+		t.Fatalf("oversized line truncated: got %d bytes, want %d", w.Len(), len(src))
+	}
+	if !strings.Contains(w.String(), "after-the-blob\n") {
+		t.Fatal("output after the oversized line was lost")
+	}
+}
+
+// TestForwardLines_NoTrailingNewline forwards a final line that the child
+// emitted without a terminating newline (e.g. a prompt) without dropping it.
+func TestForwardLines_NoTrailingNewline(t *testing.T) {
+	src := "line\npartial"
+	var w bytes.Buffer
+	forwardLines(strings.NewReader(src), &w)
+	if w.String() != src {
+		t.Fatalf("got %q, want %q", w.String(), src)
+	}
+}
+
+// TestForwardLines_DrainsAfterWriteError proves that when the downstream
+// writer fails, forwardLines keeps reading r to EOF so the child never blocks
+// on a full pipe while the forwarder is about to close the read-end.
+func TestForwardLines_DrainsAfterWriteError(t *testing.T) {
+	src := strings.NewReader("first\nsecond\nthird\n")
+	forwardLines(src, failingWriter{})
+
+	rest, err := io.ReadAll(src)
+	if err != nil {
+		t.Fatalf("reading remainder: %v", err)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("reader not drained after write error: %q remained", rest)
+	}
+}
+
+type recordingWriter struct {
+	buf    bytes.Buffer
+	writes []string
+}
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	w.writes = append(w.writes, string(p))
+	return w.buf.Write(p)
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}

--- a/runners/base/forward_lines_internal_test.go
+++ b/runners/base/forward_lines_internal_test.go
@@ -63,7 +63,12 @@ func TestForwardLines_NoTrailingNewline(t *testing.T) {
 // writer fails, forwardLines keeps reading r to EOF so the child never blocks
 // on a full pipe while the forwarder is about to close the read-end.
 func TestForwardLines_DrainsAfterWriteError(t *testing.T) {
-	src := strings.NewReader("first\nsecond\nthird\n")
+	// The body must exceed bufio.Reader's internal buffer (4KiB) so that,
+	// without an explicit drain, the underlying reader would still hold
+	// unread bytes after the first failing write — the state that blocks a
+	// child on a full pipe. A body that fits the buffer gets slurped whole on
+	// the first fill and would make this pass even with no drain.
+	src := strings.NewReader("first\n" + strings.Repeat("payload line\n", 5000))
 	forwardLines(src, failingWriter{})
 
 	rest, err := io.ReadAll(src)
@@ -71,7 +76,7 @@ func TestForwardLines_DrainsAfterWriteError(t *testing.T) {
 		t.Fatalf("reading remainder: %v", err)
 	}
 	if len(rest) != 0 {
-		t.Fatalf("reader not drained after write error: %q remained", rest)
+		t.Fatalf("reader not drained after write error: %d bytes remained", len(rest))
 	}
 }
 

--- a/runners/base/native_runner.go
+++ b/runners/base/native_runner.go
@@ -446,10 +446,10 @@ func (proc *NativeProc) Wait(ctx context.Context) error {
 // log prefix was re-applied per Write call against zero-byte separators.
 // Plain io.Copy fixed the newline loss but collapsed all output into a
 // single prefix block — worse for interactive tailing. forwardLines
-// strikes the middle: scanner gives per-line Write boundaries (so log
-// prefixes apply correctly), newline is re-appended so downstream parsers
-// see the real separator, and the scanner buffer is sized for 1MiB lines
-// so large structured-log events don't silently truncate.
+// strikes the middle: per-line Write boundaries (so log prefixes apply
+// correctly) with newlines intact so downstream parsers see the real
+// separator, and no token cap so large structured-log events don't
+// silently truncate.
 func (proc *NativeProc) Forward(_ context.Context, r io.Reader) {
 	forwardLines(r, proc.output)
 }

--- a/runners/base/pgid.go
+++ b/runners/base/pgid.go
@@ -16,25 +16,32 @@ import (
 	"github.com/codefly-dev/core/wool"
 )
 
-// forwardLines reads lines from r and writes each line — WITH its trailing
+// forwardLines reads r line by line and writes each line — WITH its trailing
 // newline — as a single Write to w. This preserves log-prefix boundaries
 // (wool's per-Write prefix still applies per line) AND keeps newline
 // separators intact (JSON-lines, structured logs, anything newline-
-// delimited works). Scanner buffer is raised to 1MiB from the 64KiB
-// default so large test output or error stacks don't silently truncate.
+// delimited works). ReadBytes grows its buffer to hold a whole line no
+// matter how large, so a single oversized event (base64 blob, minified
+// stack) is forwarded intact — unlike a bufio.Scanner, which caps its token
+// at a fixed size and, once exceeded, silently drops that line and the rest
+// of the stream. On a write failure the remaining input is drained so the
+// child never blocks on a full pipe before the forwarder closes its read-end.
 // Shared by NativeProc.Forward and NixProc.forward.
 func forwardLines(r io.Reader, w io.Writer) {
 	if w == nil {
 		_, _ = io.Copy(io.Discard, r)
 		return
 	}
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		// Re-append the newline so the downstream writer sees the real
-		// separator — losing it was the JSON-lines bug.
-		if _, err := w.Write(append(line, '\n')); err != nil {
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, werr := w.Write(line); werr != nil {
+				_, _ = io.Copy(io.Discard, br)
+				return
+			}
+		}
+		if err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Closes #29.

## Summary
- `forwardLines` (shared by `NativeProc.Forward` and `NixProc.forward`) used a `bufio.Scanner` with a 1MiB token cap. A single line past that cap made `Scan()` return false with `bufio.ErrTooLong`, the loop dropped that line **and everything after it**, and `scanner.Err()` was never inspected — silently truncating exactly the large structured-log events / base64 blobs the buffer comment claimed to protect.
- Replace the scanner with a `bufio.Reader` whose `ReadBytes('\n')` grows to hold a whole line regardless of size, so no line is ever dropped while keeping the per-line Write boundaries wool's prefixing depends on.
- Drain the reader on a downstream write failure so the child never blocks on a full pipe before the forwarder closes its read-end.

## Test plan
- [x] `go test ./runners/base/ -run TestForwardLines -v` — new internal tests cover per-line boundaries, a 4MiB oversized line + trailing output surviving intact, a final line without a trailing newline, and draining after a write error.
- [x] `go test ./runners/base/` (full package) passes.
- [x] `go vet ./runners/base/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line-by-line forwarding so each log line is written separately and keeps its newline, preserving readable output and prefixes.
  * Fixed handling of very long lines so they are no longer cut off, and later content still appears correctly.
  * Ensured final lines without a trailing newline are still delivered.
  * Made forwarding continue draining input after a write error, reducing the chance of stalled processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->