### PR TITLE
Add shared reusable CI and release workflows for services

### DIFF
--- a/.github/workflows/go-service-ci.yml
+++ b/.github/workflows/go-service-ci.yml
@@ -1,0 +1,19 @@
+name: go-service-ci
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Verify go.mod and go.sum are tidy
+        run: go mod tidy -diff

--- a/.github/workflows/go-service-release.yml
+++ b/.github/workflows/go-service-release.yml
@@ -1,0 +1,47 @@
+name: go-service-release
+
+on:
+  workflow_call:
+    inputs:
+      setup-run:
+        description: Optional shell command run before the test suite (e.g. docker pull of a test dependency).
+        type: string
+        default: ''
+      goreleaser-version:
+        description: Version constraint passed to goreleaser-action.
+        type: string
+        default: '~> v2'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Setup
+        if: inputs.setup-run != ''
+        run: ${{ inputs.setup-run }}
+      - name: Test
+        run: go test -v ./...
+
+  goreleaser:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: ${{ inputs.goreleaser-version }}
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## **User description**
## Summary
Centralizes the CI and release pipelines that every Go **service** repo (`service-go-grpc`, `-postgres`, `-redis`, `-minio`, `-mssql`, `-dynamodb`, `-temporal`, `-python-fastapi`, `-nextjs`, `-vault`) duplicated. Each service now calls one source of truth in `core`:

- **`.github/workflows/go-service-ci.yml`** — build, vet, and `go mod tidy -diff`. The tidy check fails CI when `go.mod`/`go.sum` drift, which is what silently broke releases after a `core` version bump that skipped `go mod tidy`.
- **`.github/workflows/go-service-release.yml`** — runs the test suite and GoReleaser as **separate jobs**, so GoReleaser releases from a fresh checkout. Sharing one workspace let test artifacts (a read-only `.codefly/` module cache, `testdata/container*`) break GoReleaser's default archive file glob with `globbing failed ... permission denied`, publishing no assets.

## Usage (in each service repo)
```yaml
# ci.yml
jobs:
  ci:
    uses: codefly-dev/core/.github/workflows/go-service-ci.yml@main
```
```yaml
# releaser.yml
jobs:
  release:
    uses: codefly-dev/core/.github/workflows/go-service-release.yml@main
    secrets: inherit   # supplies the org GH_PAT
```
`go-service-release.yml` accepts `with.setup-run` (pre-test shell, e.g. a docker pull) and `with.goreleaser-version` (default `~> v2`).

## Notes
- Reusable workflows only trigger on `workflow_call`, so they don't affect `core`'s own CI (`go.yml` untouched).
- Caller PRs in each service repo reference these `@main` and should merge after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add reusable CI and release workflows for Go services**

### What Changed
- Added a shared CI workflow that builds the service, runs vet, and checks that `go.mod` and `go.sum` are still tidy
- Added a shared release workflow that runs tests first, then publishes a release from a fresh checkout
- Release runs can include an optional pre-test setup command, which helps when a test dependency needs to be prepared before the suite starts

### Impact
`✅ Fewer broken releases from stale Go module files`
`✅ Cleaner release publishing after tests generate files`
`✅ Easier service repo maintenance with one shared workflow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
