### PR TITLE
Add reference-only secret manifests (#51)

### DIFF
--- a/configurations/doc.go
+++ b/configurations/doc.go
@@ -22,6 +22,12 @@
 //
 // # Secrets
 //
+// Git worktrees share repository history but not ignored files. Copying or
+// symlinking plaintext secrets from another checkout makes that checkout a
+// secret authority and exposes credentials to every process that can read the
+// worktree. Reference-only manifests separate commit-safe discovery data from
+// resolved credentials.
+//
 // Files named *.secret.ref.env and *.secret.ref.yaml are reference-only secret
 // manifests. Every value, including every scalar nested in YAML maps and
 // arrays, must be a recognized provider reference:
@@ -32,6 +38,11 @@
 //	# database.secret.ref.yaml
 //	credentials:
 //	  password: op://development-vault/database/password
+//
+// Both names map to the configuration name before .secret.ref and are always
+// secret. Their contract applies in local environments too, and mixing either
+// format with a plaintext-capable source for the same logical configuration is
+// a load error.
 //
 // Backends are selected per environment via workspace.codefly.yaml. It is a
 // list so more backends can be added later:
@@ -57,6 +68,17 @@
 // be copied or symlinked between worktrees. A locked, unavailable, or
 // misconfigured provider fails closed; Codefly does not fall back to raw
 // environment variables or values from a worktree manager.
+//
+// Project ignore rules should include:
+//
+//	*.secret.env
+//	*.secret.yaml
+//
+// Manager.Restrict prevents resolution for excluded service origins. Workspace
+// configurations are currently resolved during Manager.Load, before dependency
+// names passed later to GetWorkspaceDependenciesConfigurations are known.
+// Reference-only manifests do not change the loader's existing symlink
+// traversal policy; filesystem and repository permissions remain the boundary.
 //
 // Git owns the non-secret manifest and workspace configuration, Core validates
 // and resolves only provider references, the CLI selects the declared


### PR DESCRIPTION
## **User description**
Closes #51.

## Summary

- Make tracked local configuration safe across worktrees by giving reference-only manifests a fail-closed filename contract for env and recursively validated YAML values.
- Keep provider resolution generic and in memory while preserving per-load caching and cancellation, suppressing unsafe provider output, and avoiding excluded service origins.
- Make file consolidation, traversal, duplicate errors, and routed output deterministic, with explicit migration and failure guidance for plaintext-capable legacy files.

## Test plan

- [x] `go vet ./configurations`
- [x] `go test -race ./configurations -count=1`
- [x] Smoke each filename, env-line, URI, and recursive-YAML fuzz target
- [x] `go test -p 1 ./...` in a clean regular checkout

## Follow-up

Workspace-origin configurations are still resolved during `Manager.Load`, before dependency names reach `GetWorkspaceDependenciesConfigurations`; service origins now honor `Manager.Restrict`. #53 tracks a selection-aware manager boundary without expanding this security contract into an unsafe routing shortcut.

Provider stdout and stderr are intentionally suppressed on failures because neither stream is guaranteed to be secret-free; errors retain their cause for `errors.Is`/`errors.As` while exposing only safe configuration, key-path, and provider provenance.


___

## **CodeAnt-AI Description**
**Document reference-only secret manifests for worktree-safe secrets**

### What Changed
- Added guidance for `*.secret.ref.env` and `*.secret.ref.yaml` as commit-safe secret manifests that store provider references instead of plaintext values
- Clarified that reference-only manifests reject plaintext, unknown secret formats, malformed references, and mixed use with plaintext-capable files for the same secret
- Added notes on local worktree safety, stable secret resolution, and the need to keep legacy plaintext secret files ignored by Git

### Impact
`✅ Safer tracked secrets`
`✅ Fewer accidental secret leaks in worktrees`
`✅ Clearer rules for secret file usage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
