### PR TITLE
Close agent log-forwarding pipe on teardown; guard processors (#26)

### DIFF
--- a/agents/logger_server.go
+++ b/agents/logger_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/codefly-dev/core/wool"
 )
@@ -14,12 +15,24 @@ var (
 )
 
 // LogHandler processes structured logs from agent processes.
+//
+// mu guards processors: ForwardLogs goroutines (one per spawned agent)
+// range over the slice via process() while AddProcessor appends to it,
+// so any processor registered after an agent starts streaming is a
+// concurrent read/append without this lock.
 type LogHandler struct {
+	mu         sync.RWMutex
 	processors []wool.LogProcessorWithSource
 }
 
 func AddProcessor(processor wool.LogProcessorWithSource) {
-	handler.processors = append(handler.processors, processor)
+	handler.add(processor)
+}
+
+func (h *LogHandler) add(processor wool.LogProcessorWithSource) {
+	h.mu.Lock()
+	h.processors = append(h.processors, processor)
+	h.mu.Unlock()
 }
 
 func init() {
@@ -61,7 +74,10 @@ func (h *LogHandler) process(identifier *wool.Identifier, log *wool.Log) {
 	if log.Level < wool.GlobalLogLevel() {
 		return
 	}
-	for _, processor := range h.processors {
+	h.mu.RLock()
+	processors := h.processors
+	h.mu.RUnlock()
+	for _, processor := range processors {
 		processor.ProcessWithSource(identifier, log)
 	}
 }

--- a/agents/logger_server_test.go
+++ b/agents/logger_server_test.go
@@ -1,0 +1,99 @@
+package agents
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/codefly-dev/core/wool"
+)
+
+// countingProcessor records how many logs it received.
+type countingProcessor struct {
+	n atomic.Int64
+}
+
+func (p *countingProcessor) Process(*wool.Log)                             { p.n.Add(1) }
+func (p *countingProcessor) ProcessWithSource(*wool.Identifier, *wool.Log) { p.n.Add(1) }
+
+func mustLogLine(t *testing.T) string {
+	t.Helper()
+	data, err := json.Marshal(&LogMessage{
+		Log:    &wool.Log{Level: wool.INFO, Message: "hello"},
+		Source: wool.System(),
+	})
+	if err != nil {
+		t.Fatalf("marshal log line: %v", err)
+	}
+	return string(data) + "\n"
+}
+
+// TestForwardLogs_ConcurrentAddProcessor exercises the data race: a
+// ForwardLogs goroutine ranging over processors while AddProcessor appends.
+// Run under -race, an unguarded slice would trip the detector.
+func TestForwardLogs_ConcurrentAddProcessor(t *testing.T) {
+	h := &LogHandler{}
+
+	pr, pw := io.Pipe()
+	forwarded := make(chan struct{})
+	go func() {
+		defer close(forwarded)
+		h.ForwardLogs(pr)
+	}()
+
+	line := mustLogLine(t)
+
+	// Concurrently register processors while logs stream through.
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			h.add(&countingProcessor{})
+		})
+	}
+	for range 200 {
+		if _, err := io.WriteString(pw, line); err != nil {
+			t.Errorf("write log line: %v", err)
+			break
+		}
+	}
+
+	wg.Wait()
+	// Closing the writer must terminate ForwardLogs.
+	if err := pw.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	<-forwarded
+}
+
+// TestForwardLogs_DispatchesToProcessors verifies logs reach registered
+// processors and that closing the reader ends ForwardLogs.
+func TestForwardLogs_DispatchesToProcessors(t *testing.T) {
+	h := &LogHandler{}
+	proc := &countingProcessor{}
+	h.add(proc)
+
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ForwardLogs(pr)
+	}()
+
+	line := mustLogLine(t)
+	const count = 10
+	for range count {
+		if _, err := io.WriteString(pw, line); err != nil {
+			t.Fatalf("write log line: %v", err)
+		}
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	<-done
+
+	if got := proc.n.Load(); got != count {
+		t.Fatalf("processor received %d logs, want %d", got, count)
+	}
+}

--- a/agents/manager/loader.go
+++ b/agents/manager/loader.go
@@ -71,11 +71,7 @@ type AgentConn struct {
 	done chan struct{}
 
 	// logWriter is the caller-supplied real-time stderr sink (WithLogWriter).
-	// getOrCreateConn passes an *io.PipeWriter whose read end feeds a
-	// ForwardLogs goroutine that "blocks until the reader is closed"; Close
-	// closes it (see closeLogWriter) so that goroutine and its pipe unblock
-	// on EOF instead of leaking for the daemon's lifetime on every agent
-	// spawn/restart.
+	// The reaper and Close close it when it's an io.Closer; see closeLogWriter.
 	logWriter io.Writer
 
 	// permissionsCallback is the host-side server that answers
@@ -331,6 +327,11 @@ func WithDialTimeout(d time.Duration) LoadOption {
 // WithLogWriter tees the agent's stderr to w in real time, in addition
 // to buffering in the ring buffer. Useful for debug mode where the
 // gateway wants to surface agent logs.
+//
+// AgentConn takes ownership of w: it closes w (if it implements io.Closer)
+// when the process exits or the connection is torn down. Pass a writer whose
+// lifetime you're delegating to the connection — e.g. an io.Pipe writer whose
+// read end you're forwarding — not a shared or long-lived sink like os.Stderr.
 func WithLogWriter(w io.Writer) LoadOption {
 	return func(c *loadConfig) { c.logWriter = w }
 }
@@ -948,6 +949,12 @@ func Load(ctx context.Context, p *resources.Agent, opts ...LoadOption) (*AgentCo
 	go func() {
 		defer close(agentConn.done)
 		waitErr := cmd.Wait()
+		// cmd.Wait has returned, so exec's stderr copier is done and no
+		// more writes reach logWriter — safe to close it now. This unblocks
+		// the ForwardLogs goroutine even when the agent crashes and its conn
+		// is abandoned without a Close()/ClearAgents teardown. Idempotent
+		// with Close's own closeLogWriter.
+		agentConn.closeLogWriter()
 		// Agent process is confirmed dead — drop its pgid tracking file.
 		// Only the sweep's orphan check depends on this file; missing it
 		// just means the next sweep treats it as an already-dead group.

--- a/agents/manager/loader.go
+++ b/agents/manager/loader.go
@@ -70,6 +70,14 @@ type AgentConn struct {
 	// done is closed when the process exits (via the reaper goroutine).
 	done chan struct{}
 
+	// logWriter is the caller-supplied real-time stderr sink (WithLogWriter).
+	// getOrCreateConn passes an *io.PipeWriter whose read end feeds a
+	// ForwardLogs goroutine that "blocks until the reader is closed"; Close
+	// closes it (see closeLogWriter) so that goroutine and its pipe unblock
+	// on EOF instead of leaking for the daemon's lifetime on every agent
+	// spawn/restart.
+	logWriter io.Writer
+
 	// permissionsCallback is the host-side server that answers
 	// the plugin's Authorized() calls. Non-nil only when the
 	// caller passed WithPermissionsCallback. Close shuts it down
@@ -105,6 +113,10 @@ const gracefulShutdownTimeout = 30 * time.Second
 // cmd.Wait must only be called once — the reaper owns it. We observe
 // completion via the `done` channel the reaper closes.
 func (c *AgentConn) Close() {
+	// Close the log-forwarding pipe last (after the process has exited and
+	// stopped writing stderr, below) so its ForwardLogs goroutine unblocks
+	// on EOF without racing an in-flight copy.
+	defer c.closeLogWriter()
 	if c.conn != nil {
 		_ = c.conn.Close()
 	}
@@ -153,6 +165,17 @@ func (c *AgentConn) Close() {
 		killAgentGroup(pid)
 		<-c.done
 		w.Info(fmt.Sprintf("agent killed after %s", time.Since(startedAt).Round(time.Millisecond)))
+	}
+}
+
+// closeLogWriter closes the WithLogWriter sink if it is an io.Closer.
+// getOrCreateConn passes an *io.PipeWriter whose read end feeds a
+// ForwardLogs goroutine; closing the write end delivers EOF so that
+// goroutine (and its pipe) don't leak. No-op for writers that aren't
+// closers or when WithLogWriter wasn't used.
+func (c *AgentConn) closeLogWriter() {
+	if closer, ok := c.logWriter.(io.Closer); ok {
+		_ = closer.Close()
 	}
 }
 
@@ -913,6 +936,7 @@ func Load(ctx context.Context, p *resources.Agent, opts ...LoadOption) (*AgentCo
 		stderrBuf:           stderrBuf,
 		done:                make(chan struct{}),
 		permissionsCallback: permsCallback, // nil when WithPermissionsCallback wasn't passed
+		logWriter:           cfg.logWriter, // closed on Close so ForwardLogs unblocks (nil-safe)
 	}
 
 	// Reaper goroutine: waits for the process to exit and logs unexpected

--- a/agents/manager/loader_close_test.go
+++ b/agents/manager/loader_close_test.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// TestAgentConnClose_ClosesLogWriter verifies Close closes the WithLogWriter
+// sink so the ForwardLogs goroutine reading the other end of the pipe
+// unblocks on EOF instead of leaking for the daemon's lifetime.
+func TestAgentConnClose_ClosesLogWriter(t *testing.T) {
+	pr, pw := io.Pipe()
+
+	// Stand in for the ForwardLogs goroutine: it blocks on the reader until
+	// the writer is closed.
+	unblocked := make(chan struct{})
+	go func() {
+		defer close(unblocked)
+		_, _ = io.Copy(io.Discard, pr)
+	}()
+
+	// cmd is nil, so Close takes the no-process path but still runs the
+	// deferred closeLogWriter.
+	c := &AgentConn{logWriter: pw}
+	c.Close()
+
+	select {
+	case <-unblocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("log-forwarding reader did not unblock — Close left the pipe writer open")
+	}
+}
+
+// TestAgentConnClose_NilLogWriter ensures Close is a no-op safe when no
+// WithLogWriter sink was supplied.
+func TestAgentConnClose_NilLogWriter(t *testing.T) {
+	c := &AgentConn{}
+	c.Close() // must not panic
+}


### PR DESCRIPTION
Closes #26.

## Summary
- The agent log-forwarding pipe leaked a goroutine and a pipe on every agent spawn/restart: `getOrCreateConn` handed the agent an `*io.PipeWriter` feeding a `ForwardLogs` goroutine, but the writer was only closed on the Load-error branch — never on the success path, so `ForwardLogs` ("blocks until the reader is closed") blocked forever. `AgentConn` now owns the log writer and closes it on `Close`, which every teardown path (`ClearAgents`, `Cleanup`, `CleanupAll`) already funnels through. It's closed via `defer` so it runs after the process has exited and stopped writing stderr, avoiding a race with an in-flight copy.
- `LogHandler.processors` had a data race: `ForwardLogs` goroutines ranged over the slice while `AddProcessor` appended with no lock. Guarded with a mutex; readers snapshot under `RLock` before ranging.

> Note: the issue title mentions `NixProc.Wait`/`DockerProc.Wait`, but the issue body (the concrete spec, with file references and fix direction) describes these two log-forwarding defects. This PR implements the body. The Wait-related title appears to be a mislabel and is out of scope here.

## Test plan
- [x] `go test -race ./agents/ ./agents/manager/ ./services/` passes
- [x] New `TestForwardLogs_ConcurrentAddProcessor` trips the race detector when the mutex guard is removed, and passes with it (verified by temporarily reverting the lock)
- [x] New `TestAgentConnClose_ClosesLogWriter` confirms a `ForwardLogs`-style reader unblocks after `Close`
- [x] `go build ./...` and `go vet ./agents/... ./services/...` clean