### PR TITLE
Use full hash entropy for CLIServerPort (#28)

### DIFF
--- a/network/cli_port_test.go
+++ b/network/cli_port_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -38,15 +39,15 @@ func TestCLIServerPort_DifferentWorkspacesDifferentPorts(t *testing.T) {
 }
 
 func TestCLIServerPort_InRange(t *testing.T) {
-	// Port must live in [20000, 29900) and be a multiple of 10 so
-	// CLIRestPort at +1 is a recognizable companion.
+	// Port must live in [20000, 29900) and be even so CLIRestPort at +1
+	// (odd) can never collide with another workspace's gRPC port.
 	for _, n := range []string{"a", "b", "c", "mind-server", "some-other-workspace-name"} {
 		p := CLIServerPort(n)
-		if p < 20000 || p >= 29910 {
-			t.Errorf("CLIServerPort(%q) = %d, out of range [20000, 29910)", n, p)
+		if p < 20000 || p >= 29900 {
+			t.Errorf("CLIServerPort(%q) = %d, out of range [20000, 29900)", n, p)
 		}
-		if p%10 != 0 {
-			t.Errorf("CLIServerPort(%q) = %d, not multiple of 10", n, p)
+		if p%2 != 0 {
+			t.Errorf("CLIServerPort(%q) = %d, not even", n, p)
 		}
 	}
 }
@@ -75,6 +76,24 @@ func TestCLIRestPort_IsGrpcPlusOne(t *testing.T) {
 	for _, n := range []string{"mind-server", "codefly-agents", "x"} {
 		if CLIRestPort(n) != CLIServerPort(n)+1 {
 			t.Errorf("CLIRestPort(%q) should be CLIServerPort+1", n)
+		}
+	}
+}
+
+func TestCLIServerPort_GrpcAndRestPoolsDisjoint(t *testing.T) {
+	// A gRPC port (even) must never equal any REST port (odd), no matter
+	// the workspace — otherwise a second workspace's gRPC server could
+	// steal another's REST companion port. Even/odd parity guarantees it.
+	grpc := make(map[uint16]bool)
+	rest := make(map[uint16]bool)
+	for i := range 500 {
+		n := fmt.Sprintf("workspace-%d", i)
+		grpc[CLIServerPort(n)] = true
+		rest[CLIRestPort(n)] = true
+	}
+	for p := range grpc {
+		if rest[p] {
+			t.Errorf("gRPC port %d also used as a REST port", p)
 		}
 	}
 }

--- a/network/port.go
+++ b/network/port.go
@@ -68,10 +68,12 @@ func CLIServerPort(workspaceName string) uint16 {
 			return uint16(p)
 		}
 	}
-	// Align to a multiple of 10 so CLIRestPort (= CLIServerPort+1) is
-	// stable and readable.
-	base := HashInt(workspaceName, 20000, 29900)
-	base = base - (base % 10)
+	// Map onto even ports across the whole range. Every gRPC port is even
+	// and its REST companion (= CLIServerPort+1) is odd, so the two pools
+	// can never overlap between workspaces. This uses the full hash width
+	// (4950 buckets) instead of collapsing to multiples of 10 (~990),
+	// which made concurrent workspaces collide well below 100 names.
+	base := HashInt(workspaceName, 10000, 14950) * 2
 	return uint16(base)
 }
 

--- a/network/port.go
+++ b/network/port.go
@@ -70,8 +70,8 @@ func CLIServerPort(workspaceName string) uint16 {
 	}
 	// Map onto even ports across the whole range. Every gRPC port is even
 	// and its REST companion (= CLIServerPort+1) is odd, so the two pools
-	// can never overlap between workspaces. This uses the full hash width
-	// (4950 buckets) instead of collapsing to multiples of 10 (~990),
+	// can never overlap between workspaces. This uses the full even
+	// sub-range (4950 buckets) instead of collapsing to multiples of 10 (~990),
 	// which made concurrent workspaces collide well below 100 names.
 	base := HashInt(workspaceName, 10000, 14950) * 2
 	return uint16(base)


### PR DESCRIPTION
Closes #28.

> Note: issue #28's *title* on GitHub is mislabeled ("SetupWatcher debounce goroutine…"); its *body* describes the `CLIServerPort` port-collision bug, which is what this PR fixes.

## Summary
- `CLIServerPort` hashed into `[20000, 29900)` then rounded to a multiple of 10, collapsing ~9900 values down to ~990 buckets. By the birthday bound ~37 distinct workspace names had a 50% chance of colliding, so a second concurrent CLI gRPC server could fail to bind its supposedly-unique port.
- Now maps onto **even** ports across the full range: gRPC ports are even, their REST companion (`+1`) is odd, so the two pools can never overlap between workspaces — while restoring 4950 buckets of entropy (5x).

## Test plan
- [x] `go test ./network/` passes
- [x] Existing `CLIServerPort`/`CLIRestPort` tests updated (even-parity instead of multiple-of-10)
- [x] New `TestCLIServerPort_GrpcAndRestPoolsDisjoint` asserts gRPC and REST port pools never overlap across 500 workspaces
- [x] `go build ./...` and `go vet ./network/` clean