### PR TITLE
deps: follow gortk module rename to codefly-dev (v0.2.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/cheggaaa/pb/v3 v3.1.7
+	github.com/codefly-dev/gortk v0.2.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
 	github.com/fatih/color v1.19.0
@@ -27,7 +28,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/mind-build/gortk v0.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
+github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -222,8 +224,6 @@ github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3Ry
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
-github.com/mind-build/gortk v0.1.0 h1:sftmLKIqKRUhNTsv23XcT3KJ5KR+Qi111Kf8ELjFhCc=
-github.com/mind-build/gortk v0.1.0/go.mod h1:CkoBGIrP2L/0o/LDFqms5gxfDIXdjnloB0xvcQ+6flc=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/llmout/llmout.go
+++ b/llmout/llmout.go
@@ -1,5 +1,5 @@
 // Package llmout compresses raw command output before it is returned to the
-// model, using the gortk filter catalog (https://github.com/mind-build/gortk).
+// model, using the gortk filter catalog (https://github.com/codefly-dev/gortk).
 //
 // It is the integration seam for codefly's language agents: a Build/Test/Lint
 // implementation that has captured a command's combined output passes it
@@ -9,7 +9,7 @@
 // unchanged (only size-bounded), so this is always safe to apply.
 package llmout
 
-import "github.com/mind-build/gortk"
+import "github.com/codefly-dev/gortk"
 
 // registry is built once and shared; it is read-only after construction and
 // safe for concurrent use.

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -21,7 +21,7 @@ import (
 	"github.com/codefly-dev/core/resources"
 	"github.com/codefly-dev/core/runners/base"
 	"github.com/codefly-dev/core/shared"
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"

--- a/toolbox/github/server.go
+++ b/toolbox/github/server.go
@@ -27,7 +27,7 @@ import (
 	"github.com/codefly-dev/core/llmout"
 	"github.com/codefly-dev/core/toolbox/registry"
 	"github.com/codefly-dev/core/toolbox/respond"
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 )
 
 // Precompiled gortk filters that flatten a normalized JSON array (one object per

--- a/toolbox/github/server_test.go
+++ b/toolbox/github/server_test.go
@@ -19,7 +19,7 @@ func TestIdentity(t *testing.T) {
 
 func TestParseGitHubRemote(t *testing.T) {
 	cases := map[string][2]string{
-		"git@github.com:mind-build/gortk.git":     {"mind-build", "gortk"},
+		"git@github.com:codefly-dev/gortk.git":     {"codefly-dev", "gortk"},
 		"https://github.com/codefly-dev/core.git": {"codefly-dev", "core"},
 		"https://github.com/owner/repo":           {"owner", "repo"},
 	}

--- a/toolbox/linear/server.go
+++ b/toolbox/linear/server.go
@@ -22,7 +22,7 @@ import (
 	toolboxv0 "github.com/codefly-dev/core/generated/go/codefly/services/toolbox/v0"
 	"github.com/codefly-dev/core/toolbox/registry"
 	"github.com/codefly-dev/core/toolbox/respond"
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 )
 
 const endpoint = "https://api.linear.app/graphql"

--- a/toolbox/linear/server_test.go
+++ b/toolbox/linear/server_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 )
 
 // TestIssuesCompaction is the core proof that gortk compacts Linear's verbose

--- a/woollog/woollog.go
+++ b/woollog/woollog.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/codefly-dev/core/wool"
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 )
 
 // Writer parses a log stream and routes each line to a wool logger at its

--- a/woollog/woollog_test.go
+++ b/woollog/woollog_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/codefly-dev/core/wool"
-	"github.com/mind-build/gortk"
+	"github.com/codefly-dev/gortk"
 )
 
 // capProc captures emitted log entries for assertions.


### PR DESCRIPTION
gortk moved to the codefly-dev org and renamed its module path in v0.2.0. Updates the require + all imports. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)