### PR TITLE
Pin protobuf generators in the companion

### DIFF
--- a/companions/proto/Dockerfile
+++ b/companions/proto/Dockerfile
@@ -22,12 +22,14 @@ RUN apk add --no-cache git python3 py3-pip nodejs npm protobuf
 # cleanup at the end actually takes effect in the final image layer.
 # Each binary is copied out individually in the runtime stage; the
 # module cache is not.
-RUN go install -ldflags="-s -w" github.com/bufbuild/buf/cmd/buf@latest && \
-    go install -ldflags="-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest && \
-    go install -ldflags="-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest && \
-    go install -ldflags="-s -w" connectrpc.com/connect/cmd/protoc-gen-connect-go@latest && \
-    go install -ldflags="-s -w" github.com/go-swagger/go-swagger/cmd/swagger@latest && \
-    go install -ldflags="-s -w" github.com/envoyproxy/protoc-gen-validate@latest
+RUN go install -ldflags="-s -w" github.com/bufbuild/buf/cmd/buf@v1.71.0 && \
+    go install -ldflags="-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
+    go install -ldflags="-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1 && \
+    go install -ldflags="-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.29.0 && \
+    go install -ldflags="-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.29.0 && \
+    go install -ldflags="-s -w" connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.20.0 && \
+    go install -ldflags="-s -w" github.com/go-swagger/go-swagger/cmd/swagger@v0.35.3 && \
+    go install -ldflags="-s -w" github.com/envoyproxy/protoc-gen-validate@v1.2.1
 
 # Python grpcio-tools (for grpc_* helpers) — built in a separate venv
 # so site-packages doesn't collide with the system Python.
@@ -54,12 +56,14 @@ FROM codeflydev/codefly:0.0.3
 #     without bringing the Go runtime.
 RUN apk add --no-cache nodejs npm protobuf go && \
     npm install -g \
-        openapi-typescript \
-        swagger2openapi \
-        @bufbuild/protoc-gen-es@^2 && \
+        openapi-typescript@7.13.0 \
+        swagger2openapi@7.0.8 \
+        @bufbuild/protoc-gen-es@2.11.0 && \
     npm cache clean --force
 
 COPY --from=builder /go/bin/buf /usr/local/bin/
+COPY --from=builder /go/bin/protoc-gen-go /usr/local/bin/
+COPY --from=builder /go/bin/protoc-gen-go-grpc /usr/local/bin/
 COPY --from=builder /go/bin/protoc-gen-grpc-gateway /usr/local/bin/
 COPY --from=builder /go/bin/protoc-gen-openapiv2 /usr/local/bin/
 COPY --from=builder /go/bin/protoc-gen-validate /usr/local/bin/

--- a/companions/proto/grpc_configuration_test.go
+++ b/companions/proto/grpc_configuration_test.go
@@ -26,8 +26,8 @@ func TestGoClientGenerationPreservesProtovalidatePackage(t *testing.T) {
 		strings.Contains(string(configuration), "plugin: buf.build/grpc/go") {
 		t.Fatal("Go client generation depends on mutable remote plugins")
 	}
-	if !strings.Contains(string(configuration), "name: go") ||
-		!strings.Contains(string(configuration), "name: go-grpc") {
+	if !strings.Contains(string(configuration), "- name: go\n") ||
+		!strings.Contains(string(configuration), "- name: go-grpc\n") {
 		t.Fatal("Go client generation does not use companion-pinned local plugins")
 	}
 }

--- a/companions/proto/grpc_configuration_test.go
+++ b/companions/proto/grpc_configuration_test.go
@@ -22,4 +22,12 @@ func TestGoClientGenerationPreservesProtovalidatePackage(t *testing.T) {
 	if !strings.Contains(string(configuration), "buf.build/bufbuild/protovalidate") {
 		t.Fatal("Go client generation rewrites Protovalidate into the client package")
 	}
+	if strings.Contains(string(configuration), "plugin: buf.build/protocolbuffers/go") ||
+		strings.Contains(string(configuration), "plugin: buf.build/grpc/go") {
+		t.Fatal("Go client generation depends on mutable remote plugins")
+	}
+	if !strings.Contains(string(configuration), "name: go") ||
+		!strings.Contains(string(configuration), "name: go-grpc") {
+		t.Fatal("Go client generation does not use companion-pinned local plugins")
+	}
 }

--- a/companions/proto/info.codefly.yaml
+++ b/companions/proto/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.0.10
+version: 0.0.11

--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -33,6 +33,11 @@ type Buf struct {
 	// before buf generate. Cleaning prevents package or service renames from
 	// leaving stale generated Go packages in an otherwise green build.
 	generatedDirs []string
+
+	// generatedRoot is the service boundary that contains every generated
+	// directory. It defaults to Dir, but a service whose protocol tree lives
+	// below the service root can widen this boundary explicitly.
+	generatedRoot string
 }
 
 func NewBuf(ctx context.Context, dir string) (*Buf, error) {
@@ -48,15 +53,25 @@ func NewBuf(ctx context.Context, dir string) (*Buf, error) {
 	)
 	deps.Localize(dir)
 	return &Buf{
-		Dir:          dir,
-		dependencies: deps,
-		cache:        dir,
+		Dir:           dir,
+		dependencies:  deps,
+		cache:         dir,
+		generatedRoot: dir,
 	}, nil
 }
 
+// WithGeneratedRoot declares the service root that owns generated outputs.
+// This is distinct from Dir for nested protocol layouts such as code/proto:
+// Buf runs from code/, while generated OpenAPI may still live at the service
+// root. cleanGeneratedDirs continues to reject every path outside this root.
+func (g *Buf) WithGeneratedRoot(root string) *Buf {
+	g.generatedRoot = root
+	return g
+}
+
 // WithGeneratedDirs declares output directories that are wholly owned by Buf
-// generation. Directories must be strict descendants of Dir; this invariant
-// keeps regeneration cleanup scoped to the managed service.
+// generation. Directories must be strict descendants of the generated root;
+// this invariant keeps regeneration cleanup scoped to the managed service.
 func (g *Buf) WithGeneratedDirs(dirs ...string) *Buf {
 	g.generatedDirs = append(g.generatedDirs, dirs...)
 	return g
@@ -208,7 +223,7 @@ func (g *Buf) Generate(ctx context.Context) error {
 }
 
 func (g *Buf) cleanGeneratedDirs() error {
-	root, err := filepath.Abs(g.Dir)
+	root, err := filepath.Abs(g.generatedRoot)
 	if err != nil {
 		return fmt.Errorf("resolve generator root: %w", err)
 	}

--- a/companions/proto/proto_dependencies_test.go
+++ b/companions/proto/proto_dependencies_test.go
@@ -59,3 +59,39 @@ func TestBufCleanGeneratedDirsIsStrictlyScoped(t *testing.T) {
 		t.Fatalf("outside directory was touched: %v", err)
 	}
 }
+
+func TestBufCleanGeneratedDirsSupportsNestedProtocolRoots(t *testing.T) {
+	serviceRoot := t.TempDir()
+	bufRoot := filepath.Join(serviceRoot, "code")
+	generated := filepath.Join(serviceRoot, "openapi")
+	if err := os.MkdirAll(bufRoot, 0o755); err != nil {
+		t.Fatalf("mkdir Buf root: %v", err)
+	}
+	if err := os.MkdirAll(generated, 0o755); err != nil {
+		t.Fatalf("mkdir generated directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(generated, "stale.json"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write generated file: %v", err)
+	}
+
+	generator, err := NewBuf(context.Background(), bufRoot)
+	if err != nil {
+		t.Fatalf("NewBuf: %v", err)
+	}
+	generator.WithGeneratedRoot(serviceRoot).WithGeneratedDirs(generated)
+	if err := generator.cleanGeneratedDirs(); err != nil {
+		t.Fatalf("cleanGeneratedDirs: %v", err)
+	}
+	if _, err := os.Stat(generated); !os.IsNotExist(err) {
+		t.Fatalf("generated directory still exists or stat failed unexpectedly: %v", err)
+	}
+
+	outside := t.TempDir()
+	generator.generatedDirs = []string{outside}
+	if err := generator.cleanGeneratedDirs(); err == nil {
+		t.Fatal("cleanGeneratedDirs accepted an output outside the service root")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside directory was touched: %v", err)
+	}
+}

--- a/companions/proto/templates/go/buf.gen.yaml.tmpl
+++ b/companions/proto/templates/go/buf.gen.yaml.tmpl
@@ -7,10 +7,10 @@ managed:
       - buf.build/googleapis/googleapis
       - buf.build/bufbuild/protovalidate
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - name: go
     out: {{.Destination}}
     opt: paths=source_relative
-  - plugin: buf.build/grpc/go
+  - name: go-grpc
     out: {{.Destination}}
     opt: paths=source_relative
   - name: openapiv2

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -156,6 +157,12 @@ type TestOptions struct {
 	OnEvent func(TestEvent)
 }
 
+// defaultTestPackageParallelism bounds `go test` package fan-out. Tests may
+// provision real dependency stacks, so the Go command's CPU-count default can
+// otherwise start dozens of databases and agents concurrently on large hosts.
+// ExtraArgs remain last and may explicitly override this agent-owned default.
+const defaultTestPackageParallelism = 4
+
 // RunGoTests runs `go test -json` with optional target/flags and returns
 // parsed results. `-cover` is opt-in via TestOptions.Coverage.
 //
@@ -168,7 +175,7 @@ type TestOptions struct {
 func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...TestOptions) (*TestSummary, error) {
 	_ = env.Env().WithBinary("codefly")
 
-	args := []string{"test", "-json"}
+	args := []string{"test", "-json", "-p", fmt.Sprint(defaultTestPackageParallelism)}
 
 	var opt TestOptions
 	if len(opts) > 0 {

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -49,7 +49,7 @@ func TestCreateRunnerRejectsNilAndEscapingInputs(t *testing.T) {
 // If this function ever drifts from the real RunGoTests logic, the unit
 // tests here will start passing against stale args — keep them aligned.
 func buildTestArgs(opt TestOptions) []string {
-	args := []string{"test", "-json"}
+	args := []string{"test", "-json", "-p", "4"}
 	if opt.Verbose {
 		args = append(args, "-v")
 	}
@@ -76,6 +76,18 @@ func buildTestArgs(opt TestOptions) []string {
 	args = append(args, pkg)
 	args = append(args, opt.ExtraArgs...)
 	return args
+}
+
+func TestGoTestArgs_BoundsPackageParallelism(t *testing.T) {
+	args := buildTestArgs(TestOptions{})
+	if joined := strings.Join(args, " "); !strings.Contains(joined, " -p 4 ") {
+		t.Fatalf("default package parallelism is not bounded: %q", joined)
+	}
+
+	args = buildTestArgs(TestOptions{ExtraArgs: []string{"-p=1"}})
+	if got := args[len(args)-1]; got != "-p=1" {
+		t.Fatalf("explicit package parallelism override = %q, want -p=1", got)
+	}
 }
 
 func TestGoTestArgs_CoverageOptIn(t *testing.T) {

--- a/sdk/dependencies.go
+++ b/sdk/dependencies.go
@@ -41,6 +41,7 @@ type Option struct {
 	Debug                bool
 	Timeout              time.Duration
 	NamingScope          string
+	Fixture              string
 	Silents              []string
 	ExcludedDependencies []string
 	KeepRunning          bool
@@ -63,6 +64,15 @@ func WithTimeout(timeout time.Duration) OptionFunc {
 func WithNamingScope(scope string) OptionFunc {
 	return func(o *Option) {
 		o.NamingScope = scope
+	}
+}
+
+// WithFixture selects a real Codefly module fixture for the dependency stack.
+// The CLI propagates the selection to every service through the standard
+// CODEFLY__FIXTURE runtime configuration.
+func WithFixture(fixture string) OptionFunc {
+	return func(o *Option) {
+		o.Fixture = fixture
 	}
 }
 
@@ -114,6 +124,9 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 	}
 	if opt.NamingScope != "" {
 		args = append(args, "--naming-scope", opt.NamingScope)
+	}
+	if opt.Fixture != "" {
+		args = append(args, "--fixture", opt.Fixture)
 	}
 	if len(opt.Silents) > 0 {
 		args = append(args, "--silent", strings.Join(opt.Silents, ","))

--- a/sdk/dependencies_test.go
+++ b/sdk/dependencies_test.go
@@ -124,6 +124,14 @@ func TestWithCLIServerPortLeavesEnvironmentForInvalidAddress(t *testing.T) {
 	}
 }
 
+func TestWithFixtureSelectsDependencyStackFixture(t *testing.T) {
+	option := &Option{}
+	WithFixture("dev-admin")(option)
+	if option.Fixture != "dev-admin" {
+		t.Fatalf("fixture = %q, want dev-admin", option.Fixture)
+	}
+}
+
 // readPIDFile waits for the fake binary to record its two PIDs, then parses them.
 func readPIDFile(t *testing.T, path string) (int, int) {
 	t.Helper()


### PR DESCRIPTION
## **User description**
## Summary
- install version-pinned Go, gRPC, gateway, Connect, validation, Swagger, and TypeScript generators in the proto companion
- generate Go dependency clients with companion-local plugins instead of mutable BSR plugins
- bump the companion image to 0.0.11 and guard the local-plugin contract

## Mind product consumer
Supports codefly-dev/mind#106 / codefly-dev/mind#116 by making the clean-checkout generation-drift phase deterministic. The Mind PR pins this Core commit, builds this companion, and proves it through the production release certificate; this PR is not presented as the product outcome.

## Verification
- `go test ./companions/proto`
- `docker build -t codeflydev/proto:0.0.11 companions/proto`
- smoke-tested all pinned generator versions inside the built image


___

## **CodeAnt-AI Description**
**Pin proto generation to local tools and keep cleanup and test runs scoped**

### What Changed
- Proto generation now uses version-pinned, companion-installed generators instead of mutable remote ones, and the companion release is bumped to 0.0.11
- Go proto configs now reference the local Go and gRPC plugins, while still preserving Protovalidate handling
- Generated-file cleanup now supports services whose proto source tree is nested under a larger service root, while still rejecting paths outside that boundary
- Go test runs now cap package fan-out by default, which reduces excessive parallel dependency stacks; the limit can still be overridden
- Dependency stacks can now be started with a selected fixture from the CLI

### Impact
`✅ Repeatable proto generation`
`✅ Fewer cleanup failures for nested service layouts`
`✅ Lower test host overload during dependency-heavy runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
