### PR TITLE
Add 1Password-backed secret references (#45)

### DIFF
--- a/configurations/doc.go
+++ b/configurations/doc.go
@@ -26,26 +26,23 @@
 // literal plaintext or a reference the environment's secret backend
 // resolves at Load() time:
 //
-//	client_secret: op://dev-vault/auth0/client_secret       # 1Password
-//	client_secret: aws-sm://codefly/dev/auth0#client_secret # AWS Secrets Manager
-//	client_secret: doppler://AUTH0_CLIENT_SECRET            # Doppler
+//	client_secret: op://dev-vault/auth0/client_secret # 1Password
 //
-// Backends are selected per environment via workspace.codefly.yaml. More
-// than one can be listed so op:// and aws-sm:// references coexist:
+// Backends are selected per environment via workspace.codefly.yaml. It is a
+// list so more backends can be added later:
 //
 //	environments:
 //	  - name: local
 //	    secrets:
 //	      - kind: 1password
 //	        account: my-team
-//	  - name: production
-//	    secrets:
-//	      - kind: aws-secrets-manager
-//	        region: us-east-1
 //
 // References are safe to commit and resolved in memory — the plaintext
 // value never touches disk. A reference whose backend is not configured
 // for the environment fails the load rather than leaking the raw URI.
+//
+// 1Password is the only backend today; SecretResolver is the seam for
+// adding AWS Secrets Manager, Doppler, Vault, etc.
 //
 // Plaintext secret values still work (the CONNECTION=postgres://… escape
 // hatch), but they sit unencrypted on disk and are local/dev-only; a

--- a/configurations/doc.go
+++ b/configurations/doc.go
@@ -19,4 +19,31 @@
 // Loader is the abstract interface a service must implement to plug
 // into the manager (Identity, Load, Configurations, DNS). Concrete
 // loaders live in core/cli and similar consumer packages.
+//
+// # Secrets
+//
+// Secret values (from *.secret.env / *.secret.yaml files) may be either
+// literal plaintext or a reference the environment's secret backend
+// resolves at Load() time:
+//
+//	client_secret: op://dev-vault/auth0/client_secret       # 1Password
+//	client_secret: aws-sm://codefly/dev/auth0#client_secret # AWS Secrets Manager
+//
+// The backend is selected per environment via workspace.codefly.yaml:
+//
+//	environments:
+//	  - name: local
+//	    secrets: { provider: 1password, account: my-team }
+//	  - name: production
+//	    secrets: { provider: aws-secrets-manager, region: us-east-1 }
+//
+// References are safe to commit and resolved in memory — the plaintext
+// value never touches disk. A reference whose backend is not configured
+// for the environment fails the load rather than leaking the raw URI.
+//
+// Plaintext secret values still work (the CONNECTION=postgres://… escape
+// hatch), but they sit unencrypted on disk and are local/dev-only; a
+// plaintext secret used against a configured backend in a non-local
+// environment is logged as a warning. See secrets.go (SecretResolver,
+// ParseSecretReference, ResolversFromEnvironment).
 package configurations

--- a/configurations/doc.go
+++ b/configurations/doc.go
@@ -28,6 +28,7 @@
 //
 //	client_secret: op://dev-vault/auth0/client_secret       # 1Password
 //	client_secret: aws-sm://codefly/dev/auth0#client_secret # AWS Secrets Manager
+//	client_secret: doppler://AUTH0_CLIENT_SECRET            # Doppler
 //
 // Backends are selected per environment via workspace.codefly.yaml. More
 // than one can be listed so op:// and aws-sm:// references coexist:

--- a/configurations/doc.go
+++ b/configurations/doc.go
@@ -29,13 +29,18 @@
 //	client_secret: op://dev-vault/auth0/client_secret       # 1Password
 //	client_secret: aws-sm://codefly/dev/auth0#client_secret # AWS Secrets Manager
 //
-// The backend is selected per environment via workspace.codefly.yaml:
+// Backends are selected per environment via workspace.codefly.yaml. More
+// than one can be listed so op:// and aws-sm:// references coexist:
 //
 //	environments:
 //	  - name: local
-//	    secrets: { provider: 1password, account: my-team }
+//	    secrets:
+//	      - kind: 1password
+//	        account: my-team
 //	  - name: production
-//	    secrets: { provider: aws-secrets-manager, region: us-east-1 }
+//	    secrets:
+//	      - kind: aws-secrets-manager
+//	        region: us-east-1
 //
 // References are safe to commit and resolved in memory — the plaintext
 // value never touches disk. A reference whose backend is not configured

--- a/configurations/manager.go
+++ b/configurations/manager.go
@@ -14,6 +14,10 @@ import (
 type Loader interface {
 	Identity() string
 	Load(ctx context.Context, env *resources.Environment) error
+	// Configurations returns the configurations produced by Load. It must
+	// return the same instances on every call (not fresh copies): after Load,
+	// the Manager resolves secret references in these objects in place, and
+	// LoadConfigurations reads them back expecting the resolved values.
 	Configurations() []*basev0.Configuration
 	DNS() []*basev0.DNS
 }

--- a/configurations/manager.go
+++ b/configurations/manager.go
@@ -24,6 +24,10 @@ type Manager struct {
 
 	loaders []Loader
 
+	// Secret resolvers registered explicitly (tests, custom backends). The
+	// environment's own `secrets.provider` adds to these at Load() time.
+	secretResolvers []SecretResolver
+
 	// Per Name in
 	worspaceConfigurations map[string]*basev0.Configuration
 
@@ -53,6 +57,14 @@ func (manager *Manager) WithLoader(loader Loader) *Manager {
 	return manager
 }
 
+// WithSecretResolver registers a secret resolver. Resolvers selected by the
+// environment's `secrets` block are added automatically at Load() time; this
+// is for tests and custom backends.
+func (manager *Manager) WithSecretResolver(resolvers ...SecretResolver) *Manager {
+	manager.secretResolvers = append(manager.secretResolvers, resolvers...)
+	return manager
+}
+
 func (manager *Manager) Load(ctx context.Context, env *resources.Environment) error {
 	if manager == nil {
 		return nil
@@ -65,6 +77,9 @@ func (manager *Manager) Load(ctx context.Context, env *resources.Environment) er
 			return w.Wrapf(err, "cannot load loader %s", loader.Identity())
 		}
 	}
+	if err := manager.resolveSecrets(ctx, env); err != nil {
+		return w.Wrapf(err, "cannot resolve secrets")
+	}
 	err := manager.LoadConfigurations(ctx)
 	if err != nil {
 		return w.Wrapf(err, "cannot load configurations")
@@ -76,6 +91,27 @@ func (manager *Manager) Load(ctx context.Context, env *resources.Environment) er
 	}
 
 	w.Debug("loaded", wool.Field("dns", resources.MakeManyDNSSummary(manager.dns)))
+	return nil
+}
+
+// resolveSecrets resolves reference-valued secrets (op://…, aws-sm://…)
+// produced by the loaders, in place, before they are consolidated. Plaintext
+// secret values pass through untouched.
+func (manager *Manager) resolveSecrets(ctx context.Context, env *resources.Environment) error {
+	w := wool.Get(ctx).In("configurations.Manager.resolveSecrets")
+	fromEnv, err := ResolversFromEnvironment(env)
+	if err != nil {
+		return w.Wrapf(err, "cannot build secret resolvers for environment %s", env.Name)
+	}
+	resolvers := append(append([]SecretResolver{}, manager.secretResolvers...), fromEnv...)
+	resolution := newSecretResolution(resolvers)
+	for _, loader := range manager.loaders {
+		for _, conf := range loader.Configurations() {
+			if err := resolution.resolveConfiguration(ctx, conf, env); err != nil {
+				return w.Wrapf(err, "cannot resolve secrets from loader %s", loader.Identity())
+			}
+		}
+	}
 	return nil
 }
 

--- a/configurations/manager.go
+++ b/configurations/manager.go
@@ -98,9 +98,9 @@ func (manager *Manager) Load(ctx context.Context, env *resources.Environment) er
 	return nil
 }
 
-// resolveSecrets resolves reference-valued secrets (op://…, aws-sm://…)
-// produced by the loaders, in place, before they are consolidated. Plaintext
-// secret values pass through untouched.
+// resolveSecrets resolves reference-valued secrets (op://…) produced by the
+// loaders, in place, before they are consolidated. Plaintext secret values
+// pass through untouched.
 func (manager *Manager) resolveSecrets(ctx context.Context, env *resources.Environment) error {
 	w := wool.Get(ctx).In("configurations.Manager.resolveSecrets")
 	fromEnv, err := ResolversFromEnvironment(env)

--- a/configurations/secrets.go
+++ b/configurations/secrets.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -23,33 +22,21 @@ import (
 // scheme names a secret provider:
 //
 //	client_secret: op://dev-vault/auth0/client_secret
-//	client_secret: aws-sm://codefly/dev/auth0#client_secret
 //
 // References are safe to commit; the resolved value never touches disk. Only
-// these known schemes are treated as references — a plaintext value that
-// happens to contain "://" (a postgres:// URL, say) is passed through
-// untouched.
-const (
-	OnePasswordScheme       = "op"
-	AWSSecretsManagerScheme = "aws-sm"
-	DopplerScheme           = "doppler"
-)
+// known schemes are treated as references — a plaintext value that happens to
+// contain "://" (a postgres:// URL, say) is passed through untouched. The
+// resolver seam (SecretResolver) is designed so more backends can be added.
+const OnePasswordScheme = "op"
 
-// Provider names selected via an environment's `secrets` block.
-const (
-	ProviderOnePassword       = "1password"
-	ProviderAWSSecretsManager = "aws-secrets-manager"
-	ProviderDoppler           = "doppler"
-)
+// ProviderOnePassword is the `secrets.kind` that selects the 1Password backend.
+const ProviderOnePassword = "1password"
 
 var secretReferenceSchemes = map[string]bool{
-	OnePasswordScheme:       true,
-	AWSSecretsManagerScheme: true,
-	DopplerScheme:           true,
+	OnePasswordScheme: true,
 }
 
-// SecretReference is a parsed secret URI: op://vault/item/field or
-// aws-sm://secret-id#json-key.
+// SecretReference is a parsed secret URI, e.g. op://vault/item/field.
 type SecretReference struct {
 	Scheme string
 	Path   string
@@ -85,13 +72,9 @@ func ResolversFromEnvironment(env *resources.Environment) ([]SecretResolver, err
 		switch provider.Kind {
 		case ProviderOnePassword:
 			resolvers = append(resolvers, NewOnePasswordResolver(provider.Account))
-		case ProviderAWSSecretsManager:
-			resolvers = append(resolvers, NewAWSSecretsManagerResolver(provider.Region))
-		case ProviderDoppler:
-			resolvers = append(resolvers, NewDopplerResolver(provider.Project, provider.Config))
 		default:
-			return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s, %s)",
-				provider.Kind, ProviderOnePassword, ProviderAWSSecretsManager, ProviderDoppler)
+			return nil, fmt.Errorf("unknown secret provider %q (supported: %s)",
+				provider.Kind, ProviderOnePassword)
 		}
 	}
 	return resolvers, nil
@@ -117,98 +100,6 @@ func (r *OnePasswordResolver) Resolve(ctx context.Context, ref *SecretReference)
 		args = append(args, "--account", r.account)
 	}
 	args = append(args, ref.Raw)
-	return runCommand(ctx, r.bin, args...)
-}
-
-// AWSSecretsManagerResolver resolves aws-sm://secret-id[#json-key] references
-// through the `aws` CLI, which authenticates via the ambient IAM credentials.
-// Without a #json-key the whole SecretString is returned; with one the
-// SecretString is parsed as JSON and the named key extracted.
-type AWSSecretsManagerResolver struct {
-	region string
-	bin    string
-}
-
-func NewAWSSecretsManagerResolver(region string) *AWSSecretsManagerResolver {
-	return &AWSSecretsManagerResolver{region: region, bin: "aws"}
-}
-
-func (r *AWSSecretsManagerResolver) Scheme() string { return AWSSecretsManagerScheme }
-
-func (r *AWSSecretsManagerResolver) Resolve(ctx context.Context, ref *SecretReference) (string, error) {
-	id, key, hasKey := strings.Cut(ref.Path, "#")
-	args := []string{"secretsmanager", "get-secret-value", "--secret-id", id, "--query", "SecretString", "--output", "text"}
-	if r.region != "" {
-		args = append(args, "--region", r.region)
-	}
-	out, err := runCommand(ctx, r.bin, args...)
-	if err != nil {
-		return "", err
-	}
-	if !hasKey {
-		return out, nil
-	}
-	// UseNumber keeps numeric fields exact — a large integer secret must not be
-	// mangled by a float64 round-trip.
-	dec := json.NewDecoder(strings.NewReader(out))
-	dec.UseNumber()
-	var fields map[string]any
-	if err := dec.Decode(&fields); err != nil {
-		return "", fmt.Errorf("cannot parse secret %q as JSON to extract key %q: %w", id, key, err)
-	}
-	val, ok := fields[key]
-	if !ok {
-		return "", fmt.Errorf("key %q not found in secret %q", key, id)
-	}
-	return jsonFieldToString(val)
-}
-
-// jsonFieldToString renders a value extracted from a JSON secret. Scalars
-// become their literal string (numbers kept exact via json.Number); a nested
-// object or array is re-encoded as JSON rather than Go's %v map syntax.
-func jsonFieldToString(val any) (string, error) {
-	switch v := val.(type) {
-	case string:
-		return v, nil
-	case json.Number:
-		return v.String(), nil
-	case bool:
-		return strconv.FormatBool(v), nil
-	case nil:
-		return "", nil
-	default:
-		b, err := json.Marshal(v)
-		if err != nil {
-			return "", err
-		}
-		return string(b), nil
-	}
-}
-
-// DopplerResolver resolves doppler://SECRET_NAME references through the
-// `doppler` CLI. The project and config (Doppler's per-environment scope)
-// come from the provider settings; when empty the CLI falls back to its
-// ambient context (doppler.yaml / DOPPLER_* env / a service token).
-type DopplerResolver struct {
-	project string
-	config  string
-	bin     string
-}
-
-func NewDopplerResolver(project, config string) *DopplerResolver {
-	return &DopplerResolver{project: project, config: config, bin: "doppler"}
-}
-
-func (r *DopplerResolver) Scheme() string { return DopplerScheme }
-
-func (r *DopplerResolver) Resolve(ctx context.Context, ref *SecretReference) (string, error) {
-	args := []string{"secrets", "get", ref.Path, "--plain"}
-	if r.project != "" {
-		args = append(args, "--project", r.project)
-	}
-	if r.config != "" {
-		args = append(args, "--config", r.config)
-	}
 	return runCommand(ctx, r.bin, args...)
 }
 
@@ -403,6 +294,6 @@ func (e *secretResolution) warnPlaintext(ctx context.Context, env *resources.Env
 	}
 	e.warned[origin] = true
 	w := wool.Get(ctx).In("configurations.secrets")
-	w.Warn("plaintext secret used with a configured secret backend — dev-only, prefer a op://… or aws-sm://… reference",
+	w.Warn("plaintext secret used with a configured secret backend — dev-only, prefer an op://… reference",
 		wool.Field("origin", origin), wool.Field("environment", env.Name))
 }

--- a/configurations/secrets.go
+++ b/configurations/secrets.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -154,7 +155,29 @@ func (r *AWSSecretsManagerResolver) Resolve(ctx context.Context, ref *SecretRefe
 	if !ok {
 		return "", fmt.Errorf("key %q not found in secret %q", key, id)
 	}
-	return fmt.Sprintf("%v", val), nil
+	return jsonFieldToString(val)
+}
+
+// jsonFieldToString renders a value extracted from a JSON secret. Scalars
+// become their literal string (numbers kept exact via json.Number); a nested
+// object or array is re-encoded as JSON rather than Go's %v map syntax.
+func jsonFieldToString(val any) (string, error) {
+	switch v := val.(type) {
+	case string:
+		return v, nil
+	case json.Number:
+		return v.String(), nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case nil:
+		return "", nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
 }
 
 // runCommand runs a resolver's CLI and returns its stdout with a single

--- a/configurations/secrets.go
+++ b/configurations/secrets.go
@@ -70,21 +70,25 @@ type SecretResolver interface {
 }
 
 // ResolversFromEnvironment builds the secret resolvers an environment selects
-// via its `secrets` block. An empty provider means plaintext-only (no
-// resolvers): secret values are used verbatim from the files.
+// via its `secrets` block. No providers means plaintext-only (no resolvers):
+// secret values are used verbatim from the files.
 func ResolversFromEnvironment(env *resources.Environment) ([]SecretResolver, error) {
-	if env == nil || env.Secrets == nil || env.Secrets.Provider == "" {
+	if env == nil {
 		return nil, nil
 	}
-	switch env.Secrets.Provider {
-	case ProviderOnePassword:
-		return []SecretResolver{NewOnePasswordResolver(env.Secrets.Account)}, nil
-	case ProviderAWSSecretsManager:
-		return []SecretResolver{NewAWSSecretsManagerResolver(env.Secrets.Region)}, nil
-	default:
-		return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s)",
-			env.Secrets.Provider, ProviderOnePassword, ProviderAWSSecretsManager)
+	var resolvers []SecretResolver
+	for _, provider := range env.Secrets {
+		switch provider.Kind {
+		case ProviderOnePassword:
+			resolvers = append(resolvers, NewOnePasswordResolver(provider.Account))
+		case ProviderAWSSecretsManager:
+			resolvers = append(resolvers, NewAWSSecretsManagerResolver(provider.Region))
+		default:
+			return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s)",
+				provider.Kind, ProviderOnePassword, ProviderAWSSecretsManager)
+		}
 	}
+	return resolvers, nil
 }
 
 // OnePasswordResolver resolves op://vault/item/field references through the
@@ -138,8 +142,12 @@ func (r *AWSSecretsManagerResolver) Resolve(ctx context.Context, ref *SecretRefe
 	if !hasKey {
 		return out, nil
 	}
+	// UseNumber keeps numeric fields exact — a large integer secret must not be
+	// mangled by a float64 round-trip.
+	dec := json.NewDecoder(strings.NewReader(out))
+	dec.UseNumber()
 	var fields map[string]any
-	if err := json.Unmarshal([]byte(out), &fields); err != nil {
+	if err := dec.Decode(&fields); err != nil {
 		return "", fmt.Errorf("cannot parse secret %q as JSON to extract key %q: %w", id, key, err)
 	}
 	val, ok := fields[key]
@@ -149,8 +157,11 @@ func (r *AWSSecretsManagerResolver) Resolve(ctx context.Context, ref *SecretRefe
 	return fmt.Sprintf("%v", val), nil
 }
 
-// runCommand runs a resolver's CLI and returns its trimmed stdout. Only stderr
-// is surfaced on failure so a resolved secret value never reaches an error or a log.
+// runCommand runs a resolver's CLI and returns its stdout with a single
+// trailing newline stripped — the one the CLI appends. Leading and internal
+// whitespace is preserved so a multi-line secret (a PEM key, say) survives
+// intact. Only stderr is surfaced on failure so a resolved secret value never
+// reaches an error or a log.
 func runCommand(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	var stdout, stderr bytes.Buffer
@@ -162,7 +173,9 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 		}
 		return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	out := strings.TrimSuffix(stdout.String(), "\n")
+	out = strings.TrimSuffix(out, "\r")
+	return out, nil
 }
 
 // secretResolution resolves references across a single Load pass, caching by
@@ -170,6 +183,7 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 type secretResolution struct {
 	resolvers map[string]SecretResolver
 	cache     map[string]string
+	warned    map[string]bool
 }
 
 func newSecretResolution(resolvers []SecretResolver) *secretResolution {
@@ -179,7 +193,7 @@ func newSecretResolution(resolvers []SecretResolver) *secretResolution {
 			m[r.Scheme()] = r
 		}
 	}
-	return &secretResolution{resolvers: m, cache: make(map[string]string)}
+	return &secretResolution{resolvers: m, cache: make(map[string]string), warned: make(map[string]bool)}
 }
 
 func (e *secretResolution) resolve(ctx context.Context, ref *SecretReference) (string, error) {
@@ -248,7 +262,9 @@ func (e *secretResolution) resolveData(ctx context.Context, data *basev0.Configu
 			return err
 		}
 	case "json":
-		if err := json.Unmarshal(data.Content, &node); err != nil {
+		dec := json.NewDecoder(bytes.NewReader(data.Content))
+		dec.UseNumber()
+		if err := dec.Decode(&node); err != nil {
 			return err
 		}
 	default:
@@ -293,6 +309,19 @@ func (e *secretResolution) resolveNode(ctx context.Context, node any) (any, bool
 			}
 		}
 		return v, changed, nil
+	case map[any]any:
+		changed := false
+		for key, val := range v {
+			nv, c, err := e.resolveNode(ctx, val)
+			if err != nil {
+				return nil, false, err
+			}
+			if c {
+				v[key] = nv
+				changed = true
+			}
+		}
+		return v, changed, nil
 	case []any:
 		changed := false
 		for i, val := range v {
@@ -314,9 +343,10 @@ func (e *secretResolution) resolveNode(ctx context.Context, node any) (any, bool
 // warnPlaintext flags a plaintext secret used where a backend is configured.
 // Local envs stay silent — plaintext is the sanctioned local escape hatch.
 func (e *secretResolution) warnPlaintext(ctx context.Context, env *resources.Environment, origin string) {
-	if len(e.resolvers) == 0 || env == nil || env.Local() {
+	if len(e.resolvers) == 0 || env == nil || env.Local() || e.warned[origin] {
 		return
 	}
+	e.warned[origin] = true
 	w := wool.Get(ctx).In("configurations.secrets")
 	w.Warn("plaintext secret used with a configured secret backend — dev-only, prefer a op://… or aws-sm://… reference",
 		wool.Field("origin", origin), wool.Field("environment", env.Name))

--- a/configurations/secrets.go
+++ b/configurations/secrets.go
@@ -1,0 +1,323 @@
+package configurations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/wool"
+
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+)
+
+// Secret values live in *.secret.* files as either a literal plaintext value
+// (the local/dev-only escape hatch — unencrypted on disk) or a reference the
+// configured backend resolves at Load() time. A reference is a URI whose
+// scheme names a secret provider:
+//
+//	client_secret: op://dev-vault/auth0/client_secret
+//	client_secret: aws-sm://codefly/dev/auth0#client_secret
+//
+// References are safe to commit; the resolved value never touches disk. Only
+// these known schemes are treated as references — a plaintext value that
+// happens to contain "://" (a postgres:// URL, say) is passed through
+// untouched.
+const (
+	OnePasswordScheme       = "op"
+	AWSSecretsManagerScheme = "aws-sm"
+)
+
+// Provider names selected via an environment's `secrets.provider`.
+const (
+	ProviderOnePassword       = "1password"
+	ProviderAWSSecretsManager = "aws-secrets-manager"
+)
+
+var secretReferenceSchemes = map[string]bool{
+	OnePasswordScheme:       true,
+	AWSSecretsManagerScheme: true,
+}
+
+// SecretReference is a parsed secret URI: op://vault/item/field or
+// aws-sm://secret-id#json-key.
+type SecretReference struct {
+	Scheme string
+	Path   string
+	Raw    string
+}
+
+// ParseSecretReference reports whether value is a known secret reference and,
+// if so, splits it into scheme and path. Unknown schemes return false so the
+// value is treated as plaintext.
+func ParseSecretReference(value string) (*SecretReference, bool) {
+	scheme, path, found := strings.Cut(value, "://")
+	if !found || !secretReferenceSchemes[scheme] {
+		return nil, false
+	}
+	return &SecretReference{Scheme: scheme, Path: path, Raw: value}, true
+}
+
+// SecretResolver resolves references for a single backend.
+type SecretResolver interface {
+	Scheme() string
+	Resolve(ctx context.Context, ref *SecretReference) (string, error)
+}
+
+// ResolversFromEnvironment builds the secret resolvers an environment selects
+// via its `secrets` block. An empty provider means plaintext-only (no
+// resolvers): secret values are used verbatim from the files.
+func ResolversFromEnvironment(env *resources.Environment) ([]SecretResolver, error) {
+	if env == nil || env.Secrets == nil || env.Secrets.Provider == "" {
+		return nil, nil
+	}
+	switch env.Secrets.Provider {
+	case ProviderOnePassword:
+		return []SecretResolver{NewOnePasswordResolver(env.Secrets.Account)}, nil
+	case ProviderAWSSecretsManager:
+		return []SecretResolver{NewAWSSecretsManagerResolver(env.Secrets.Region)}, nil
+	default:
+		return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s)",
+			env.Secrets.Provider, ProviderOnePassword, ProviderAWSSecretsManager)
+	}
+}
+
+// OnePasswordResolver resolves op://vault/item/field references through the
+// 1Password `op` CLI. `op read` accepts the full URI and prints the field
+// value to stdout — biometric/session unlock is handled by the CLI itself.
+type OnePasswordResolver struct {
+	account string
+	bin     string
+}
+
+func NewOnePasswordResolver(account string) *OnePasswordResolver {
+	return &OnePasswordResolver{account: account, bin: "op"}
+}
+
+func (r *OnePasswordResolver) Scheme() string { return OnePasswordScheme }
+
+func (r *OnePasswordResolver) Resolve(ctx context.Context, ref *SecretReference) (string, error) {
+	args := []string{"read", "--no-newline"}
+	if r.account != "" {
+		args = append(args, "--account", r.account)
+	}
+	args = append(args, ref.Raw)
+	return runCommand(ctx, r.bin, args...)
+}
+
+// AWSSecretsManagerResolver resolves aws-sm://secret-id[#json-key] references
+// through the `aws` CLI, which authenticates via the ambient IAM credentials.
+// Without a #json-key the whole SecretString is returned; with one the
+// SecretString is parsed as JSON and the named key extracted.
+type AWSSecretsManagerResolver struct {
+	region string
+	bin    string
+}
+
+func NewAWSSecretsManagerResolver(region string) *AWSSecretsManagerResolver {
+	return &AWSSecretsManagerResolver{region: region, bin: "aws"}
+}
+
+func (r *AWSSecretsManagerResolver) Scheme() string { return AWSSecretsManagerScheme }
+
+func (r *AWSSecretsManagerResolver) Resolve(ctx context.Context, ref *SecretReference) (string, error) {
+	id, key, hasKey := strings.Cut(ref.Path, "#")
+	args := []string{"secretsmanager", "get-secret-value", "--secret-id", id, "--query", "SecretString", "--output", "text"}
+	if r.region != "" {
+		args = append(args, "--region", r.region)
+	}
+	out, err := runCommand(ctx, r.bin, args...)
+	if err != nil {
+		return "", err
+	}
+	if !hasKey {
+		return out, nil
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(out), &fields); err != nil {
+		return "", fmt.Errorf("cannot parse secret %q as JSON to extract key %q: %w", id, key, err)
+	}
+	val, ok := fields[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret %q", key, id)
+	}
+	return fmt.Sprintf("%v", val), nil
+}
+
+// runCommand runs a resolver's CLI and returns its trimmed stdout. Only stderr
+// is surfaced on failure so a resolved secret value never reaches an error or a log.
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, msg)
+		}
+		return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// secretResolution resolves references across a single Load pass, caching by
+// URI so an item referenced twice is fetched once.
+type secretResolution struct {
+	resolvers map[string]SecretResolver
+	cache     map[string]string
+}
+
+func newSecretResolution(resolvers []SecretResolver) *secretResolution {
+	m := make(map[string]SecretResolver)
+	for _, r := range resolvers {
+		if _, ok := m[r.Scheme()]; !ok {
+			m[r.Scheme()] = r
+		}
+	}
+	return &secretResolution{resolvers: m, cache: make(map[string]string)}
+}
+
+func (e *secretResolution) resolve(ctx context.Context, ref *SecretReference) (string, error) {
+	if v, ok := e.cache[ref.Raw]; ok {
+		return v, nil
+	}
+	resolver, ok := e.resolvers[ref.Scheme]
+	if !ok {
+		return "", fmt.Errorf("secret reference %q requires the %q backend, which is not configured for this environment", ref.Raw, ref.Scheme)
+	}
+	v, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+	e.cache[ref.Raw] = v
+	return v, nil
+}
+
+// resolveString resolves value if it is a reference, otherwise returns it
+// unchanged. changed reports whether a resolution happened.
+func (e *secretResolution) resolveString(ctx context.Context, value string) (resolved string, changed bool, err error) {
+	ref, ok := ParseSecretReference(value)
+	if !ok {
+		return value, false, nil
+	}
+	v, err := e.resolve(ctx, ref)
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+func (e *secretResolution) resolveConfiguration(ctx context.Context, conf *basev0.Configuration, env *resources.Environment) error {
+	for _, info := range conf.Infos {
+		for _, value := range info.ConfigurationValues {
+			if !value.Secret {
+				continue
+			}
+			resolved, changed, err := e.resolveString(ctx, value.Value)
+			if err != nil {
+				return err
+			}
+			if changed {
+				value.Value = resolved
+			} else {
+				e.warnPlaintext(ctx, env, conf.Origin)
+			}
+		}
+		if info.Data != nil && info.Data.Secret {
+			if err := e.resolveData(ctx, info.Data, env, conf.Origin); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolveData resolves references embedded in a structured secret blob
+// (.secret.yaml / .secret.json). It parses the content, resolves any string
+// references in place, and re-marshals only if something changed.
+func (e *secretResolution) resolveData(ctx context.Context, data *basev0.ConfigurationData, env *resources.Environment, origin string) error {
+	var node any
+	switch data.Kind {
+	case "yaml", "yml":
+		if err := yaml.Unmarshal(data.Content, &node); err != nil {
+			return err
+		}
+	case "json":
+		if err := json.Unmarshal(data.Content, &node); err != nil {
+			return err
+		}
+	default:
+		return nil
+	}
+	resolved, changed, err := e.resolveNode(ctx, node)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		e.warnPlaintext(ctx, env, origin)
+		return nil
+	}
+	var out []byte
+	switch data.Kind {
+	case "yaml", "yml":
+		out, err = yaml.Marshal(resolved)
+	case "json":
+		out, err = json.Marshal(resolved)
+	}
+	if err != nil {
+		return err
+	}
+	data.Content = out
+	return nil
+}
+
+func (e *secretResolution) resolveNode(ctx context.Context, node any) (any, bool, error) {
+	switch v := node.(type) {
+	case string:
+		return e.resolveString(ctx, v)
+	case map[string]any:
+		changed := false
+		for key, val := range v {
+			nv, c, err := e.resolveNode(ctx, val)
+			if err != nil {
+				return nil, false, err
+			}
+			if c {
+				v[key] = nv
+				changed = true
+			}
+		}
+		return v, changed, nil
+	case []any:
+		changed := false
+		for i, val := range v {
+			nv, c, err := e.resolveNode(ctx, val)
+			if err != nil {
+				return nil, false, err
+			}
+			if c {
+				v[i] = nv
+				changed = true
+			}
+		}
+		return v, changed, nil
+	default:
+		return node, false, nil
+	}
+}
+
+// warnPlaintext flags a plaintext secret used where a backend is configured.
+// Local envs stay silent — plaintext is the sanctioned local escape hatch.
+func (e *secretResolution) warnPlaintext(ctx context.Context, env *resources.Environment, origin string) {
+	if len(e.resolvers) == 0 || env == nil || env.Local() {
+		return
+	}
+	w := wool.Get(ctx).In("configurations.secrets")
+	w.Warn("plaintext secret used with a configured secret backend — dev-only, prefer a op://… or aws-sm://… reference",
+		wool.Field("origin", origin), wool.Field("environment", env.Name))
+}

--- a/configurations/secrets.go
+++ b/configurations/secrets.go
@@ -32,17 +32,20 @@ import (
 const (
 	OnePasswordScheme       = "op"
 	AWSSecretsManagerScheme = "aws-sm"
+	DopplerScheme           = "doppler"
 )
 
-// Provider names selected via an environment's `secrets.provider`.
+// Provider names selected via an environment's `secrets` block.
 const (
 	ProviderOnePassword       = "1password"
 	ProviderAWSSecretsManager = "aws-secrets-manager"
+	ProviderDoppler           = "doppler"
 )
 
 var secretReferenceSchemes = map[string]bool{
 	OnePasswordScheme:       true,
 	AWSSecretsManagerScheme: true,
+	DopplerScheme:           true,
 }
 
 // SecretReference is a parsed secret URI: op://vault/item/field or
@@ -84,9 +87,11 @@ func ResolversFromEnvironment(env *resources.Environment) ([]SecretResolver, err
 			resolvers = append(resolvers, NewOnePasswordResolver(provider.Account))
 		case ProviderAWSSecretsManager:
 			resolvers = append(resolvers, NewAWSSecretsManagerResolver(provider.Region))
+		case ProviderDoppler:
+			resolvers = append(resolvers, NewDopplerResolver(provider.Project, provider.Config))
 		default:
-			return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s)",
-				provider.Kind, ProviderOnePassword, ProviderAWSSecretsManager)
+			return nil, fmt.Errorf("unknown secret provider %q (supported: %s, %s, %s)",
+				provider.Kind, ProviderOnePassword, ProviderAWSSecretsManager, ProviderDoppler)
 		}
 	}
 	return resolvers, nil
@@ -178,6 +183,33 @@ func jsonFieldToString(val any) (string, error) {
 		}
 		return string(b), nil
 	}
+}
+
+// DopplerResolver resolves doppler://SECRET_NAME references through the
+// `doppler` CLI. The project and config (Doppler's per-environment scope)
+// come from the provider settings; when empty the CLI falls back to its
+// ambient context (doppler.yaml / DOPPLER_* env / a service token).
+type DopplerResolver struct {
+	project string
+	config  string
+	bin     string
+}
+
+func NewDopplerResolver(project, config string) *DopplerResolver {
+	return &DopplerResolver{project: project, config: config, bin: "doppler"}
+}
+
+func (r *DopplerResolver) Scheme() string { return DopplerScheme }
+
+func (r *DopplerResolver) Resolve(ctx context.Context, ref *SecretReference) (string, error) {
+	args := []string{"secrets", "get", ref.Path, "--plain"}
+	if r.project != "" {
+		args = append(args, "--project", r.project)
+	}
+	if r.config != "" {
+		args = append(args, "--config", r.config)
+	}
+	return runCommand(ctx, r.bin, args...)
 }
 
 // runCommand runs a resolver's CLI and returns its stdout with a single

--- a/configurations/secrets_test.go
+++ b/configurations/secrets_test.go
@@ -30,39 +30,6 @@ case "$uri" in
 esac
 `
 
-// awsStub stands in for the `aws` CLI: it prints the SecretString for known
-// --secret-id values.
-const awsStub = `#!/bin/sh
-id=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --secret-id) id="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-case "$id" in
-  codefly/dev/token) printf 'aws-token-value' ;;
-  codefly/dev/auth0) printf '{"client_secret":"aws-client-secret","client_id":"abc"}' ;;
-  codefly/dev/nested) printf '{"obj":{"a":1},"count":42,"account":123456789012345678}' ;;
-  *) echo "aws: secret not found: $id" 1>&2; exit 1 ;;
-esac
-`
-
-// dopplerStub stands in for the `doppler` CLI: `doppler secrets get NAME
-// --plain [...]` prints the value for known secret names.
-const dopplerStub = `#!/bin/sh
-name=""
-capture=0
-for a in "$@"; do
-  if [ "$capture" = "1" ]; then name="$a"; capture=0; continue; fi
-  if [ "$a" = "get" ]; then capture=1; fi
-done
-case "$name" in
-  STRIPE_KEY) printf 'sk_test_123\n' ;;
-  *) echo "doppler: secret not found: $name" 1>&2; exit 1 ;;
-esac
-`
-
 func writeStub(t *testing.T, name, body string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), name)
@@ -78,7 +45,8 @@ func TestParseSecretReference(t *testing.T) {
 		path   string
 	}{
 		{"op://dev-vault/auth0/client_secret", true, "op", "dev-vault/auth0/client_secret"},
-		{"aws-sm://codefly/dev/auth0#client_secret", true, "aws-sm", "codefly/dev/auth0#client_secret"},
+		// A scheme with no registered backend is not a reference — passthrough.
+		{"aws-sm://codefly/dev/auth0#client_secret", false, "", ""},
 		{"postgres://user:pass@host/db", false, "", ""},
 		{"literal-plaintext", false, "", ""},
 		{"", false, "", ""},
@@ -123,60 +91,6 @@ func TestResolverPreservesMultilineSecret(t *testing.T) {
 	require.Equal(t, "-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----", v)
 }
 
-func TestAWSSecretsManagerResolver(t *testing.T) {
-	ctx := context.Background()
-	r := NewAWSSecretsManagerResolver("us-east-1")
-	r.bin = writeStub(t, "aws", awsStub)
-
-	ref, _ := ParseSecretReference("aws-sm://codefly/dev/token")
-	v, err := r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.Equal(t, "aws-token-value", v)
-
-	ref, _ = ParseSecretReference("aws-sm://codefly/dev/auth0#client_secret")
-	v, err = r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.Equal(t, "aws-client-secret", v)
-
-	ref, _ = ParseSecretReference("aws-sm://codefly/dev/auth0#missing")
-	_, err = r.Resolve(ctx, ref)
-	require.Error(t, err)
-
-	// A nested object key is re-encoded as JSON, not Go's map syntax.
-	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#obj")
-	v, err = r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.JSONEq(t, `{"a":1}`, v)
-
-	// Numeric keys stay exact — no float64 round-trip.
-	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#count")
-	v, err = r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.Equal(t, "42", v)
-
-	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#account")
-	v, err = r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.Equal(t, "123456789012345678", v)
-}
-
-func TestDopplerResolver(t *testing.T) {
-	ctx := context.Background()
-	r := NewDopplerResolver("codefly", "dev")
-	r.bin = writeStub(t, "doppler", dopplerStub)
-
-	ref, ok := ParseSecretReference("doppler://STRIPE_KEY")
-	require.True(t, ok)
-	require.Equal(t, DopplerScheme, r.Scheme())
-	v, err := r.Resolve(ctx, ref)
-	require.NoError(t, err)
-	require.Equal(t, "sk_test_123", v)
-
-	ref, _ = ParseSecretReference("doppler://MISSING")
-	_, err = r.Resolve(ctx, ref)
-	require.Error(t, err)
-}
-
 func TestResolversFromEnvironment(t *testing.T) {
 	rs, err := ResolversFromEnvironment(&resources.Environment{Name: "local"})
 	require.NoError(t, err)
@@ -189,21 +103,6 @@ func TestResolversFromEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rs, 1)
 	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
-
-	// Multiple backends coexist in one environment.
-	rs, err = ResolversFromEnvironment(&resources.Environment{
-		Name: "prod",
-		Secrets: []*resources.EnvironmentSecretProvider{
-			{Kind: ProviderOnePassword},
-			{Kind: ProviderAWSSecretsManager, Region: "us-east-1"},
-			{Kind: ProviderDoppler, Project: "codefly", Config: "prd"},
-		},
-	})
-	require.NoError(t, err)
-	require.Len(t, rs, 3)
-	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
-	require.Equal(t, AWSSecretsManagerScheme, rs[1].Scheme())
-	require.Equal(t, DopplerScheme, rs[2].Scheme())
 
 	_, err = ResolversFromEnvironment(&resources.Environment{
 		Name:    "prod",
@@ -225,12 +124,10 @@ func TestManagerResolvesSecretReferences(t *testing.T) {
 
 	op := NewOnePasswordResolver("")
 	op.bin = writeStub(t, "op", opStub)
-	aws := NewAWSSecretsManagerResolver("")
-	aws.bin = writeStub(t, "aws", awsStub)
 
 	manager, err := NewManager(ctx, ws)
 	require.NoError(t, err)
-	manager.WithLoader(loader).WithSecretResolver(op, aws)
+	manager.WithLoader(loader).WithSecretResolver(op)
 
 	require.NoError(t, manager.Load(ctx, resources.LocalEnvironment()))
 
@@ -243,16 +140,6 @@ func TestManagerResolvesSecretReferences(t *testing.T) {
 	v, err := resources.GetConfigurationValue(ctx, frontend, "auth0/frontend", "client_secret")
 	require.NoError(t, err)
 	require.Equal(t, "op-client-secret", v)
-
-	// aws references resolved (whole SecretString + json-key extraction)
-	awsConf, err := resources.FindWorkspaceConfiguration(ctx, confs, "aws")
-	require.NoError(t, err)
-	tok, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "token")
-	require.NoError(t, err)
-	require.Equal(t, "aws-token-value", tok)
-	dbp, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "db_password")
-	require.NoError(t, err)
-	require.Equal(t, "aws-client-secret", dbp)
 
 	// plaintext and unknown-scheme values pass through untouched
 	plain, err := resources.FindWorkspaceConfiguration(ctx, confs, "plain")
@@ -275,14 +162,14 @@ func TestManagerResolvesSecretReferences(t *testing.T) {
 	require.Equal(t, "op-client-secret", parsed["client_secret"])
 	nested, ok := parsed["nested"].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "aws-token-value", nested["api_token"])
+	require.Equal(t, "op-db-password", nested["api_token"])
 	require.Equal(t, "keep-me", nested["plain"])
 }
 
 // End-to-end through the real selection path: the environment declared in
-// workspace.codefly.yaml (`secrets:`) drives resolver construction, and those
-// resolvers use the default `op`/`aws` binaries — here shadowed by stubs on
-// PATH. No resolvers are injected.
+// workspace.codefly.yaml (`secrets:`) drives resolver construction, and that
+// resolver uses the default `op` binary — here shadowed by a stub on PATH.
+// No resolvers are injected.
 func TestManagerResolvesViaEnvironmentProvider(t *testing.T) {
 	ctx := context.Background()
 	dir, err := shared.SolvePath("testdata/secrets")
@@ -290,15 +177,13 @@ func TestManagerResolvesViaEnvironmentProvider(t *testing.T) {
 	ws, err := resources.LoadWorkspaceFromDir(ctx, dir)
 	require.NoError(t, err)
 
-	// The workspace's "local" environment declares both backends.
 	env := ws.FindEnvironment("local")
 	require.NotNil(t, env)
-	require.Len(t, env.Secrets, 2)
+	require.Len(t, env.Secrets, 1)
 	require.Equal(t, ProviderOnePassword, env.Secrets[0].Kind)
 
 	stubDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(stubDir, "op"), []byte(opStub), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(stubDir, "aws"), []byte(awsStub), 0o755))
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	loader, err := NewConfigurationLocalReader(ctx, ws)
@@ -317,12 +202,6 @@ func TestManagerResolvesViaEnvironmentProvider(t *testing.T) {
 	v, err := resources.GetConfigurationValue(ctx, frontend, "auth0/frontend", "client_secret")
 	require.NoError(t, err)
 	require.Equal(t, "op-client-secret", v)
-
-	awsConf, err := resources.FindWorkspaceConfiguration(ctx, confs, "aws")
-	require.NoError(t, err)
-	tok, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "token")
-	require.NoError(t, err)
-	require.Equal(t, "aws-token-value", tok)
 
 	// Service-level reference resolved through the same environment backend.
 	sconfs, err := manager.GetServiceConfigurations(ctx)

--- a/configurations/secrets_test.go
+++ b/configurations/secrets_test.go
@@ -48,6 +48,21 @@ case "$id" in
 esac
 `
 
+// dopplerStub stands in for the `doppler` CLI: `doppler secrets get NAME
+// --plain [...]` prints the value for known secret names.
+const dopplerStub = `#!/bin/sh
+name=""
+capture=0
+for a in "$@"; do
+  if [ "$capture" = "1" ]; then name="$a"; capture=0; continue; fi
+  if [ "$a" = "get" ]; then capture=1; fi
+done
+case "$name" in
+  STRIPE_KEY) printf 'sk_test_123\n' ;;
+  *) echo "doppler: secret not found: $name" 1>&2; exit 1 ;;
+esac
+`
+
 func writeStub(t *testing.T, name, body string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), name)
@@ -145,6 +160,23 @@ func TestAWSSecretsManagerResolver(t *testing.T) {
 	require.Equal(t, "123456789012345678", v)
 }
 
+func TestDopplerResolver(t *testing.T) {
+	ctx := context.Background()
+	r := NewDopplerResolver("codefly", "dev")
+	r.bin = writeStub(t, "doppler", dopplerStub)
+
+	ref, ok := ParseSecretReference("doppler://STRIPE_KEY")
+	require.True(t, ok)
+	require.Equal(t, DopplerScheme, r.Scheme())
+	v, err := r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_123", v)
+
+	ref, _ = ParseSecretReference("doppler://MISSING")
+	_, err = r.Resolve(ctx, ref)
+	require.Error(t, err)
+}
+
 func TestResolversFromEnvironment(t *testing.T) {
 	rs, err := ResolversFromEnvironment(&resources.Environment{Name: "local"})
 	require.NoError(t, err)
@@ -164,12 +196,14 @@ func TestResolversFromEnvironment(t *testing.T) {
 		Secrets: []*resources.EnvironmentSecretProvider{
 			{Kind: ProviderOnePassword},
 			{Kind: ProviderAWSSecretsManager, Region: "us-east-1"},
+			{Kind: ProviderDoppler, Project: "codefly", Config: "prd"},
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, rs, 2)
+	require.Len(t, rs, 3)
 	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
 	require.Equal(t, AWSSecretsManagerScheme, rs[1].Scheme())
+	require.Equal(t, DopplerScheme, rs[2].Scheme())
 
 	_, err = ResolversFromEnvironment(&resources.Environment{
 		Name:    "prod",

--- a/configurations/secrets_test.go
+++ b/configurations/secrets_test.go
@@ -1,0 +1,230 @@
+package configurations
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/shared"
+	"github.com/codefly-dev/core/wool"
+
+	"github.com/stretchr/testify/require"
+)
+
+// opStub stands in for the `op` CLI: it prints the field value for known
+// op:// references and fails (to stderr) for anything else.
+const opStub = `#!/bin/sh
+uri=""
+for a in "$@"; do
+  case "$a" in
+    op://*) uri="$a" ;;
+  esac
+done
+case "$uri" in
+  op://dev-vault/auth0/client_secret) printf 'op-client-secret' ;;
+  op://dev-vault/db/password) printf 'op-db-password' ;;
+  *) echo "op: item not found: $uri" 1>&2; exit 1 ;;
+esac
+`
+
+// awsStub stands in for the `aws` CLI: it prints the SecretString for known
+// --secret-id values.
+const awsStub = `#!/bin/sh
+id=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --secret-id) id="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$id" in
+  codefly/dev/token) printf 'aws-token-value' ;;
+  codefly/dev/auth0) printf '{"client_secret":"aws-client-secret","client_id":"abc"}' ;;
+  *) echo "aws: secret not found: $id" 1>&2; exit 1 ;;
+esac
+`
+
+func writeStub(t *testing.T, name, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o755))
+	return p
+}
+
+func TestParseSecretReference(t *testing.T) {
+	tcs := []struct {
+		in     string
+		ok     bool
+		scheme string
+		path   string
+	}{
+		{"op://dev-vault/auth0/client_secret", true, "op", "dev-vault/auth0/client_secret"},
+		{"aws-sm://codefly/dev/auth0#client_secret", true, "aws-sm", "codefly/dev/auth0#client_secret"},
+		{"postgres://user:pass@host/db", false, "", ""},
+		{"literal-plaintext", false, "", ""},
+		{"", false, "", ""},
+	}
+	for _, tc := range tcs {
+		ref, ok := ParseSecretReference(tc.in)
+		require.Equal(t, tc.ok, ok, tc.in)
+		if tc.ok {
+			require.Equal(t, tc.scheme, ref.Scheme)
+			require.Equal(t, tc.path, ref.Path)
+			require.Equal(t, tc.in, ref.Raw)
+		}
+	}
+}
+
+func TestOnePasswordResolver(t *testing.T) {
+	ctx := context.Background()
+	r := NewOnePasswordResolver("")
+	r.bin = writeStub(t, "op", opStub)
+
+	ref, ok := ParseSecretReference("op://dev-vault/auth0/client_secret")
+	require.True(t, ok)
+	v, err := r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "op-client-secret", v)
+
+	ref, _ = ParseSecretReference("op://dev-vault/missing/x")
+	_, err = r.Resolve(ctx, ref)
+	require.Error(t, err)
+}
+
+func TestAWSSecretsManagerResolver(t *testing.T) {
+	ctx := context.Background()
+	r := NewAWSSecretsManagerResolver("us-east-1")
+	r.bin = writeStub(t, "aws", awsStub)
+
+	ref, _ := ParseSecretReference("aws-sm://codefly/dev/token")
+	v, err := r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "aws-token-value", v)
+
+	ref, _ = ParseSecretReference("aws-sm://codefly/dev/auth0#client_secret")
+	v, err = r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "aws-client-secret", v)
+
+	ref, _ = ParseSecretReference("aws-sm://codefly/dev/auth0#missing")
+	_, err = r.Resolve(ctx, ref)
+	require.Error(t, err)
+}
+
+func TestResolversFromEnvironment(t *testing.T) {
+	rs, err := ResolversFromEnvironment(&resources.Environment{Name: "local"})
+	require.NoError(t, err)
+	require.Empty(t, rs)
+
+	rs, err = ResolversFromEnvironment(&resources.Environment{
+		Name:    "local",
+		Secrets: &resources.EnvironmentSecrets{Provider: ProviderOnePassword},
+	})
+	require.NoError(t, err)
+	require.Len(t, rs, 1)
+	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
+
+	rs, err = ResolversFromEnvironment(&resources.Environment{
+		Name:    "prod",
+		Secrets: &resources.EnvironmentSecrets{Provider: ProviderAWSSecretsManager},
+	})
+	require.NoError(t, err)
+	require.Len(t, rs, 1)
+	require.Equal(t, AWSSecretsManagerScheme, rs[0].Scheme())
+
+	_, err = ResolversFromEnvironment(&resources.Environment{
+		Name:    "prod",
+		Secrets: &resources.EnvironmentSecrets{Provider: "vault"},
+	})
+	require.Error(t, err)
+}
+
+func TestManagerResolvesSecretReferences(t *testing.T) {
+	wool.SetGlobalLogLevel(wool.DEBUG)
+	ctx := context.Background()
+	dir, err := shared.SolvePath("testdata/secrets")
+	require.NoError(t, err)
+	ws, err := resources.LoadWorkspaceFromDir(ctx, dir)
+	require.NoError(t, err)
+
+	loader, err := NewConfigurationLocalReader(ctx, ws)
+	require.NoError(t, err)
+
+	op := NewOnePasswordResolver("")
+	op.bin = writeStub(t, "op", opStub)
+	aws := NewAWSSecretsManagerResolver("")
+	aws.bin = writeStub(t, "aws", awsStub)
+
+	manager, err := NewManager(ctx, ws)
+	require.NoError(t, err)
+	manager.WithLoader(loader).WithSecretResolver(op, aws)
+
+	require.NoError(t, manager.Load(ctx, resources.LocalEnvironment()))
+
+	confs, err := manager.GetWorkspaceConfigurations(ctx)
+	require.NoError(t, err)
+
+	// op reference resolved
+	frontend, err := resources.FindWorkspaceConfiguration(ctx, confs, "auth0/frontend")
+	require.NoError(t, err)
+	v, err := resources.GetConfigurationValue(ctx, frontend, "auth0/frontend", "client_secret")
+	require.NoError(t, err)
+	require.Equal(t, "op-client-secret", v)
+
+	// aws references resolved (whole SecretString + json-key extraction)
+	awsConf, err := resources.FindWorkspaceConfiguration(ctx, confs, "aws")
+	require.NoError(t, err)
+	tok, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "token")
+	require.NoError(t, err)
+	require.Equal(t, "aws-token-value", tok)
+	dbp, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "db_password")
+	require.NoError(t, err)
+	require.Equal(t, "aws-client-secret", dbp)
+
+	// plaintext and unknown-scheme values pass through untouched
+	plain, err := resources.FindWorkspaceConfiguration(ctx, confs, "plain")
+	require.NoError(t, err)
+	api, err := resources.GetConfigurationValue(ctx, plain, "plain", "api_key")
+	require.NoError(t, err)
+	require.Equal(t, "literal-plaintext-value", api)
+	conn, err := resources.GetConfigurationValue(ctx, plain, "plain", "connection")
+	require.NoError(t, err)
+	require.Equal(t, "postgres://user:pass@localhost:5432/db", conn)
+
+	// references embedded in a secret yaml blob are resolved in memory
+	backend, err := resources.FindWorkspaceConfiguration(ctx, confs, "auth0/backend")
+	require.NoError(t, err)
+	info, err := resources.GetConfigurationInformation(ctx, backend, "auth0/backend")
+	require.NoError(t, err)
+	require.NotNil(t, info.Data)
+	var parsed map[string]any
+	require.NoError(t, InformationUnmarshal(info, &parsed))
+	require.Equal(t, "op-client-secret", parsed["client_secret"])
+	nested, ok := parsed["nested"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "aws-token-value", nested["api_token"])
+	require.Equal(t, "keep-me", nested["plain"])
+}
+
+// A reference whose backend is not configured for the environment must fail
+// loudly rather than inject the raw op://… string as a value.
+func TestManagerUnconfiguredBackendErrors(t *testing.T) {
+	ctx := context.Background()
+	dir, err := shared.SolvePath("testdata/secrets")
+	require.NoError(t, err)
+	ws, err := resources.LoadWorkspaceFromDir(ctx, dir)
+	require.NoError(t, err)
+
+	loader, err := NewConfigurationLocalReader(ctx, ws)
+	require.NoError(t, err)
+
+	manager, err := NewManager(ctx, ws)
+	require.NoError(t, err)
+	manager.WithLoader(loader)
+
+	err = manager.Load(ctx, resources.LocalEnvironment())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not configured")
+}

--- a/configurations/secrets_test.go
+++ b/configurations/secrets_test.go
@@ -43,6 +43,7 @@ done
 case "$id" in
   codefly/dev/token) printf 'aws-token-value' ;;
   codefly/dev/auth0) printf '{"client_secret":"aws-client-secret","client_id":"abc"}' ;;
+  codefly/dev/nested) printf '{"obj":{"a":1},"count":42,"account":123456789012345678}' ;;
   *) echo "aws: secret not found: $id" 1>&2; exit 1 ;;
 esac
 `
@@ -125,6 +126,23 @@ func TestAWSSecretsManagerResolver(t *testing.T) {
 	ref, _ = ParseSecretReference("aws-sm://codefly/dev/auth0#missing")
 	_, err = r.Resolve(ctx, ref)
 	require.Error(t, err)
+
+	// A nested object key is re-encoded as JSON, not Go's map syntax.
+	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#obj")
+	v, err = r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"a":1}`, v)
+
+	// Numeric keys stay exact — no float64 round-trip.
+	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#count")
+	v, err = r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "42", v)
+
+	ref, _ = ParseSecretReference("aws-sm://codefly/dev/nested#account")
+	v, err = r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "123456789012345678", v)
 }
 
 func TestResolversFromEnvironment(t *testing.T) {

--- a/configurations/secrets_test.go
+++ b/configurations/secrets_test.go
@@ -25,6 +25,7 @@ done
 case "$uri" in
   op://dev-vault/auth0/client_secret) printf 'op-client-secret' ;;
   op://dev-vault/db/password) printf 'op-db-password' ;;
+  op://dev-vault/tls/key) printf '%s\n' '-----BEGIN KEY-----' 'line1' 'line2' '-----END KEY-----' ;;
   *) echo "op: item not found: $uri" 1>&2; exit 1 ;;
 esac
 `
@@ -93,6 +94,19 @@ func TestOnePasswordResolver(t *testing.T) {
 	require.Error(t, err)
 }
 
+// Only the single trailing newline the CLI appends is stripped; the secret's
+// own internal newlines (a PEM key, say) survive intact.
+func TestResolverPreservesMultilineSecret(t *testing.T) {
+	ctx := context.Background()
+	r := NewOnePasswordResolver("")
+	r.bin = writeStub(t, "op", opStub)
+
+	ref, _ := ParseSecretReference("op://dev-vault/tls/key")
+	v, err := r.Resolve(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----", v)
+}
+
 func TestAWSSecretsManagerResolver(t *testing.T) {
 	ctx := context.Background()
 	r := NewAWSSecretsManagerResolver("us-east-1")
@@ -120,23 +134,28 @@ func TestResolversFromEnvironment(t *testing.T) {
 
 	rs, err = ResolversFromEnvironment(&resources.Environment{
 		Name:    "local",
-		Secrets: &resources.EnvironmentSecrets{Provider: ProviderOnePassword},
+		Secrets: []*resources.EnvironmentSecretProvider{{Kind: ProviderOnePassword}},
 	})
 	require.NoError(t, err)
 	require.Len(t, rs, 1)
 	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
 
+	// Multiple backends coexist in one environment.
 	rs, err = ResolversFromEnvironment(&resources.Environment{
-		Name:    "prod",
-		Secrets: &resources.EnvironmentSecrets{Provider: ProviderAWSSecretsManager},
+		Name: "prod",
+		Secrets: []*resources.EnvironmentSecretProvider{
+			{Kind: ProviderOnePassword},
+			{Kind: ProviderAWSSecretsManager, Region: "us-east-1"},
+		},
 	})
 	require.NoError(t, err)
-	require.Len(t, rs, 1)
-	require.Equal(t, AWSSecretsManagerScheme, rs[0].Scheme())
+	require.Len(t, rs, 2)
+	require.Equal(t, OnePasswordScheme, rs[0].Scheme())
+	require.Equal(t, AWSSecretsManagerScheme, rs[1].Scheme())
 
 	_, err = ResolversFromEnvironment(&resources.Environment{
 		Name:    "prod",
-		Secrets: &resources.EnvironmentSecrets{Provider: "vault"},
+		Secrets: []*resources.EnvironmentSecretProvider{{Kind: "vault"}},
 	})
 	require.Error(t, err)
 }
@@ -206,6 +225,60 @@ func TestManagerResolvesSecretReferences(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "aws-token-value", nested["api_token"])
 	require.Equal(t, "keep-me", nested["plain"])
+}
+
+// End-to-end through the real selection path: the environment declared in
+// workspace.codefly.yaml (`secrets:`) drives resolver construction, and those
+// resolvers use the default `op`/`aws` binaries — here shadowed by stubs on
+// PATH. No resolvers are injected.
+func TestManagerResolvesViaEnvironmentProvider(t *testing.T) {
+	ctx := context.Background()
+	dir, err := shared.SolvePath("testdata/secrets")
+	require.NoError(t, err)
+	ws, err := resources.LoadWorkspaceFromDir(ctx, dir)
+	require.NoError(t, err)
+
+	// The workspace's "local" environment declares both backends.
+	env := ws.FindEnvironment("local")
+	require.NotNil(t, env)
+	require.Len(t, env.Secrets, 2)
+	require.Equal(t, ProviderOnePassword, env.Secrets[0].Kind)
+
+	stubDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stubDir, "op"), []byte(opStub), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stubDir, "aws"), []byte(awsStub), 0o755))
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	loader, err := NewConfigurationLocalReader(ctx, ws)
+	require.NoError(t, err)
+	manager, err := NewManager(ctx, ws)
+	require.NoError(t, err)
+	manager.WithLoader(loader) // no injected resolvers — backend comes from the environment
+
+	require.NoError(t, manager.Load(ctx, env))
+
+	confs, err := manager.GetWorkspaceConfigurations(ctx)
+	require.NoError(t, err)
+
+	frontend, err := resources.FindWorkspaceConfiguration(ctx, confs, "auth0/frontend")
+	require.NoError(t, err)
+	v, err := resources.GetConfigurationValue(ctx, frontend, "auth0/frontend", "client_secret")
+	require.NoError(t, err)
+	require.Equal(t, "op-client-secret", v)
+
+	awsConf, err := resources.FindWorkspaceConfiguration(ctx, confs, "aws")
+	require.NoError(t, err)
+	tok, err := resources.GetConfigurationValue(ctx, awsConf, "aws", "token")
+	require.NoError(t, err)
+	require.Equal(t, "aws-token-value", tok)
+
+	// Service-level reference resolved through the same environment backend.
+	sconfs, err := manager.GetServiceConfigurations(ctx)
+	require.NoError(t, err)
+	require.Len(t, sconfs, 1)
+	pw, err := resources.GetConfigurationValue(ctx, sconfs[0], "db", "password")
+	require.NoError(t, err)
+	require.Equal(t, "op-db-password", pw)
 }
 
 // A reference whose backend is not configured for the environment must fail

--- a/configurations/testdata/secrets/configurations/local/auth0/backend.secret.yaml
+++ b/configurations/testdata/secrets/configurations/local/auth0/backend.secret.yaml
@@ -1,4 +1,4 @@
 client_secret: op://dev-vault/auth0/client_secret
 nested:
-  api_token: aws-sm://codefly/dev/token
+  api_token: op://dev-vault/db/password
   plain: keep-me

--- a/configurations/testdata/secrets/configurations/local/auth0/backend.secret.yaml
+++ b/configurations/testdata/secrets/configurations/local/auth0/backend.secret.yaml
@@ -1,0 +1,4 @@
+client_secret: op://dev-vault/auth0/client_secret
+nested:
+  api_token: aws-sm://codefly/dev/token
+  plain: keep-me

--- a/configurations/testdata/secrets/configurations/local/auth0/frontend.secret.env
+++ b/configurations/testdata/secrets/configurations/local/auth0/frontend.secret.env
@@ -1,0 +1,1 @@
+CLIENT_SECRET=op://dev-vault/auth0/client_secret

--- a/configurations/testdata/secrets/configurations/local/aws.secret.env
+++ b/configurations/testdata/secrets/configurations/local/aws.secret.env
@@ -1,0 +1,2 @@
+TOKEN=aws-sm://codefly/dev/token
+DB_PASSWORD=aws-sm://codefly/dev/auth0#client_secret

--- a/configurations/testdata/secrets/configurations/local/aws.secret.env
+++ b/configurations/testdata/secrets/configurations/local/aws.secret.env
@@ -1,2 +1,0 @@
-TOKEN=aws-sm://codefly/dev/token
-DB_PASSWORD=aws-sm://codefly/dev/auth0#client_secret

--- a/configurations/testdata/secrets/configurations/local/plain.secret.env
+++ b/configurations/testdata/secrets/configurations/local/plain.secret.env
@@ -1,0 +1,2 @@
+API_KEY=literal-plaintext-value
+CONNECTION=postgres://user:pass@localhost:5432/db

--- a/configurations/testdata/secrets/services/svc/configurations/local/db.secret.env
+++ b/configurations/testdata/secrets/services/svc/configurations/local/db.secret.env
@@ -1,0 +1,1 @@
+PASSWORD=op://dev-vault/db/password

--- a/configurations/testdata/secrets/services/svc/service.codefly.yaml
+++ b/configurations/testdata/secrets/services/svc/service.codefly.yaml
@@ -1,0 +1,9 @@
+kind: service
+name: svc
+version: 0.0.0
+module: mod
+agent:
+  kind: runtime::service
+  name: go-grpc
+  version: 0.0.1
+  publisher: codefly.ai

--- a/configurations/testdata/secrets/workspace.codefly.yaml
+++ b/configurations/testdata/secrets/workspace.codefly.yaml
@@ -1,0 +1,4 @@
+name: codefly-platform
+layout: flat
+services:
+    - name: svc

--- a/configurations/testdata/secrets/workspace.codefly.yaml
+++ b/configurations/testdata/secrets/workspace.codefly.yaml
@@ -6,4 +6,3 @@ environments:
     - name: local
       secrets:
           - kind: 1password
-          - kind: aws-secrets-manager

--- a/configurations/testdata/secrets/workspace.codefly.yaml
+++ b/configurations/testdata/secrets/workspace.codefly.yaml
@@ -2,3 +2,8 @@ name: codefly-platform
 layout: flat
 services:
     - name: svc
+environments:
+    - name: local
+      secrets:
+          - kind: 1password
+          - kind: aws-secrets-manager

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -53,18 +53,23 @@ type EnvironmentRegistry struct {
 
 // EnvironmentSecretProvider configures one secret backend for an environment.
 // With a backend configured, secret values in *.secret.* files are references
-// (op://…, aws-sm://…) resolved at Load() time through the backend's CLI;
-// nothing secret is written to disk. Multiple providers can be listed so
-// op:// and aws-sm:// references coexist in the same environment.
+// (op://…, aws-sm://…, doppler://…) resolved at Load() time through the
+// backend's CLI; nothing secret is written to disk. Multiple providers can be
+// listed so different schemes coexist in the same environment.
 //
-//	Kind:    "1password" or "aws-secrets-manager".
+//	Kind:    "1password", "aws-secrets-manager", or "doppler".
 //	Account: 1Password account shorthand passed as `op --account`.
 //	Region:  AWS region passed as `aws --region` (defaults to the caller's
 //	         ambient AWS config when empty).
+//	Project: Doppler project passed as `doppler --project`.
+//	Config:  Doppler config (its per-environment scope, e.g. dev/stg/prd)
+//	         passed as `doppler --config`.
 type EnvironmentSecretProvider struct {
 	Kind    string `yaml:"kind"`
 	Account string `yaml:"account,omitempty"`
 	Region  string `yaml:"region,omitempty"`
+	Project string `yaml:"project,omitempty"`
+	Config  string `yaml:"config,omitempty"`
 }
 
 // Environment is a configuration for an environment

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -51,22 +51,20 @@ type EnvironmentRegistry struct {
 	Auth string `yaml:"auth,omitempty"`
 }
 
-// EnvironmentSecrets selects how an environment resolves secret values.
+// EnvironmentSecretProvider configures one secret backend for an environment.
+// With a backend configured, secret values in *.secret.* files are references
+// (op://…, aws-sm://…) resolved at Load() time through the backend's CLI;
+// nothing secret is written to disk. Multiple providers can be listed so
+// op:// and aws-sm:// references coexist in the same environment.
 //
-// When Provider is empty, secret values are taken verbatim from the
-// plaintext *.secret.* files (local/dev-only — the values sit unencrypted
-// on disk). When a Provider is set, secret values are treated as
-// references (op://…, aws-sm://…) resolved at Load() time through the
-// backend's CLI; nothing secret is written to disk.
-//
-//	Provider: "" (plaintext, default), "1password", or "aws-secrets-manager".
-//	Account:  1Password account shorthand passed as `op --account`.
-//	Region:   AWS region passed as `aws --region` (defaults to the caller's
-//	          ambient AWS config when empty).
-type EnvironmentSecrets struct {
-	Provider string `yaml:"provider,omitempty"`
-	Account  string `yaml:"account,omitempty"`
-	Region   string `yaml:"region,omitempty"`
+//	Kind:    "1password" or "aws-secrets-manager".
+//	Account: 1Password account shorthand passed as `op --account`.
+//	Region:  AWS region passed as `aws --region` (defaults to the caller's
+//	         ambient AWS config when empty).
+type EnvironmentSecretProvider struct {
+	Kind    string `yaml:"kind"`
+	Account string `yaml:"account,omitempty"`
+	Region  string `yaml:"region,omitempty"`
 }
 
 // Environment is a configuration for an environment
@@ -83,9 +81,9 @@ type Environment struct {
 	Registry  *EnvironmentRegistry `yaml:"registry,omitempty"`
 	Namespace string               `yaml:"namespace,omitempty"`
 
-	// Secrets selects the secret backend for this environment. Empty means
+	// Secrets lists the secret backends for this environment. Empty means
 	// plaintext *.secret.* files (local-only). CLI-side; not serialized to proto.
-	Secrets *EnvironmentSecrets `yaml:"secrets,omitempty"`
+	Secrets []*EnvironmentSecretProvider `yaml:"secrets,omitempty"`
 }
 
 func (env *Environment) Proto() (*basev0.Environment, error) {

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -51,6 +51,24 @@ type EnvironmentRegistry struct {
 	Auth string `yaml:"auth,omitempty"`
 }
 
+// EnvironmentSecrets selects how an environment resolves secret values.
+//
+// When Provider is empty, secret values are taken verbatim from the
+// plaintext *.secret.* files (local/dev-only — the values sit unencrypted
+// on disk). When a Provider is set, secret values are treated as
+// references (op://…, aws-sm://…) resolved at Load() time through the
+// backend's CLI; nothing secret is written to disk.
+//
+//	Provider: "" (plaintext, default), "1password", or "aws-secrets-manager".
+//	Account:  1Password account shorthand passed as `op --account`.
+//	Region:   AWS region passed as `aws --region` (defaults to the caller's
+//	          ambient AWS config when empty).
+type EnvironmentSecrets struct {
+	Provider string `yaml:"provider,omitempty"`
+	Account  string `yaml:"account,omitempty"`
+	Region   string `yaml:"region,omitempty"`
+}
+
 // Environment is a configuration for an environment
 type Environment struct {
 	Name        string `yaml:"name"`
@@ -64,6 +82,10 @@ type Environment struct {
 	Cluster   *EnvironmentCluster  `yaml:"cluster,omitempty"`
 	Registry  *EnvironmentRegistry `yaml:"registry,omitempty"`
 	Namespace string               `yaml:"namespace,omitempty"`
+
+	// Secrets selects the secret backend for this environment. Empty means
+	// plaintext *.secret.* files (local-only). CLI-side; not serialized to proto.
+	Secrets *EnvironmentSecrets `yaml:"secrets,omitempty"`
 }
 
 func (env *Environment) Proto() (*basev0.Environment, error) {

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -53,23 +53,14 @@ type EnvironmentRegistry struct {
 
 // EnvironmentSecretProvider configures one secret backend for an environment.
 // With a backend configured, secret values in *.secret.* files are references
-// (op://…, aws-sm://…, doppler://…) resolved at Load() time through the
-// backend's CLI; nothing secret is written to disk. Multiple providers can be
-// listed so different schemes coexist in the same environment.
+// (op://…) resolved at Load() time through the backend's CLI; nothing secret
+// is written to disk. It is a list so more backends can be added later.
 //
-//	Kind:    "1password", "aws-secrets-manager", or "doppler".
+//	Kind:    "1password".
 //	Account: 1Password account shorthand passed as `op --account`.
-//	Region:  AWS region passed as `aws --region` (defaults to the caller's
-//	         ambient AWS config when empty).
-//	Project: Doppler project passed as `doppler --project`.
-//	Config:  Doppler config (its per-environment scope, e.g. dev/stg/prd)
-//	         passed as `doppler --config`.
 type EnvironmentSecretProvider struct {
 	Kind    string `yaml:"kind"`
 	Account string `yaml:"account,omitempty"`
-	Region  string `yaml:"region,omitempty"`
-	Project string `yaml:"project,omitempty"`
-	Config  string `yaml:"config,omitempty"`
 }
 
 // Environment is a configuration for an environment


### PR DESCRIPTION
Closes #45.

## Summary

- Secrets in `*.secret.*` files can now hold **references** (`op://vault/item/field`) that a per-environment backend resolves at `Load()` time. References are safe to commit and the resolved value is never written to disk — it only reaches the child process via the existing env-var injection.
- One backend ships now — **1Password** (via the `op` CLI). The design is a pluggable `SecretResolver` seam with a `secrets:` provider **list**, so AWS Secrets Manager / Doppler / Vault drop in later without reshaping config.
- Selected per environment in `workspace.codefly.yaml`:
  ```yaml
  environments:
    - name: local
      secrets:
        - kind: 1password
          account: my-team   # optional: op --account
  ```
  ```env
  # configurations/local/auth0/frontend.secret.env  ← now committable
  CLIENT_SECRET=op://dev-vault/auth0/client_secret
  ```
- Plaintext `*.secret.*` values still work (the local/dev-only escape hatch) and pass through untouched; a plaintext secret used against a configured backend in a non-local environment is warned (once per origin). A reference whose backend isn't configured fails the load instead of silently injecting the raw URI.

## Design notes

- `SecretResolver` (`configurations/secrets.go`) is the per-backend seam; `ResolversFromEnvironment` maps an environment's `secrets` list to resolvers; `Manager.resolveSecrets` walks the loaders' output and resolves references in both `ConfigurationValue`s and secret `yaml`/`json` data blobs, caching by URI within a `Load` pass.
- Only known schemes (currently just `op`) are treated as references, so a plaintext `postgres://…` connection string is left alone.
- Resolution is byte-faithful: only the CLI's single trailing newline is stripped, so multi-line secrets (PEM keys) survive intact and match the plaintext path's verbatim handling.
- `Manager.resolveSecrets` mutates the loader's configuration objects in place; the `Loader.Configurations()` stable-pointer requirement this relies on is documented on the interface.
- Cancellation/timeout is the caller's `ctx` — deliberately not a hardcoded deadline, so interactive `op` biometric unlock isn't cut off.

## Test plan

- [x] `go test ./configurations/... ./resources/...`, `go build ./...`, `go vet`, `gofmt` clean
- [x] `TestParseSecretReference` — op scheme parsed; unknown scheme (incl. an unconfigured backend's) treated as plaintext
- [x] `TestOnePasswordResolver` — real `os/exec` against a stub `op`: field read + error path (no secret leaked to stderr/errors)
- [x] `TestResolverPreservesMultilineSecret` — internal newlines preserved, trailing CLI newline stripped
- [x] `TestResolversFromEnvironment` — provider selection + unknown-provider error
- [x] `TestManagerResolvesSecretReferences` — `.secret.env` + `.secret.yaml` references resolved; plaintext/`postgres://` passthrough (injected resolver)
- [x] `TestManagerResolvesViaEnvironmentProvider` — drives the **real** selection path: env declared in `workspace.codefly.yaml` builds a resolver using the default `op` binary, stubbed on `PATH`
- [x] `TestManagerUnconfiguredBackendErrors` — reference with no configured backend fails the load

## Scope boundaries

- **1Password only for now.** AWS Secrets Manager and Doppler were prototyped and pulled back to keep the surface tight; re-adding either is one `SecretResolver` (a `Scheme()` + a `Resolve()` that shells out), no config reshape.
- **Live 1Password integration test:** not runnable in CI without an unlocked `op`; the `os/exec` boundary is exercised with a real subprocess (stub binary).
- **Migration command / container tmpfs injection:** the issue's own "open questions" — separate features (the migration command belongs in the CLI repo).