### PR TITLE
Stop watcher debounce goroutine on context cancel (#27)

### DIFF
--- a/agents/helpers/code/watcher.go
+++ b/agents/helpers/code/watcher.go
@@ -133,6 +133,11 @@ func (watcher *Watcher) Start(ctx context.Context) {
 	w := wool.Get(ctx).In("Watcher.Start")
 	// Start listening for events.
 	defer watcher.watcher.Close()
+	// Start is the sole sender on events (via Handle, only from this loop), so
+	// closing it here is race-free and lets the consumer's range/receive drain
+	// and exit on teardown instead of blocking forever on a channel nobody
+	// closes.
+	defer close(watcher.events)
 	for {
 		select {
 		case <-ctx.Done():

--- a/agents/helpers/code/watcher.go
+++ b/agents/helpers/code/watcher.go
@@ -134,9 +134,8 @@ func (watcher *Watcher) Start(ctx context.Context) {
 	// Start listening for events.
 	defer watcher.watcher.Close()
 	// Start is the sole sender on events (via Handle, only from this loop), so
-	// closing it here is race-free and lets the consumer's range/receive drain
-	// and exit on teardown instead of blocking forever on a channel nobody
-	// closes.
+	// closing it here is race-free and lets the consumer's receive drain and
+	// exit on teardown instead of blocking forever on a channel nobody closes.
 	defer close(watcher.events)
 	for {
 		select {

--- a/agents/services/base.go
+++ b/agents/services/base.go
@@ -236,11 +236,6 @@ func (s *Base) SetupWatcher(ctx context.Context, conf *WatchConfiguration, handl
 		var last code.Change
 		for {
 			select {
-			case <-ctx.Done():
-				if timer != nil {
-					timer.Stop()
-				}
-				return
 			case event, ok := <-s.Events:
 				if !ok {
 					return

--- a/agents/services/base.go
+++ b/agents/services/base.go
@@ -236,6 +236,11 @@ func (s *Base) SetupWatcher(ctx context.Context, conf *WatchConfiguration, handl
 		var last code.Change
 		for {
 			select {
+			case <-ctx.Done():
+				if timer != nil {
+					timer.Stop()
+				}
+				return
 			case event, ok := <-s.Events:
 				if !ok {
 					return

--- a/agents/services/base_test.go
+++ b/agents/services/base_test.go
@@ -22,8 +22,17 @@ import (
 // matches on stack frames rather than a global NumGoroutine baseline so it is
 // immune to unrelated background goroutines (e.g. wool telemetry).
 func countWatcherGoroutines() int {
+	// Grow the buffer until the dump fits: runtime.Stack silently truncates to
+	// the buffer, and a truncated dump could under-count into a false pass.
 	buf := make([]byte, 1<<20)
-	dump := string(buf[:runtime.Stack(buf, true)])
+	for {
+		if n := runtime.Stack(buf, true); n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	dump := string(buf)
 	n := 0
 	for g := range strings.SplitSeq(dump, "\n\n") {
 		if strings.Contains(g, "(*Watcher).Start(") || strings.Contains(g, "SetupWatcher.func") {
@@ -89,6 +98,9 @@ func TestSetupWatcher_DrainsInFlightEventOnCancel(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
+	// Only the first handler call blocks. After the drain, the debounce
+	// goroutine can invoke the handler again; that later call must return
+	// immediately or teardown would deadlock.
 	handler := func(code.Change) error {
 		once.Do(func() {
 			close(entered)

--- a/agents/services/base_test.go
+++ b/agents/services/base_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/codefly-dev/core/agents/helpers/code"
+	"github.com/codefly-dev/core/builders"
+	"github.com/codefly-dev/core/wool"
+)
+
+// TestSetupWatcher_DebounceGoroutineExitsOnCancel is the regression for the
+// debounce goroutine leak: on context cancellation the fsnotify watcher stops,
+// but the debounce goroutine used to block forever reading s.Events (which is
+// never closed). Both goroutines must exit when ctx is cancelled.
+func TestSetupWatcher_DebounceGoroutineExitsOnCancel(t *testing.T) {
+	base := &Base{
+		Wool:     wool.Get(context.Background()),
+		Location: t.TempDir(),
+	}
+
+	before := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conf := NewWatchConfiguration(builders.NewDependencies("test"))
+	if err := base.SetupWatcher(ctx, conf, func(code.Change) error { return nil }); err != nil {
+		t.Fatalf("SetupWatcher: %v", err)
+	}
+
+	cancel()
+
+	// Poll until the two watcher goroutines settle back to baseline. A leaked
+	// debounce goroutine keeps the count above baseline indefinitely.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= before {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("goroutines did not settle after cancel: before=%d after=%d", before, runtime.NumGoroutine())
+}

--- a/agents/services/base_test.go
+++ b/agents/services/base_test.go
@@ -2,43 +2,132 @@ package services
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/codefly-dev/core/agents/helpers/code"
 	"github.com/codefly-dev/core/builders"
+	"github.com/codefly-dev/core/shared"
 	"github.com/codefly-dev/core/wool"
+	"github.com/stretchr/testify/require"
 )
 
-// TestSetupWatcher_DebounceGoroutineExitsOnCancel is the regression for the
-// debounce goroutine leak: on context cancellation the fsnotify watcher stops,
-// but the debounce goroutine used to block forever reading s.Events (which is
-// never closed). Both goroutines must exit when ctx is cancelled.
-func TestSetupWatcher_DebounceGoroutineExitsOnCancel(t *testing.T) {
+// countWatcherGoroutines counts the live goroutines belonging to a watcher:
+// the fsnotify Watcher.Start loop and the SetupWatcher debounce closure. It
+// matches on stack frames rather than a global NumGoroutine baseline so it is
+// immune to unrelated background goroutines (e.g. wool telemetry).
+func countWatcherGoroutines() int {
+	buf := make([]byte, 1<<20)
+	dump := string(buf[:runtime.Stack(buf, true)])
+	n := 0
+	for g := range strings.SplitSeq(dump, "\n\n") {
+		if strings.Contains(g, "(*Watcher).Start(") || strings.Contains(g, "SetupWatcher.func") {
+			n++
+		}
+	}
+	return n
+}
+
+func waitWatcherGoroutines(t *testing.T, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		got := countWatcherGoroutines()
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watcher goroutines = %d, want %d after %s", got, want, timeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestSetupWatcher_GoroutinesExitOnCancel is the regression for the debounce
+// goroutine leak: on cancellation the fsnotify Start loop returns and closes
+// s.Events, and the debounce goroutine must observe that close and exit rather
+// than block forever on a channel nobody closes.
+func TestSetupWatcher_GoroutinesExitOnCancel(t *testing.T) {
 	base := &Base{
 		Wool:     wool.Get(context.Background()),
 		Location: t.TempDir(),
 	}
 
-	before := runtime.NumGoroutine()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	conf := NewWatchConfiguration(builders.NewDependencies("test"))
-	if err := base.SetupWatcher(ctx, conf, func(code.Change) error { return nil }); err != nil {
-		t.Fatalf("SetupWatcher: %v", err)
-	}
+	require.NoError(t, base.SetupWatcher(ctx, conf, func(code.Change) error { return nil }))
+
+	waitWatcherGoroutines(t, 2, time.Second) // Start loop + debounce goroutine
 
 	cancel()
 
-	// Poll until the two watcher goroutines settle back to baseline. A leaked
-	// debounce goroutine keeps the count above baseline indefinitely.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if runtime.NumGoroutine() <= before {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	waitWatcherGoroutines(t, 0, 3*time.Second)
+}
+
+// TestSetupWatcher_DrainsInFlightEventOnCancel exercises teardown while the
+// handler is running and a fresh event is mid-send: Start blocks sending to
+// s.Events because the debounce goroutine is busy in the handler. Cancellation
+// must still unwind cleanly — Start's in-flight send has to be drained (not
+// stranded) so both goroutines exit.
+func TestSetupWatcher_DrainsInFlightEventOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	codeDir := filepath.Join(dir, "code")
+	require.NoError(t, os.MkdirAll(codeDir, 0o755))
+	target := filepath.Join(codeDir, "main.go")
+	require.NoError(t, os.WriteFile(target, []byte("package main\n"), 0o644))
+
+	base := &Base{
+		Wool:     wool.Get(context.Background()),
+		Location: dir,
 	}
-	t.Fatalf("goroutines did not settle after cancel: before=%d after=%d", before, runtime.NumGoroutine())
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	handler := func(code.Change) error {
+		once.Do(func() {
+			close(entered)
+			<-release
+		})
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conf := NewWatchConfiguration(builders.NewDependencies("test",
+		builders.NewDependency("code").WithPathSelect(shared.NewSelect("*.go"))))
+	require.NoError(t, base.SetupWatcher(ctx, conf, handler))
+	time.Sleep(150 * time.Millisecond) // let fsnotify register the dir watches
+
+	// First save → after the debounce window the handler fires and blocks,
+	// leaving the debounce goroutine unable to receive.
+	save(t, target, "package main\n// one\n")
+
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler was never invoked")
+	}
+
+	// Second save while the handler is blocked → Start parks on the send to
+	// s.Events. Then cancel mid-handler and release.
+	save(t, target, "package main\n// two\n")
+	time.Sleep(150 * time.Millisecond) // let the second event reach Start's send
+	cancel()
+	close(release)
+
+	waitWatcherGoroutines(t, 0, 3*time.Second)
+}
+
+// save performs an atomic-rename save (write temp → rename over original),
+// which is how most editors save and what the directory watcher observes.
+func save(t *testing.T, target, content string) {
+	t.Helper()
+	tmp := target + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte(content), 0o644))
+	require.NoError(t, os.Rename(tmp, target))
 }


### PR DESCRIPTION
Closes #27.

## Summary
- `SetupWatcher`'s debounce goroutine only exited when `s.Events` closed, but the channel was never closed. On `ctx.Done()` the fsnotify `Watcher.Start` returns while the debounce goroutine keeps blocking on `<-s.Events` — leaking one goroutine per watcher teardown.
- Fix: `Watcher.Start` (the channel's sole sender, via `Handle`, only from its own loop) closes `events` in a `defer`. This is race-free and also drains any send that's in flight at cancel time, so both the fsnotify loop and the debounce goroutine always exit. A `ctx.Done()` case in the debounce `select` was considered but rejected: it races the in-flight send — if `Start` is blocked on `events <- change` when the debounce goroutine takes the `ctx.Done()` branch, that send is stranded and `Start` leaks instead.

Note: the issue *title* also mentions logger `io.Pipe`/`ForwardLogs`/processors items, but the issue *body* concretely specifies only the `SetupWatcher` leak. This PR fixes exactly what the body describes; the title's other items are out of scope here.

## Test plan
- [x] `TestSetupWatcher_GoroutinesExitOnCancel` — clean teardown; both watcher goroutines exit on cancel.
- [x] `TestSetupWatcher_DrainsInFlightEventOnCancel` — parks `Start` on an in-flight send while the handler is blocked, then cancels; asserts no goroutine is stranded.
- [x] Both tests use per-goroutine stack inspection (immune to unrelated background goroutines) and fail before the fix, pass after.
- [x] `go test -race ./agents/services/ ./agents/helpers/code/`
- [x] `go vet` on affected packages