### PR TITLE
Return real exit error from NixProc.Wait and DockerProc.Wait (#25)

### DIFF
--- a/runners/base/nix_runner.go
+++ b/runners/base/nix_runner.go
@@ -519,26 +519,21 @@ func (proc *NixProc) IsRunning(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-// Wait blocks until the nix process exits or ctx is cancelled.
-// Polls IsRunning at 1s intervals — Nix wraps the binary in `nix develop`,
-// so we don't have direct access to the leaf process's cmd.Wait, and the
-// existing forwarder goroutines already hold the cmd.Wait result.
+// Wait blocks until the nix process exits or ctx is cancelled. Returns the
+// process's exit error (nil on clean exit). Safe to call multiple times: the
+// single cmd.Wait goroutine spawned in start() publishes the result to exitCh,
+// which every caller reads. Polling IsRunning (the previous approach) could
+// only ever surface nil or ctx.Err(), so a supervisor never saw a crash.
 func (proc *NixProc) Wait(ctx context.Context) error {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			running, err := proc.IsRunning(ctx)
-			if err != nil {
-				return err
-			}
-			if !running {
-				return nil
-			}
-		}
+	if proc.exitCh == nil {
+		// Process never started — nothing to wait on.
+		return nil
+	}
+	select {
+	case <-proc.exitCh:
+		return proc.exitErr
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/runners/base/nix_runner_test.go
+++ b/runners/base/nix_runner_test.go
@@ -86,6 +86,29 @@ func TestNixEnvironment_FiniteScript(t *testing.T) {
 	require.Contains(t, d.Snapshot(), "1")
 }
 
+func TestNixEnvironment_WaitReturnsExitError(t *testing.T) {
+	requireNix(t)
+	wool.SetGlobalLogLevel(wool.DEBUG)
+	ctx := context.Background()
+
+	dir := nixTestDir(t)
+	env, err := base.NewNixEnvironment(ctx, dir)
+	require.NoError(t, err, "nix environment not usable")
+	require.NoError(t, env.Init(ctx))
+
+	// Clean exit: Wait returns nil.
+	clean, err := env.NewProcess("sh", "good/finite_counter.sh")
+	require.NoError(t, err)
+	require.NoError(t, clean.Start(ctx))
+	require.NoError(t, clean.Wait(ctx))
+
+	// Non-zero exit: Wait must surface the failure, not report a clean exit.
+	crashing, err := env.NewProcess("sh", "crashing/crash.sh")
+	require.NoError(t, err)
+	require.NoError(t, crashing.Start(ctx))
+	require.Error(t, crashing.Wait(ctx))
+}
+
 func TestNixEnvironment_NoFlake(t *testing.T) {
 	requireNix(t)
 	ctx := context.Background()

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -723,7 +723,6 @@ func (proc *DockerProc) IsRunning(ctx context.Context) (bool, error) {
 // approach) scanned /proc and could only ever return nil or ctx.Err(), so a
 // supervisor never saw a non-zero exit.
 func (proc *DockerProc) Wait(ctx context.Context) error {
-	w := wool.Get(ctx).In("DockerProc.Wait")
 	if proc.ID == "" {
 		// Process never started — nothing to wait on.
 		return nil
@@ -735,19 +734,31 @@ func (proc *DockerProc) Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			inspect, err := proc.env.client.ContainerExecInspect(ctx, proc.ID)
-			if err != nil {
-				return w.Wrapf(err, "cannot inspect process")
+			if done, err := proc.pollExit(ctx); done || err != nil {
+				return err
 			}
-			if inspect.Running {
-				continue
-			}
-			if inspect.ExitCode == 0 {
-				return nil
-			}
-			return fmt.Errorf("process exited with code %d", inspect.ExitCode)
 		}
 	}
+}
+
+// pollExit inspects the exec once via ContainerExecInspect. While the exec is
+// still running it returns done=false, err=nil. Once it has finished, done=true
+// and err carries the exit error: nil for exit code 0, non-nil otherwise. An
+// inspect failure returns done=false with the wrapped error. Shared by Run and
+// Wait so both surface the exit status identically.
+func (proc *DockerProc) pollExit(ctx context.Context) (bool, error) {
+	w := wool.Get(ctx).In("DockerProc.pollExit")
+	inspect, err := proc.env.client.ContainerExecInspect(ctx, proc.ID)
+	if err != nil {
+		return false, w.Wrapf(err, "cannot inspect process")
+	}
+	if inspect.Running {
+		return false, nil
+	}
+	if inspect.ExitCode == 0 {
+		return true, nil
+	}
+	return true, fmt.Errorf("process exited with code %d", inspect.ExitCode)
 }
 
 func (proc *DockerProc) WaitOn(bin string) {
@@ -795,17 +806,9 @@ func (proc *DockerProc) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			inspect, err := proc.env.client.ContainerExecInspect(ctx, proc.ID)
-			if err != nil {
-				return w.Wrapf(err, "cannot inspect process")
+			if done, err := proc.pollExit(ctx); done || err != nil {
+				return err
 			}
-			if inspect.Running {
-				continue
-			}
-			if inspect.ExitCode == 0 {
-				return nil
-			}
-			return fmt.Errorf("process exited with code %d", inspect.ExitCode)
 		}
 	}
 }

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -714,9 +714,20 @@ func (proc *DockerProc) IsRunning(ctx context.Context) (bool, error) {
 	}
 }
 
-// Wait blocks until the container process exits or ctx is cancelled.
-// Polls IsRunning since Docker doesn't expose a clean blocking-wait here.
+// Wait blocks until the container exec exits or ctx is cancelled. Returns the
+// exec's exit error: nil for a clean (exit code 0) exit, non-nil carrying the
+// code otherwise — matching Run and the Proc.Wait contract. The exit status
+// comes from ContainerExecInspect (the authoritative source Run polls too),
+// which stays queryable after the exec finishes, so repeated or late Wait
+// calls all observe the same result. Polling IsRunning (the previous
+// approach) scanned /proc and could only ever return nil or ctx.Err(), so a
+// supervisor never saw a non-zero exit.
 func (proc *DockerProc) Wait(ctx context.Context) error {
+	w := wool.Get(ctx).In("DockerProc.Wait")
+	if proc.ID == "" {
+		// Process never started — nothing to wait on.
+		return nil
+	}
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
@@ -724,13 +735,17 @@ func (proc *DockerProc) Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			running, err := proc.IsRunning(ctx)
+			inspect, err := proc.env.client.ContainerExecInspect(ctx, proc.ID)
 			if err != nil {
-				return err
+				return w.Wrapf(err, "cannot inspect process")
 			}
-			if !running {
+			if inspect.Running {
+				continue
+			}
+			if inspect.ExitCode == 0 {
 				return nil
 			}
+			return fmt.Errorf("process exited with code %d", inspect.ExitCode)
 		}
 	}
 }

--- a/runners/dockerrun/docker_runner_test.go
+++ b/runners/dockerrun/docker_runner_test.go
@@ -316,6 +316,47 @@ func TestDockerProcWithoutPipes(t *testing.T) {
 	require.Contains(t, output.Snapshot(), "hello from docker")
 }
 
+// TestDockerProcWaitReturnsExitError verifies Wait honors the Proc.Wait
+// contract: nil for a clean exit, non-nil for a non-zero exit. The previous
+// implementation polled IsRunning and could only ever return nil, so a
+// supervisor Waiting on a crashed exec saw a clean exit.
+func TestDockerProcWaitReturnsExitError(t *testing.T) {
+	requireDocker(t)
+	wool.SetGlobalLogLevel(wool.DEBUG)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("test-wait-%d", time.Now().UnixMilli())
+	env, err := dockerrun.NewDockerEnvironment(ctx, resources.NewDockerImage("alpine:3.19.1"), shared.Must(shared.SolvePath("testdata")), name)
+	require.NoError(t, err)
+	defer func() {
+		_ = env.Shutdown(ctx)
+	}()
+
+	env.WithPause()
+	require.NoError(t, env.Init(ctx))
+
+	// Clean exit: Wait returns nil.
+	clean, err := env.NewProcess("sh", "-c", "exit 0")
+	require.NoError(t, err)
+	require.NoError(t, clean.Start(ctx))
+	require.NoError(t, clean.Wait(ctx))
+
+	// Non-zero exit: Wait must surface the failure.
+	crashing, err := env.NewProcess("sh", "-c", "exit 3")
+	require.NoError(t, err)
+	require.NoError(t, crashing.Start(ctx))
+	require.Error(t, crashing.Wait(ctx))
+
+	// ctx cancellation short-circuits a still-running exec.
+	longRun, err := env.NewProcess("sh", "-c", "sleep 30")
+	require.NoError(t, err)
+	require.NoError(t, longRun.Start(ctx))
+	cancelCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	require.ErrorIs(t, longRun.Wait(cancelCtx), context.DeadlineExceeded)
+	require.NoError(t, longRun.Stop(ctx))
+}
+
 func TestFindFreePort(t *testing.T) {
 	port, err := base.FindFreePort()
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #25.

## Summary

- `NixProc.Wait` and `DockerProc.Wait` polled `IsRunning` (a liveness probe) instead of reading the captured exit status, so both could only ever return `nil` or `ctx.Err()`. A supervisor that `Start()`s a service then `Wait()`s to propagate failures saw a clean exit even when the process crashed with a non-zero code — violating the `Proc.Wait` contract (`runners/base/runner.go:46-52`), of which `NativeProc.Wait` is the reference.
- `NixProc` already captures the exit result on `exitCh` (published by the single `cmd.Wait` goroutine in `start()`); `Wait` now reads it, mirroring `NativeProc.Wait`.
- `DockerProc` has no `exitCh`, so `Wait` now polls the authoritative `ContainerExecInspect` — the same source `Run` already uses — and returns the exit-code error. `ContainerExecInspect` stays queryable after the exec finishes, so repeated/late `Wait` calls all observe the same result.

## Test plan

- [x] `TestDockerProcWaitReturnsExitError` — clean exit → `nil`, non-zero exit → error, ctx cancellation → `context.DeadlineExceeded` (real Docker).
- [x] `TestNixEnvironment_WaitReturnsExitError` — clean exit → `nil`, non-zero exit → error (real Nix).
- [x] `go test -race ./runners/base/ ./runners/dockerrun/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Waiting for processes now reports the real exit result instead of always treating completion as successful.
  * Clean exits still return success, non-zero exits now surface as errors, and cancelled waits return the context timeout/cancellation.
  * Improved handling for processes that were never started, avoiding misleading wait behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->