### PR TITLE
dockerrun: kill in-container exec and unblock demux on Run cancellation (#24)

### DIFF
--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -816,12 +816,15 @@ func (proc *DockerProc) Run(ctx context.Context) error {
 	// above blocks Run on the very timeout it should honor. Stop gets a
 	// fresh bounded ctx because the caller's is already dead here.
 	abort := func() {
+		// Close the connection before the (multi-second, best-effort)
+		// Stop so the demux goroutine drains immediately rather than
+		// staying blocked for the duration of the kill.
+		proc.closeExecConn()
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer stopCancel()
 		if stopErr := proc.Stop(stopCtx); stopErr != nil {
 			w.Warn("cannot stop in-container process", wool.ErrField(stopErr))
 		}
-		proc.closeExecConn()
 	}
 
 	for {
@@ -1023,7 +1026,7 @@ func (proc *DockerProc) start(ctx context.Context) error {
 		if _, err := stdcopy.StdCopy(stdoutDest, stderrDest, execResp.Reader); err != nil {
 			// A closed connection is the normal shutdown signal when Run
 			// aborts on cancellation and closes the hijacked conn itself.
-			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+			if !errors.Is(err, net.ErrClosed) {
 				w.Error("cannot copy output", wool.ErrField(err))
 			}
 		}

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"runtime"
 	"strconv"
@@ -673,6 +674,13 @@ type DockerProc struct {
 	// reading proc.output never race against an in-flight
 	// stdcopy.StdCopy. Same race that bit NativeProc; same fix.
 	forwarderWG sync.WaitGroup
+
+	// closeExecConn closes the hijacked exec connection created by
+	// start(). The connection is detached from the request ctx, so when
+	// Run exits while the process may still be running it must close it
+	// explicitly — otherwise the stdcopy goroutine blocks forever and
+	// forwarderWG never drains.
+	closeExecConn func()
 }
 
 func (proc *DockerProc) WithEnvironmentVariablesAppend(ctx context.Context, added *resources.EnvironmentVariable, sep string) {
@@ -801,12 +809,35 @@ func (proc *DockerProc) Run(ctx context.Context) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
+	// abort kills the in-container process and closes the hijacked exec
+	// connection so the stdcopy goroutine unblocks. Docker execs are NOT
+	// tied to the request ctx: without this, cancellation leaks the
+	// process, the goroutine + its FD, and the deferred forwarderWG.Wait
+	// above blocks Run on the very timeout it should honor. Stop gets a
+	// fresh bounded ctx because the caller's is already dead here.
+	abort := func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		if stopErr := proc.Stop(stopCtx); stopErr != nil {
+			w.Warn("cannot stop in-container process", wool.ErrField(stopErr))
+		}
+		proc.closeExecConn()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
+			abort()
 			return ctx.Err()
 		case <-ticker.C:
-			if done, err := proc.pollExit(ctx); done || err != nil {
+			done, err := proc.pollExit(ctx)
+			if done {
+				return err
+			}
+			if err != nil {
+				// Inspect failed with the exec possibly still running —
+				// same leak hazard as cancellation.
+				abort()
 				return err
 			}
 		}
@@ -947,6 +978,7 @@ func (proc *DockerProc) start(ctx context.Context) error {
 		return err
 	}
 	proc.ID = execIDResp.ID
+	proc.closeExecConn = execResp.Close
 
 	// Stdin goroutine: copy from the caller's pipe into the exec connection.
 	if proc.stdinReader != nil {
@@ -989,7 +1021,11 @@ func (proc *DockerProc) start(ctx context.Context) error {
 			stderrDest = io.Discard
 		}
 		if _, err := stdcopy.StdCopy(stdoutDest, stderrDest, execResp.Reader); err != nil {
-			w.Error("cannot copy output", wool.ErrField(err))
+			// A closed connection is the normal shutdown signal when Run
+			// aborts on cancellation and closes the hijacked conn itself.
+			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+				w.Error("cannot copy output", wool.ErrField(err))
+			}
 		}
 	}()
 	return nil

--- a/runners/dockerrun/docker_runner_test.go
+++ b/runners/dockerrun/docker_runner_test.go
@@ -357,6 +357,47 @@ func TestDockerProcWaitReturnsExitError(t *testing.T) {
 	require.NoError(t, longRun.Stop(ctx))
 }
 
+// TestDockerProcRunCancellation runs a never-ending in-container command
+// and cancels the caller's ctx: Run must return promptly (the hijacked
+// exec connection is detached from ctx, so it has to be closed explicitly
+// for the demux goroutine to drain) and the in-container process must be
+// killed rather than leaked.
+func TestDockerProcRunCancellation(t *testing.T) {
+	requireDocker(t)
+	wool.SetGlobalLogLevel(wool.DEBUG)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("test-cancel-%d", time.Now().UnixMilli())
+	env, err := dockerrun.NewDockerEnvironment(ctx, resources.NewDockerImage("alpine:3.19.1"), shared.Must(shared.SolvePath("testdata")), name)
+	require.NoError(t, err)
+	defer func() {
+		_ = env.Shutdown(ctx)
+	}()
+
+	env.WithPause()
+	err = env.Init(ctx)
+	require.NoError(t, err)
+
+	proc, err := env.NewProcess("sh", "good/infinite_counter.sh")
+	require.NoError(t, err)
+	proc.WithOutput(shared.NewSliceWriter())
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = proc.Run(runCtx)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, elapsed, 10*time.Second, "Run must return promptly after the deadline")
+
+	require.Eventually(t, func() bool {
+		running, err := proc.IsRunning(ctx)
+		return err == nil && !running
+	}, 10*time.Second, 500*time.Millisecond, "in-container process must be killed on cancellation")
+}
+
 func TestFindFreePort(t *testing.T) {
 	port, err := base.FindFreePort()
 	require.NoError(t, err)

--- a/runners/dockerrun/docker_runner_test.go
+++ b/runners/dockerrun/docker_runner_test.go
@@ -390,7 +390,9 @@ func TestDockerProcRunCancellation(t *testing.T) {
 	elapsed := time.Since(start)
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Less(t, elapsed, 10*time.Second, "Run must return promptly after the deadline")
+	// Bound must exceed abort's worst case: 2s deadline + 5s FindPid
+	// (stopCtx) + 5s kill exec (its own killCtx) = 12s.
+	require.Less(t, elapsed, 15*time.Second, "Run must return promptly after the deadline")
 
 	require.Eventually(t, func() bool {
 		running, err := proc.IsRunning(ctx)


### PR DESCRIPTION
Closes #24.

## Summary

- `DockerProc.Run` returned `ctx.Err()` on cancellation without killing the in-container exec or touching the hijacked attach connection. Since docker execs are not tied to the request ctx, a hung command leaked the container process, blocked the `stdcopy` demux goroutine (goroutine + FD leak), and could hang `Run` itself on its deferred `forwarderWG.Wait()` — failing to honor the very timeout that fired.
- `Run` now aborts on `ctx.Done()` (and on exec-inspect failure): it closes the hijacked connection first so the demux goroutine drains and `Run` returns promptly, then stops the in-container process via `proc.Stop` under a fresh bounded context. This mirrors `NativeProc.Run`'s stop-on-cancel behavior.
- The demux goroutine no longer logs `net.ErrClosed` from `stdcopy.StdCopy`, since a closed connection is now the normal shutdown signal on the cancellation path.

## Known limitation

The kill is best-effort: `proc.Stop` locates the process by scanning `/proc` and name-matching, so if the docker daemon is too slow to answer within the 5s bound (or the argv doesn't match), the in-container process can still survive — with a warning logged. The connection close and prompt return of `Run` hold regardless. Docker exposes no exec-scoped kill API, so a guaranteed kill would need a deeper redesign of `Stop`.

## Test plan

- [x] New `TestDockerProcRunCancellation` runs a never-ending script in a real alpine container, cancels after 2s, and asserts `Run` returns `context.DeadlineExceeded` promptly and the in-container process is gone. Verified it hangs until the test-binary timeout against the unfixed code.
- [x] `go test ./runners/dockerrun/ -race` passes.
- [x] `go test ./runners/... -race` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cancellation handling so running jobs stop more reliably and return promptly when interrupted.
  * Reduced the chance of hanging or leaking resources during command shutdown.
  * Suppressed expected connection-closed errors during shutdown for cleaner behavior.
* **Tests**
  * Added coverage for cancellation to verify interrupted runs exit quickly and the in-container process stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->