### PR TITLE
fix(watcher): make s.Events single-closer to stop double-close panic

### DIFF
--- a/agents/helpers/code/watcher.go
+++ b/agents/helpers/code/watcher.go
@@ -133,9 +133,12 @@ func (watcher *Watcher) Start(ctx context.Context) {
 	w := wool.Get(ctx).In("Watcher.Start")
 	// Start listening for events.
 	defer watcher.watcher.Close()
-	// Start is the sole sender on events (via Handle, only from this loop), so
-	// closing it here is race-free and lets the consumer's receive drain and
-	// exit on teardown instead of blocking forever on a channel nobody closes.
+	// Start is the sole sender on events (via Handle, only from this loop) AND
+	// the sole closer: closing it here is the single close of the channel, which
+	// lets the consumer's receive drain and exit on teardown. Nothing else may
+	// close Events — a second closer (an earlier version had Runtime.Stop close
+	// it too) races this goroutine into a "close of closed channel" panic. To end
+	// this goroutine, cancel its context (see services.Base.StopWatcher).
 	defer close(watcher.events)
 	for {
 		select {

--- a/agents/services/base.go
+++ b/agents/services/base.go
@@ -81,6 +81,10 @@ type Base struct {
 	// Code Watcher
 	Watcher *code.Watcher
 	Events  chan code.Change
+	// watcherCancel stops the Watcher.Start goroutine so its `defer close(Events)`
+	// runs — that deferred close is the SINGLE close of Events. nil when no
+	// watcher is running. See SetupWatcher / StopWatcher.
+	watcherCancel context.CancelFunc
 
 	// Command registry for agent-provided tools (exposed via ListCommands/RunPluginCommand)
 	commands *CommandRegistry
@@ -219,7 +223,15 @@ func (s *Base) SetupWatcher(ctx context.Context, conf *WatchConfiguration, handl
 	if err != nil {
 		return err
 	}
-	go s.Watcher.Start(ctx)
+	// The Watcher is the SOLE closer of s.Events: its Start goroutine runs
+	// `defer close(events)` on exit. Give it a dedicated cancelable context
+	// stored on the Base so StopWatcher can end that goroutine and let the
+	// deferred close fire exactly once. Runtime.Stop must NOT close s.Events
+	// itself — a second close raced this goroutine into a "close of closed
+	// channel" panic that crashed the agent.
+	watcherCtx, cancel := context.WithCancel(ctx)
+	s.watcherCancel = cancel
+	go s.Watcher.Start(watcherCtx)
 
 	// DEBOUNCE file-change events. A single save often fires a burst (multi-file
 	// saves, gofmt rewriting several files, editor temp churn), and the handler
@@ -272,6 +284,23 @@ func (s *Base) SetupWatcher(ctx context.Context, conf *WatchConfiguration, handl
 // into before the watcher fires one rebuild. Long enough to coalesce a save's
 // multi-file churn, short enough to feel instant.
 const WatchDebounce = 600 * time.Millisecond
+
+// StopWatcher tears down the file watcher. It cancels the Watcher.Start
+// goroutine, whose `defer close(Events)` then closes the events channel exactly
+// once — unblocking the debounce consumer — and closes the underlying fsnotify
+// handle. Idempotent: safe when no watcher is running and safe to call more than
+// once. Runtime.Stop implementations MUST use this instead of closing s.Events
+// directly; the Watcher is the sole closer, and a second close raced the watcher
+// goroutine into a "close of closed channel" panic that crashed the agent.
+func (s *Base) StopWatcher() {
+	if s.Watcher != nil {
+		s.Watcher.Pause()
+	}
+	if s.watcherCancel != nil {
+		s.watcherCancel()
+		s.watcherCancel = nil
+	}
+}
 
 func (s *Base) Local(f string, args ...any) string {
 	return path.Join(s.Location, fmt.Sprintf(f, args...))


### PR DESCRIPTION
## Problem

The file-watcher's events channel (`s.Events`) had **two closers**:

- `code.Watcher.Start` — `defer close(watcher.events)` (fires when its context is cancelled), `agents/helpers/code/watcher.go:139`
- `Runtime.Stop` — `close(s.Events)` in both `service-go` and `service-go-grpc`

At shutdown both fire on the same channel → `panic: close of closed channel`. Whichever loses the race panics; when the loser is the **watcher goroutine** (no gRPC recovery interceptor around it) the panic escapes and crashes the agent with **exit status 2**. This happened on every teardown, including a clean **Ctrl-C**.

## Fix

Make the `Watcher` the **sole closer** (Go idiom: the sender closes). `SetupWatcher` now runs the watcher under a stored cancelable context; new `Base.StopWatcher()` cancels it so the watcher's own `defer close(events)` runs exactly once, unblocking the debounce consumer. `Runtime.Stop` implementations call `StopWatcher()` instead of closing `s.Events` (companion PRs in `service-go` / `service-go-grpc`).

## Test

- `go test ./agents/services/ ./agents/helpers/code/` passes, incl. the existing `TestSetupWatcher_GoroutinesExitOnCancel` / `DrainsInFlightEventOnCancel` teardown regressions.
- `close(...events)` now exists only at `watcher.go:139`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)