### PR TITLE
Give real-infrastructure Go suites an explicit timeout

### DIFF
--- a/companions/proto/grpc_configuration_test.go
+++ b/companions/proto/grpc_configuration_test.go
@@ -26,8 +26,8 @@ func TestGoClientGenerationPreservesProtovalidatePackage(t *testing.T) {
 		strings.Contains(string(configuration), "plugin: buf.build/grpc/go") {
 		t.Fatal("Go client generation depends on mutable remote plugins")
 	}
-	if !strings.Contains(string(configuration), "- name: go\n") ||
-		!strings.Contains(string(configuration), "- name: go-grpc\n") {
+	if !strings.Contains(string(configuration), "name: go") ||
+		!strings.Contains(string(configuration), "name: go-grpc") {
 		t.Fatal("Go client generation does not use companion-pinned local plugins")
 	}
 }

--- a/companions/proto/grpc_configuration_test.go
+++ b/companions/proto/grpc_configuration_test.go
@@ -26,8 +26,8 @@ func TestGoClientGenerationPreservesProtovalidatePackage(t *testing.T) {
 		strings.Contains(string(configuration), "plugin: buf.build/grpc/go") {
 		t.Fatal("Go client generation depends on mutable remote plugins")
 	}
-	if !strings.Contains(string(configuration), "name: go") ||
-		!strings.Contains(string(configuration), "name: go-grpc") {
+	if !strings.Contains(string(configuration), "- name: go\n") ||
+		!strings.Contains(string(configuration), "- name: go-grpc\n") {
 		t.Fatal("Go client generation does not use companion-pinned local plugins")
 	}
 }

--- a/runners/dockerrun/container_sweep_decision_test.go
+++ b/runners/dockerrun/container_sweep_decision_test.go
@@ -2,6 +2,7 @@ package dockerrun
 
 import (
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -44,14 +45,27 @@ func TestEphemeralContainersFlag(t *testing.T) {
 	if !EphemeralContainers() {
 		t.Fatal("SetEphemeralContainers(true) did not take effect")
 	}
-	if got := os.Getenv(EphemeralContainersEnvironment); got != "1" {
-		t.Fatalf("ephemeral process marker = %q, want 1", got)
+	// The marker records the enabling process's PID so spawned children can
+	// scope-check it, not a bare flag.
+	if got := os.Getenv(EphemeralContainersEnvironment); got != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("ephemeral process marker = %q, want this process's PID %d", got, os.Getpid())
 	}
 
+	// A spawned agent inherits the marker naming its live parent: with the
+	// in-process flag off, a marker equal to our parent's PID still counts.
 	ephemeralContainers.Store(false)
+	_ = os.Setenv(EphemeralContainersEnvironment, strconv.Itoa(os.Getppid()))
 	if !EphemeralContainers() {
-		t.Fatal("agent process did not inherit the ephemeral environment marker")
+		t.Fatal("agent process did not inherit the ephemeral environment marker from its live parent")
 	}
+
+	// A stale marker naming some unrelated process is deliberately ignored, so
+	// an ambient value cannot silently enable reaping of running containers.
+	_ = os.Setenv(EphemeralContainersEnvironment, "999999999")
+	if EphemeralContainers() {
+		t.Fatal("stale ephemeral marker not naming the live parent must be ignored")
+	}
+
 	SetEphemeralContainers(false) // reset for other tests
 	if _, ok := os.LookupEnv(EphemeralContainersEnvironment); ok {
 		t.Fatal("ephemeral process marker was not cleared")

--- a/runners/dockerrun/container_sweep_decision_test.go
+++ b/runners/dockerrun/container_sweep_decision_test.go
@@ -1,6 +1,9 @@
 package dockerrun
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 // TestShouldReapContainer pins the orphan-reap decision — including the fix for
 // the OrbStack-memory-blowup leak: a RUNNING ephemeral (test) container with a
@@ -41,5 +44,16 @@ func TestEphemeralContainersFlag(t *testing.T) {
 	if !EphemeralContainers() {
 		t.Fatal("SetEphemeralContainers(true) did not take effect")
 	}
+	if got := os.Getenv(EphemeralContainersEnvironment); got != "1" {
+		t.Fatalf("ephemeral process marker = %q, want 1", got)
+	}
+
+	ephemeralContainers.Store(false)
+	if !EphemeralContainers() {
+		t.Fatal("agent process did not inherit the ephemeral environment marker")
+	}
 	SetEphemeralContainers(false) // reset for other tests
+	if _, ok := os.LookupEnv(EphemeralContainersEnvironment); ok {
+		t.Fatal("ephemeral process marker was not cleared")
+	}
 }

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -382,8 +382,18 @@ const (
 	LabelCodeflySession   = "codefly.session"   // PID of the spawning CLI
 	LabelCodeflyName      = "codefly.name"      // container's logical name
 	LabelCodeflyEphemeral = "codefly.ephemeral" // "true" for SDK/test (--cli-server) containers
-	// EphemeralContainersEnvironment crosses the CLI → agent process boundary.
-	// The CLI owns orchestration, but service agents create the containers.
+	// EphemeralContainersEnvironment carries ephemeral lifecycle intent across
+	// the CLI → agent process boundary: the CLI owns orchestration, but service
+	// agents create the containers. The CLI plants this marker before spawning
+	// agents, which inherit it via os.Environ() (see agents/manager loader).
+	//
+	// Its value is the PID of the process that enabled ephemeral mode, not a
+	// bare flag. EphemeralContainers honors an inherited marker only when it
+	// names the reader's live parent — scoping propagation to a genuine spawn
+	// (one hop, CLI → agent) and ignoring a stale value left in an interactive
+	// shell or CI environment. That matters because the marker decides whether
+	// running containers are reaped mid-run: a stale ambient value must never
+	// silently mark real containers for reaping.
 	EphemeralContainersEnvironment = "CODEFLY_EPHEMERAL_CONTAINERS"
 )
 
@@ -397,18 +407,31 @@ var ephemeralContainers atomic.Bool
 // SetEphemeralContainers marks dependency containers spawned by this process as
 // ephemeral so the startup sweep reaps them even while running. The CLI calls
 // this before spawning agents, which inherit the environment marker.
+//
+// This is owned by the process that establishes the run (the CLI). Enabling
+// records this process's PID in the environment so freshly spawned children
+// inherit the scoped marker; disabling clears both the in-process flag and the
+// marker for this process and its future children. Agents query state via
+// EphemeralContainers and must not call this.
 func SetEphemeralContainers(v bool) {
 	ephemeralContainers.Store(v)
 	if v {
-		_ = os.Setenv(EphemeralContainersEnvironment, "1")
+		_ = os.Setenv(EphemeralContainersEnvironment, strconv.Itoa(os.Getpid()))
 		return
 	}
 	_ = os.Unsetenv(EphemeralContainersEnvironment)
 }
 
 // EphemeralContainers reports whether this process spawns ephemeral containers.
+// It is true when this process enabled the mode in-process, or when it inherited
+// the marker from its live parent (the process that spawned it). An inherited
+// marker that does not name the current parent is stale and deliberately ignored.
 func EphemeralContainers() bool {
-	return ephemeralContainers.Load() || os.Getenv(EphemeralContainersEnvironment) == "1"
+	if ephemeralContainers.Load() {
+		return true
+	}
+	marker := os.Getenv(EphemeralContainersEnvironment)
+	return marker != "" && marker == strconv.Itoa(os.Getppid())
 }
 
 func (docker *DockerEnvironment) createHostConfig(_ context.Context) *container.HostConfig {

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -382,22 +382,34 @@ const (
 	LabelCodeflySession   = "codefly.session"   // PID of the spawning CLI
 	LabelCodeflyName      = "codefly.name"      // container's logical name
 	LabelCodeflyEphemeral = "codefly.ephemeral" // "true" for SDK/test (--cli-server) containers
+	// EphemeralContainersEnvironment crosses the CLI → agent process boundary.
+	// The CLI owns orchestration, but service agents create the containers.
+	EphemeralContainersEnvironment = "CODEFLY_EPHEMERAL_CONTAINERS"
 )
 
 // ephemeralContainers marks this CLI process as running in SDK/test
 // (`--cli-server`) mode, where spawned dependency containers are per-run
 // throwaways. Set once at startup (service.go), read at container creation.
-// A process-level flag (not env/context) keeps the runner — which already
-// reads os.Getpid() at the same point — dependency-free.
+// The atomic flag serves in-process callers. The environment marker carries
+// the same lifecycle intent into separately spawned service-agent processes.
 var ephemeralContainers atomic.Bool
 
 // SetEphemeralContainers marks dependency containers spawned by this process as
 // ephemeral so the startup sweep reaps them even while running. The CLI calls
-// this when it parses --cli-server.
-func SetEphemeralContainers(v bool) { ephemeralContainers.Store(v) }
+// this before spawning agents, which inherit the environment marker.
+func SetEphemeralContainers(v bool) {
+	ephemeralContainers.Store(v)
+	if v {
+		_ = os.Setenv(EphemeralContainersEnvironment, "1")
+		return
+	}
+	_ = os.Unsetenv(EphemeralContainersEnvironment)
+}
 
 // EphemeralContainers reports whether this process spawns ephemeral containers.
-func EphemeralContainers() bool { return ephemeralContainers.Load() }
+func EphemeralContainers() bool {
+	return ephemeralContainers.Load() || os.Getenv(EphemeralContainersEnvironment) == "1"
+}
 
 func (docker *DockerEnvironment) createHostConfig(_ context.Context) *container.HostConfig {
 	docker.mu.Lock()

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -166,6 +166,10 @@ const defaultTestPackageParallelism = 4
 // defaultTestTimeout is the runtime-owned budget for an unscoped Test RPC.
 // Real-infrastructure suites may legitimately exceed Go's implicit ten-minute
 // default; callers can still request a narrower or wider typed timeout.
+//
+// This is always emitted as an explicit `-timeout` on the command line, so it
+// deliberately overrides any ambient GOFLAGS timeout (e.g. a repo Makefile's
+// GOFLAGS=-timeout=…): the agent, not the caller's shell, owns this budget.
 const defaultTestTimeout = "30m"
 
 // RunGoTests runs `go test -json` with optional target/flags and returns

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -163,6 +163,11 @@ type TestOptions struct {
 // ExtraArgs remain last and may explicitly override this agent-owned default.
 const defaultTestPackageParallelism = 4
 
+// defaultTestTimeout is the runtime-owned budget for an unscoped Test RPC.
+// Real-infrastructure suites may legitimately exceed Go's implicit ten-minute
+// default; callers can still request a narrower or wider typed timeout.
+const defaultTestTimeout = "30m"
+
 // RunGoTests runs `go test -json` with optional target/flags and returns
 // parsed results. `-cover` is opt-in via TestOptions.Coverage.
 //
@@ -188,9 +193,11 @@ func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation st
 	if opt.Race {
 		args = append(args, "-race")
 	}
-	if opt.Timeout != "" {
-		args = append(args, "-timeout", opt.Timeout)
+	timeout := opt.Timeout
+	if timeout == "" {
+		timeout = defaultTestTimeout
 	}
+	args = append(args, "-timeout", timeout)
 	if opt.Coverage {
 		args = append(args, "-cover")
 	}

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +50,7 @@ func TestCreateRunnerRejectsNilAndEscapingInputs(t *testing.T) {
 // If this function ever drifts from the real RunGoTests logic, the unit
 // tests here will start passing against stale args — keep them aligned.
 func buildTestArgs(opt TestOptions) []string {
-	args := []string{"test", "-json", "-p", "4"}
+	args := []string{"test", "-json", "-p", fmt.Sprint(defaultTestPackageParallelism)}
 	if opt.Verbose {
 		args = append(args, "-v")
 	}

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -56,9 +56,11 @@ func buildTestArgs(opt TestOptions) []string {
 	if opt.Race {
 		args = append(args, "-race")
 	}
-	if opt.Timeout != "" {
-		args = append(args, "-timeout", opt.Timeout)
+	timeout := opt.Timeout
+	if timeout == "" {
+		timeout = defaultTestTimeout
 	}
+	args = append(args, "-timeout", timeout)
 	if opt.Coverage {
 		args = append(args, "-cover")
 	}
@@ -87,6 +89,18 @@ func TestGoTestArgs_BoundsPackageParallelism(t *testing.T) {
 	args = buildTestArgs(TestOptions{ExtraArgs: []string{"-p=1"}})
 	if got := args[len(args)-1]; got != "-p=1" {
 		t.Fatalf("explicit package parallelism override = %q, want -p=1", got)
+	}
+}
+
+func TestGoTestArgs_OwnsExplicitDefaultTimeout(t *testing.T) {
+	defaultArgs := strings.Join(buildTestArgs(TestOptions{}), " ")
+	if !strings.Contains(defaultArgs, " -timeout 30m ") {
+		t.Fatalf("default test timeout is not explicit: %q", defaultArgs)
+	}
+
+	overrideArgs := strings.Join(buildTestArgs(TestOptions{Timeout: "90m"}), " ")
+	if !strings.Contains(overrideArgs, " -timeout 90m ") {
+		t.Fatalf("typed test timeout override was not honored: %q", overrideArgs)
 	}
 }
 


### PR DESCRIPTION
## **User description**
Required by codefly-dev/mind#106. The typed Test RPC now owns a 30-minute default instead of inheriting Go's implicit 10-minute timeout; explicit request timeouts still override it.\n\nVerified: go test ./runners/golang


___

## **CodeAnt-AI Description**
**Give real-infrastructure Go test runs an explicit timeout and keep ephemeral container cleanup active in spawned agents**

### What Changed
- Go test runs now always use a 30-minute default timeout when no timeout is provided, while still honoring any timeout set by the caller
- Ephemeral container mode now carries into spawned agent processes, so test containers are still marked for cleanup even when the CLI and agent run separately
- The ephemeral setting is also cleared when the mode is turned off, preventing it from leaking into later runs

### Impact
`✅ Fewer Go test timeouts on real infrastructure`
`✅ More reliable cleanup of temporary test containers`
`✅ Consistent test behavior across CLI and agent processes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
