### PR TITLE
tui: keep service gutter on wrapped log continuation lines (#58)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/codefly-dev/gortk v0.2.0
 	github.com/cyphar/filepath-securejoin v0.6.1
@@ -67,7 +68,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20260422141420-a6cbdff8a7e2 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/tui/logview.go
+++ b/tui/logview.go
@@ -129,21 +129,18 @@ func wrapLogLine(prefix, message string, width int) []string {
 	if bodyWidth < 20 {
 		return []string{prefix + message}
 	}
-	continuation := strings.Repeat(" ", len(prefix))
 	var out []string
 	remaining := message
-	currentPrefix := prefix
-	for len(currentPrefix)+len(remaining) > width {
+	for len(prefix)+len(remaining) > width {
 		cut := bodyWidth
 		if idx := strings.LastIndexByte(remaining[:bodyWidth], ' '); idx > 0 {
 			cut = idx
 		}
-		out = append(out, currentPrefix+strings.TrimRight(remaining[:cut], " "))
+		out = append(out, prefix+strings.TrimRight(remaining[:cut], " "))
 		remaining = strings.TrimLeft(remaining[cut:], " ")
-		currentPrefix = continuation
 	}
 	if remaining != "" {
-		out = append(out, currentPrefix+remaining)
+		out = append(out, prefix+remaining)
 	}
 	return out
 }

--- a/tui/logview.go
+++ b/tui/logview.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/codefly-dev/core/wool"
 )
 
@@ -122,25 +123,18 @@ func padServiceSource(source string) string {
 }
 
 func wrapLogLine(prefix, message string, width int) []string {
-	if width <= 0 || len(prefix)+len(message) <= width {
+	prefixWidth := ansi.StringWidth(prefix)
+	if width <= 0 || prefixWidth+ansi.StringWidth(message) <= width {
 		return []string{prefix + message}
 	}
-	bodyWidth := width - len(prefix)
+	bodyWidth := width - prefixWidth
 	if bodyWidth < 20 {
 		return []string{prefix + message}
 	}
-	var out []string
-	remaining := message
-	for len(prefix)+len(remaining) > width {
-		cut := bodyWidth
-		if idx := strings.LastIndexByte(remaining[:bodyWidth], ' '); idx > 0 {
-			cut = idx
-		}
-		out = append(out, prefix+strings.TrimRight(remaining[:cut], " "))
-		remaining = strings.TrimLeft(remaining[cut:], " ")
-	}
-	if remaining != "" {
-		out = append(out, prefix+remaining)
+	bodies := strings.Split(ansi.Wrap(message, bodyWidth, ""), "\n")
+	out := make([]string, 0, len(bodies))
+	for _, body := range bodies {
+		out = append(out, prefix+body)
 	}
 	return out
 }

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -105,10 +106,34 @@ func TestFormatServiceLogLinesWrapsWithContinuationGutter(t *testing.T) {
 	if len(lines) < 2 {
 		t.Fatalf("expected wrapped lines, got %#v", lines)
 	}
-	if lines[0] != "infra/neo4j      > This instance is" {
+	gutter := "infra/neo4j      > "
+	if lines[0] != gutter+"This instance is" {
 		t.Fatalf("unexpected first line: %q", lines[0])
 	}
-	if lines[1] != "infra/neo4j      > ServerId{257a2499}" {
+	for i, line := range lines {
+		if !strings.HasPrefix(line, gutter) {
+			t.Fatalf("line %d missing service gutter: %q", i, line)
+		}
+	}
+}
+
+func TestFormatServiceLogLinesWrapsByDisplayWidth(t *testing.T) {
+	// Wide runes occupy two display columns each; byte-length wrapping would
+	// break far too early and misalign the continuation gutter.
+	lines := formatServiceLogLines(ServiceLogMsg{
+		Level:   wool.FORWARD,
+		Source:  "svc",
+		Message: "上上上上上上上上上上 tail",
+	}, 40)
+
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapped lines, got %#v", lines)
+	}
+	prefix := fmt.Sprintf("%s > ", padServiceSource("svc"))
+	if lines[0] != prefix+"上上上上上上上上上上" {
+		t.Fatalf("unexpected first line: %q", lines[0])
+	}
+	if lines[1] != prefix+"tail" {
 		t.Fatalf("unexpected continuation line: %q", lines[1])
 	}
 }

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -95,7 +95,7 @@ func TestFormatServiceLogLinesTrimsForwardNewlines(t *testing.T) {
 	}
 }
 
-func TestFormatServiceLogLinesWrapsWithContinuationIndent(t *testing.T) {
+func TestFormatServiceLogLinesWrapsWithContinuationGutter(t *testing.T) {
 	lines := formatServiceLogLines(ServiceLogMsg{
 		Level:   wool.FORWARD,
 		Source:  "infra/neo4j",
@@ -108,7 +108,7 @@ func TestFormatServiceLogLinesWrapsWithContinuationIndent(t *testing.T) {
 	if lines[0] != "infra/neo4j      > This instance is" {
 		t.Fatalf("unexpected first line: %q", lines[0])
 	}
-	if lines[1] != "                   ServerId{257a2499}" {
+	if lines[1] != "infra/neo4j      > ServerId{257a2499}" {
 		t.Fatalf("unexpected continuation line: %q", lines[1])
 	}
 }


### PR DESCRIPTION
## **User description**
Closes #58.

## Summary

- Wrapped log entries lost their service gutter (`codefly          |` / `infra/neo4j      >`) on continuation lines — the remainder was padded with blank spaces, so entries stopped being visually delimited. `wrapLogLine` now repeats the real gutter prefix on every physical line.
- Wrapping measured width with byte length (`len`), so multibyte/wide-rune and ANSI content wrapped at the wrong column and misaligned the gutter. Wrapping now delegates to `ansi.Wrap`, which is grapheme-width and ANSI aware (this also treats `-` as a word-break point, so long hyphenated tokens can wrap at hyphens).

## Test plan

- [x] `go test ./tui/` passes
- [x] `TestFormatServiceLogLinesWrapsWithContinuationGutter` asserts every physical line of a wrapped entry carries the gutter
- [x] Added `TestFormatServiceLogLinesWrapsByDisplayWidth` covering wide-rune (2-column) wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep wrapped log lines aligned and readable**

### What Changed
- Wrapped log entries now keep the service label and separator on every line, instead of switching continuation lines to blank padding.
- Long messages now wrap at visible character width, so wide characters and styled text stay aligned with the gutter.
- Tests now cover both wrapped service gutters and wrapping with wide characters.

### Impact
`✅ Clearer wrapped logs`
`✅ Easier service identification in the TUI`
`✅ Fewer misaligned log lines`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
