### PR TITLE
test(watcher): cover StopWatcher teardown without context cancel

### DIFF
--- a/agents/services/base_test.go
+++ b/agents/services/base_test.go
@@ -135,6 +135,34 @@ func TestSetupWatcher_DrainsInFlightEventOnCancel(t *testing.T) {
 	waitWatcherGoroutines(t, 0, 3*time.Second)
 }
 
+// TestStopWatcher_ExitsWithoutContextCancel is the regression for the actual
+// production teardown path: Runtime.Stop calls StopWatcher() (it must NOT close
+// s.Events — that second close raced the watcher into a "close of closed
+// channel" panic). The context passed to SetupWatcher is NOT cancelled here, so
+// this proves StopWatcher alone ends both goroutines via its stored cancelFunc,
+// whose `defer close(Events)` unblocks the debounce consumer.
+func TestStopWatcher_ExitsWithoutContextCancel(t *testing.T) {
+	base := &Base{
+		Wool:     wool.Get(context.Background()),
+		Location: t.TempDir(),
+	}
+
+	// Background context — the test never cancels it; only StopWatcher can.
+	conf := NewWatchConfiguration(builders.NewDependencies("test"))
+	require.NoError(t, base.SetupWatcher(context.Background(), conf, func(code.Change) error { return nil }))
+
+	waitWatcherGoroutines(t, 2, time.Second) // Start loop + debounce goroutine
+
+	base.StopWatcher()
+
+	waitWatcherGoroutines(t, 0, 3*time.Second)
+
+	// Idempotent: a second StopWatcher is safe (Runtime.Stop may run twice), and
+	// StopWatcher on a Base that never set up a watcher must also be a no-op.
+	base.StopWatcher()
+	(&Base{Wool: wool.Get(context.Background())}).StopWatcher()
+}
+
 // save performs an atomic-rename save (write temp → rename over original),
 // which is how most editors save and what the directory watcher observes.
 func save(t *testing.T, target, content string) {


### PR DESCRIPTION
## Context

Follow-up to #49, which made the `Watcher` the sole closer of `s.Events` and added `Base.StopWatcher()` as the teardown path `Runtime.Stop` must use (instead of `close(s.Events)`). That PR merged before this test landed on its branch, so this adds the missing regression coverage directly to `main`.

## What

The regressions merged in #49 (`TestSetupWatcher_GoroutinesExitOnCancel` / `DrainsInFlightEventOnCancel`) both tear the watcher down by **cancelling the parent context**. None exercised `StopWatcher()` directly — the actual production teardown path, where `Runtime.Stop` ends the watcher goroutine via its stored `cancelFunc` (whose `defer close(Events)` unblocks the debounce consumer) rather than closing `s.Events`.

`TestStopWatcher_ExitsWithoutContextCancel`:
- sets up the watcher on a `context.Background()` the test never cancels, so only `StopWatcher()` can end it;
- calls `StopWatcher()` and asserts both the fsnotify `Start` loop and the debounce goroutine exit;
- asserts idempotency (a second `StopWatcher()` is safe — `Runtime.Stop` may run twice) and the no-watcher no-op.

## Test

`go test ./agents/services/ -run TestStopWatcher -race` passes; full `./agents/services/ ./agents/helpers/code/ -race` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watcher shutdown behavior so background processing stops cleanly without requiring context cancellation.
  * Made repeated shutdown calls safe, including when no watcher was initialized.

* **Tests**
  * Added regression coverage for watcher cleanup and idempotent shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->