### PR TITLE
runners: selector zero-match is test-selection-error, not env-blocked

### DIFF
--- a/runners/golang/formula.go
+++ b/runners/golang/formula.go
@@ -221,14 +221,21 @@ func RunFormula(ctx context.Context, sourceDir string, command []string, selecto
 	// -run pattern matches nothing or the scoped packages have no test
 	// files. Same structural reasons — and reason strings — as the python
 	// twin, so language-blind consumers route both identically.
+	//
+	// TAG CONTRACT: the two zero-case shapes carry DIFFERENT tags because
+	// they demand different remediation. Selector-scoped zero-match is the
+	// CALLER naming tests that don't exist — the module may be perfectly
+	// healthy, so tagging it env-blocked sends the caller repairing an
+	// environment that isn't broken. It gets `test-selection-error (...)`:
+	// actionable feedback to fix the selection, never an environment claim.
 	if total == 0 {
-		reason := EnvErrorNoTestsExecuted
-		detail := "test command executed zero tests — a command that discovers nothing is a broken invocation, not a passing run"
 		if len(runSelectors) > 0 || len(selPkgs) > 0 {
-			reason = EnvErrorNoTestsMatchedSelectors
-			detail = fmt.Sprintf("selectors %v matched zero tests — the selectors do not name any test in the module", selectors)
+			msg := fmt.Sprintf("test-selection-error (%s): selectors %v matched zero tests — the selectors do not name any test in the module",
+				EnvErrorNoTestsMatchedSelectors, selectors)
+			return erroredResponse(msg, raw), nil
 		}
-		msg := fmt.Sprintf("env-blocked (%s): %s", reason, detail)
+		msg := fmt.Sprintf("env-blocked (%s): test command executed zero tests — a command that discovers nothing is a broken invocation, not a passing run",
+			EnvErrorNoTestsExecuted)
 		return erroredResponse(msg, raw), nil
 	}
 

--- a/runners/golang/formula_test.go
+++ b/runners/golang/formula_test.go
@@ -280,8 +280,14 @@ func TestRunFormula_NoMatchSelectorIsNeverGreen(t *testing.T) {
 	if resp.GetResult().GetState() != runtimev0.TestRunResult_ERRORED {
 		t.Fatalf("a selector matching nothing must not read as a pass: state = %s (%s)", resp.GetResult().GetState(), resp.GetResult().GetMessage())
 	}
-	if !strings.Contains(resp.GetResult().GetMessage(), "env-blocked ("+EnvErrorNoTestsMatchedSelectors+")") {
-		t.Fatalf("want %s classification, got: %s", EnvErrorNoTestsMatchedSelectors, resp.GetResult().GetMessage())
+	if !strings.Contains(resp.GetResult().GetMessage(), "test-selection-error ("+EnvErrorNoTestsMatchedSelectors+")") {
+		t.Fatalf("want test-selection-error(%s) classification, got: %s", EnvErrorNoTestsMatchedSelectors, resp.GetResult().GetMessage())
+	}
+	// The selection tag must NOT claim the environment: a healthy module with
+	// a bad selector routed to env repair sends the caller healing infra that
+	// isn't broken (seen live: gofixture 01-healthy spiraling into prepare-env).
+	if strings.Contains(resp.GetResult().GetMessage(), "env-blocked") {
+		t.Fatalf("selector zero-match must not carry the env-blocked tag: %s", resp.GetResult().GetMessage())
 	}
 }
 

--- a/runners/python/pytest_structured.go
+++ b/runners/python/pytest_structured.go
@@ -756,7 +756,16 @@ func (r *StructuredTestRun) ToProtoResponse(runner, suiteName string, duration t
 	// without re-parsing raw output.
 	if r.EnvError != nil {
 		runResult.State = runtimev0.TestRunResult_ERRORED
-		runResult.Message = fmt.Sprintf("env-blocked (%s): %s", r.EnvError.Reason, r.EnvError.Detail)
+		// TAG CONTRACT: selector-scoped zero-match is the CALLER naming tests
+		// that don't exist — the environment may be perfectly healthy, so it
+		// must not carry the env-blocked tag (which routes callers to
+		// environment repair). It gets `test-selection-error (...)` instead:
+		// fix the selection, not the environment. Same tag as the Go twin.
+		tag := "env-blocked"
+		if r.EnvError.Reason == EnvErrorNoTestsMatchedSelectors {
+			tag = "test-selection-error"
+		}
+		runResult.Message = fmt.Sprintf("%s (%s): %s", tag, r.EnvError.Reason, r.EnvError.Detail)
 	}
 	// Materialized-but-interrupted: the environment is USABLE (runner launched)
 	// but the run was budget-cut before any case completed. Report a healthy,

--- a/runners/python/pytest_structured_test.go
+++ b/runners/python/pytest_structured_test.go
@@ -284,3 +284,30 @@ func TestToProtoResponseTagsDependencyWarningFailures(t *testing.T) {
 		t.Fatalf("real failure must stay a test failure, got %q", m)
 	}
 }
+
+// Selector-scoped zero-match is the CALLER naming tests that don't exist; the
+// environment may be perfectly healthy. It must carry the test-selection-error
+// tag — never env-blocked, which routes callers into environment repair (seen
+// live: a healthy Go fixture spiraling into prepare-env remediation). The
+// no-selector twin (nothing discovered at all) stays env-blocked.
+func TestToProtoResponseTagsSelectorZeroMatchAsSelectionError(t *testing.T) {
+	selMiss := &python.StructuredTestRun{EnvError: &python.RunEnvError{
+		Reason: python.EnvErrorNoTestsMatchedSelectors,
+		Detail: "selectors [test_nope] matched zero tests",
+	}}
+	msg := selMiss.ToProtoResponse("formula", "", 0).GetResult().GetMessage()
+	if !strings.Contains(msg, "test-selection-error ("+python.EnvErrorNoTestsMatchedSelectors+")") {
+		t.Fatalf("want test-selection-error tag, got %q", msg)
+	}
+	if strings.Contains(msg, "env-blocked") {
+		t.Fatalf("selector zero-match must not claim the environment, got %q", msg)
+	}
+
+	noneRun := &python.StructuredTestRun{EnvError: &python.RunEnvError{
+		Reason: python.EnvErrorNoTestsExecuted,
+		Detail: "test command executed zero tests",
+	}}
+	if m := noneRun.ToProtoResponse("formula", "", 0).GetResult().GetMessage(); !strings.Contains(m, "env-blocked ("+python.EnvErrorNoTestsExecuted+")") {
+		t.Fatalf("no-selector zero-discovery stays env-blocked, got %q", m)
+	}
+}


### PR DESCRIPTION
A selector that matches zero tests is the caller's selection error — the environment may be perfectly healthy. Tagging it `env-blocked` sent consumers into environment repair: mind's healthy gofixture 01 spiraled into prepare-env remediation rounds when literal selector routing (v0.2.13) made a near-miss selector match nothing.

- Go + python runners: selector-scoped zero-match → `test-selection-error (no-tests-matched-selectors)`
- no-selector zero-discovery keeps `env-blocked (no-tests-executed)`
- reason strings unchanged (shared contract); only the tag prefix classifies
- tag-level tests added on both runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)