### PR TITLE
Keep materialized Nix environments GC-rooted

### DIFF
--- a/runners/base/nix_materialize_integration_test.go
+++ b/runners/base/nix_materialize_integration_test.go
@@ -118,6 +118,38 @@ func TestNixMaterialize_PinsGoCache(t *testing.T) {
 	}
 }
 
+// TestNixMaterialize_CreatesPersistentGCRoot proves materialization protects
+// its complete store closure from Nix garbage collection. Long-lived services
+// such as Postgres load extension libraries after startup; an exported PATH
+// alone does not keep those libraries alive.
+func TestNixMaterialize_CreatesPersistentGCRoot(t *testing.T) {
+	dir := requireWorkingNix(t)
+	ctx := context.Background()
+	cacheDir := t.TempDir()
+
+	env, err := base.NewNixEnvironment(ctx, dir)
+	if err != nil {
+		t.Fatalf("NewNixEnvironment: %v", err)
+	}
+	env.WithCacheDir(cacheDir)
+	if err := env.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	profile := filepath.Join(cacheDir, "nix-devshell-profile")
+	if _, err := os.Stat(profile); err != nil {
+		t.Fatalf("materialized Nix profile is not a live GC root: %v", err)
+	}
+	query := exec.Command("nix-store", "-qR", profile)
+	closure, err := query.CombinedOutput()
+	if err != nil {
+		t.Fatalf("query materialized profile closure: %v\n%s", err, closure)
+	}
+	if !strings.Contains(string(closure), "coreutils") {
+		t.Fatalf("materialized profile closure does not contain the dev-shell package:\n%s", closure)
+	}
+}
+
 // TestNixMaterialize_FallsBackGracefullyOnBadNix — if we gave Nix a
 // flake that fails to evaluate, Init must NOT return an error. Instead
 // it logs a warning and leaves materialized=nil, which makes subsequent

--- a/runners/base/nix_runner.go
+++ b/runners/base/nix_runner.go
@@ -37,9 +37,10 @@ type NixEnvironment struct {
 	dir       string
 	flakePath string
 
-	// mu guards envs and materialized. Init/materialization can overlap with
-	// process construction in orchestration, while environment overrides may be
-	// appended from another goroutine.
+	// mu guards envs, materialized, profilePath, and ephemeralProfileRoot.
+	// Init/materialization can overlap with process construction in
+	// orchestration, while environment overrides may be appended from another
+	// goroutine.
 	mu   sync.RWMutex
 	envs []*resources.EnvironmentVariable
 
@@ -55,6 +56,14 @@ type NixEnvironment struct {
 	// `nix print-dev-env` entirely if nothing has changed. Debug: the
 	// cached env is inspectable on disk.
 	cacheDir string
+
+	// profilePath is a Nix profile that roots every store path referenced by
+	// the materialized dev shell. Capturing only the exported environment is
+	// insufficient: Nix is then free to garbage-collect binaries and shared
+	// libraries while long-lived children are still using them. The profile is
+	// persistent when cacheDir is set and process-scoped otherwise.
+	profilePath          string
+	ephemeralProfileRoot string
 
 	out io.Writer
 	ctx context.Context
@@ -110,11 +119,16 @@ func (nix *NixEnvironment) Init(ctx context.Context) error {
 	nix.ctx = ctx
 
 	// Fast path: reload a previously-materialized env from disk if the
-	// flake hasn't changed. Skips `nix print-dev-env --json` entirely.
+	// flake hasn't changed and its GC-rooting profile still exists. Skips
+	// `nix print-dev-env --json` entirely.
 	if nix.cacheDir != "" {
 		if loaded, err := nix.loadCachedMaterialization(ctx); err == nil && loaded != nil {
+			// loadCachedMaterialization only returns a hit when the persistent
+			// profile still exists, so recording it upholds the invariant that
+			// profilePath names the live GC root whenever materialized is set.
 			nix.mu.Lock()
 			nix.materialized = loaded
+			nix.profilePath = nix.persistentProfilePath()
 			nix.mu.Unlock()
 			wool.Get(ctx).In("NixEnvironment.Init").
 				Info("reloaded materialized nix env from cache",
@@ -124,10 +138,13 @@ func (nix *NixEnvironment) Init(ctx context.Context) error {
 	}
 
 	if err := nix.materialize(ctx); err != nil {
-		// Materialization is an optimization; failure falls back to
-		// wrapped `nix develop --command` on each call.
+		// Materialization is an optimization; failure falls back to wrapped
+		// `nix develop --command` on each call. Warn (not silent) because this
+		// disables both the fast path and GC-rooting — e.g. a `nix` too old to
+		// accept `print-dev-env --profile` degrades here rather than erroring,
+		// and only this log distinguishes it from a healthy run.
 		wool.Get(ctx).In("NixEnvironment.Init").
-			Warn("could not materialize nix dev env; falling back to nix-develop-per-call",
+			Warn("could not materialize nix dev env; fast path and GC-rooting disabled, falling back to nix-develop-per-call",
 				wool.ErrField(err))
 		return nil
 	}
@@ -195,6 +212,18 @@ func (nix *NixEnvironment) cacheFilePath() string {
 	return filepath.Join(nix.cacheDir, "nix-devshell.json")
 }
 
+// nixDevShellProfileName is the basename of the Nix profile that GC-roots the
+// materialized dev shell, stored beside the serialized env in cacheDir. The
+// load path checks it exists; materialize creates/updates it. Kept in one place
+// so those two never drift apart.
+const nixDevShellProfileName = "nix-devshell-profile"
+
+// persistentProfilePath is the GC-root profile path for a cache-backed
+// environment. Only meaningful when cacheDir is set.
+func (nix *NixEnvironment) persistentProfilePath() string {
+	return filepath.Join(nix.cacheDir, nixDevShellProfileName)
+}
+
 // loadCachedMaterialization returns the previously-materialized env iff
 // it exists AND the flake fingerprint still matches. Any mismatch, read
 // error, or JSON parse error returns (nil, nil) — we fall through to a
@@ -205,6 +234,13 @@ func (nix *NixEnvironment) loadCachedMaterialization(ctx context.Context) (map[s
 	data, err := os.ReadFile(nix.cacheFilePath())
 	if err != nil {
 		return nil, nil // miss, not an error
+	}
+	// The environment cache contains store paths but is not itself a Nix GC
+	// root. A missing/broken profile means those paths are no longer protected,
+	// so rematerialize instead of launching children against collectable state.
+	if _, err := os.Stat(nix.persistentProfilePath()); err != nil {
+		w.Trace("materialization profile missing; invalidating cache")
+		return nil, nil
 	}
 	var payload cachedEnvPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
@@ -270,10 +306,14 @@ func (nix *NixEnvironment) saveCachedMaterialization(ctx context.Context) error 
 func (nix *NixEnvironment) materialize(ctx context.Context) error {
 	w := wool.Get(ctx).In("NixEnvironment.materialize", wool.DirField(nix.dir))
 
+	profile, err := nix.materializationProfile()
+	if err != nil {
+		return err
+	}
 	// #nosec G204
 	cmd := exec.CommandContext(ctx,
 		"nix", "--extra-experimental-features", "nix-command flakes",
-		"print-dev-env", "--json", nix.flakeRef())
+		"print-dev-env", "--json", "--profile", profile, nix.flakeRef())
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -326,6 +366,32 @@ func (nix *NixEnvironment) materialize(ctx context.Context) error {
 	return nil
 }
 
+// materializationProfile returns a profile path that keeps the dev shell's
+// complete Nix closure alive. Persistent caches use a stable profile beside
+// the serialized environment; uncached environments use an owner-scoped
+// temporary root removed by Shutdown.
+func (nix *NixEnvironment) materializationProfile() (string, error) {
+	nix.mu.Lock()
+	defer nix.mu.Unlock()
+	if nix.profilePath != "" {
+		return nix.profilePath, nil
+	}
+	if nix.cacheDir != "" {
+		if err := os.MkdirAll(nix.cacheDir, 0o755); err != nil {
+			return "", fmt.Errorf("create nix materialization cache: %w", err)
+		}
+		nix.profilePath = nix.persistentProfilePath()
+		return nix.profilePath, nil
+	}
+	root, err := os.MkdirTemp("", "codefly-nix-profile-*")
+	if err != nil {
+		return "", fmt.Errorf("create nix materialization profile root: %w", err)
+	}
+	nix.ephemeralProfileRoot = root
+	nix.profilePath = filepath.Join(root, "profile")
+	return nix.profilePath, nil
+}
+
 // parseNixDevEnv parses `nix print-dev-env --json` output into a flat
 // string map. Only `exported` and `var` scalar entries are kept —
 // bash arrays, associative arrays, and functions are dropped because
@@ -372,7 +438,15 @@ func (nix *NixEnvironment) Stop(context.Context) error {
 }
 
 func (nix *NixEnvironment) Shutdown(context.Context) error {
-	return nil
+	nix.mu.Lock()
+	root := nix.ephemeralProfileRoot
+	nix.ephemeralProfileRoot = ""
+	nix.profilePath = ""
+	nix.mu.Unlock()
+	if root == "" {
+		return nil
+	}
+	return os.RemoveAll(root)
 }
 
 // NewProcess creates a process that runs under the Nix devShell.

--- a/runners/base/nix_runner_internal_test.go
+++ b/runners/base/nix_runner_internal_test.go
@@ -301,6 +301,9 @@ func TestSaveAndLoadCachedMaterialization(t *testing.T) {
 	if err := nix.saveCachedMaterialization(ctx); err != nil {
 		t.Fatalf("save: %v", err)
 	}
+	if err := os.Mkdir(filepath.Join(cacheDir, nixDevShellProfileName), 0o755); err != nil {
+		t.Fatalf("create materialization profile fixture: %v", err)
+	}
 
 	// Fresh instance — simulates a new agent process reading the cache.
 	fresh := &NixEnvironment{dir: dir, cacheDir: cacheDir}
@@ -393,6 +396,80 @@ func TestLoadCachedMaterialization_MissingFileIsSilentMiss(t *testing.T) {
 	}
 	if loaded != nil {
 		t.Errorf("missing cache should return nil map, got %v", loaded)
+	}
+}
+
+// TestLoadCachedMaterialization_RejectsMissingProfile proves a serialized
+// environment cannot outlive its Nix GC root. Without this check, a later
+// process can reload PATH entries whose packages were already collected.
+func TestLoadCachedMaterialization_RejectsMissingProfile(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cacheDir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "flake.nix"), "{ x = 1; }")
+
+	saver := &NixEnvironment{
+		dir:          dir,
+		cacheDir:     cacheDir,
+		materialized: map[string]string{"PATH": "/nix/store/collectable/bin"},
+	}
+	if err := saver.saveCachedMaterialization(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := &NixEnvironment{dir: dir, cacheDir: cacheDir}
+	loaded, err := fresh.loadCachedMaterialization(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded != nil {
+		t.Fatalf("cache without a materialization profile must miss, got %v", loaded)
+	}
+}
+
+// TestMaterializationProfile_EphemeralRootRemovedOnShutdown proves an uncached
+// environment roots its dev shell under an owner-scoped temp directory, that
+// the path is idempotent, and that Shutdown removes the directory and clears
+// the in-memory state — so a short-lived environment leaves no leaked GC root.
+func TestMaterializationProfile_EphemeralRootRemovedOnShutdown(t *testing.T) {
+	nix := &NixEnvironment{dir: t.TempDir()} // no cacheDir => ephemeral profile
+
+	profile, err := nix.materializationProfile()
+	if err != nil {
+		t.Fatalf("materializationProfile: %v", err)
+	}
+	root := nix.ephemeralProfileRoot
+	if root == "" {
+		t.Fatal("ephemeral profile root was not recorded")
+	}
+	if filepath.Dir(profile) != root {
+		t.Fatalf("profile %q is not under ephemeral root %q", profile, root)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("ephemeral profile root should exist after materialization: %v", err)
+	}
+
+	// Idempotent: a second call reuses the same path and does not allocate a
+	// second temp root.
+	again, err := nix.materializationProfile()
+	if err != nil {
+		t.Fatalf("second materializationProfile: %v", err)
+	}
+	if again != profile {
+		t.Fatalf("materializationProfile not idempotent: %q != %q", again, profile)
+	}
+	if nix.ephemeralProfileRoot != root {
+		t.Fatalf("ephemeral root changed on repeat call: %q != %q", nix.ephemeralProfileRoot, root)
+	}
+
+	if err := nix.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("ephemeral profile root must be removed by Shutdown, stat err = %v", err)
+	}
+	if nix.ephemeralProfileRoot != "" || nix.profilePath != "" {
+		t.Fatal("Shutdown must clear ephemeral profile state")
 	}
 }
 


### PR DESCRIPTION
## Summary
- record materialized Nix dev shells in a persistent profile
- invalidate cached environments when their GC root is missing
- clean up ephemeral profiles on shutdown
- add unit and real-Nix regression coverage

## Why
Long-lived services execute directly from a cached materialized environment. Without a Nix profile, garbage collection can remove deferred shared libraries (observed with Postgres pgvector during Mind benchmark certification) while the service is still running.

## Verification
- `go test ./runners/base -count=1`