### PR TITLE
Run proto companion as host user; fix non-root output (#67)

### DIFF
--- a/companions/proto/Dockerfile
+++ b/companions/proto/Dockerfile
@@ -54,11 +54,16 @@ FROM codeflydev/codefly:0.0.3
 #   - Go-built plugins (buf, protoc-gen-*) ARE static (CGO_ENABLED=0
 #     by default for `go install`), so we COPY just those binaries
 #     without bringing the Go runtime.
+# HOME=/tmp so the companion works when run as an arbitrary non-root UID
+# (codefly runs it as the host user on Linux CI). buf and npm/npx write
+# their caches under $HOME; the default /root isn't writable by that user.
+ENV HOME=/tmp
+
 RUN apk add --no-cache nodejs npm protobuf go && \
     npm install -g \
         openapi-typescript@7.13.0 \
         swagger2openapi@7.0.8 \
-        @bufbuild/protoc-gen-es@2.11.0 && \
+        @bufbuild/protoc-gen-es@2.12.0 && \
     npm cache clean --force
 
 COPY --from=builder /go/bin/buf /usr/local/bin/

--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -116,6 +117,14 @@ func (g *Buf) Generate(ctx context.Context) error {
 	if runner.Backend() == companion.BackendDocker {
 		runner.WithMount(g.Dir, "/workspace")
 		runner.WithWorkDir("/workspace/proto")
+		// On Linux, containers default to root, so buf writes the generated
+		// tree as root into the bind mount. A non-root host (e.g. a CI
+		// runner) then can't read it back. Run as the host user so the
+		// output is host-owned. Docker Desktop on macOS remaps bind-mount
+		// ownership to the host user already, so this is Linux-only.
+		if runtime.GOOS == "linux" {
+			runner.WithUser(fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()))
+		}
 	} else {
 		runner.WithWorkDir(path.Join(g.Dir, "proto"))
 	}

--- a/runners/companion/companion.go
+++ b/runners/companion/companion.go
@@ -37,6 +37,12 @@ type CompanionRunner interface {
 	// WithWorkDir sets the working directory for all processes.
 	WithWorkDir(dir string)
 
+	// WithUser runs the companion as the given "UID[:GID]" user.
+	// Docker: sets the container user so bind-mounted output is owned by
+	// that user rather than root. Nix/Local: no-op (already runs as the
+	// host user).
+	WithUser(user string)
+
 	// WithPause keeps the environment alive after Init.
 	// Docker: runs `sleep infinity`. Nix/Local: no-op.
 	WithPause()
@@ -156,6 +162,10 @@ func (d *dockerCompanion) WithWorkDir(dir string) {
 	d.inner.WithWorkDir(dir)
 }
 
+func (d *dockerCompanion) WithUser(user string) {
+	d.inner.WithUser(user)
+}
+
 func (d *dockerCompanion) WithPause() {
 	d.inner.WithPause()
 }
@@ -202,6 +212,9 @@ func (l *localCompanion) WithPortMapping(_ context.Context, _, _ uint16) {}
 func (l *localCompanion) WithWorkDir(dir string) {
 	l.workDir = dir
 }
+
+// WithUser is a no-op for local runners -- already runs as the host user.
+func (l *localCompanion) WithUser(_ string) {}
 
 // WithPause is a no-op for local runners.
 func (l *localCompanion) WithPause() {}
@@ -255,6 +268,9 @@ func (n *nixCompanion) WithPortMapping(_ context.Context, _, _ uint16) {}
 func (n *nixCompanion) WithWorkDir(dir string) {
 	n.workDir = dir
 }
+
+// WithUser is a no-op for Nix runners -- already runs as the host user.
+func (n *nixCompanion) WithUser(_ string) {}
 
 // WithPause is a no-op for Nix runners.
 func (n *nixCompanion) WithPause() {}

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -44,6 +44,10 @@ type DockerEnvironment struct {
 
 	cmd   []string
 	pause bool
+	// user, when set, runs the container (and its execs) as this UID[:GID].
+	// Used to make files a container writes to a bind mount owned by the
+	// invoking host user rather than root — see WithUser.
+	user string
 
 	// mu guards envs / portMappings / mounts which may be mutated via
 	// WithEnvironmentVariables / WithPortMapping / WithMount while another
@@ -334,6 +338,7 @@ func (docker *DockerEnvironment) createContainerConfig(ctx context.Context) *con
 	docker.mu.Unlock()
 	config := &container.Config{
 		Image: docker.image.FullName(),
+		User:  docker.user,
 		Env:   resources.EnvironmentVariableAsStrings(envCopy),
 		// Service containers are background processes, not interactive terminal
 		// sessions. A pseudo-TTY merges stdout/stderr, changes application
@@ -569,6 +574,14 @@ func (docker *DockerEnvironment) WithPublicPorts() *DockerEnvironment {
 
 func (docker *DockerEnvironment) WithPause() {
 	docker.pause = true
+}
+
+// WithUser runs the container as the given user, in Docker's "UID[:GID]"
+// form. Bind-mounted output is then owned by that user instead of root,
+// so a non-root host process can read (and clean up) what the container
+// wrote. Empty string keeps the image's default user.
+func (docker *DockerEnvironment) WithUser(user string) {
+	docker.user = user
 }
 
 func ContainerName(name string) string {

--- a/runners/dockerrun/docker_user_test.go
+++ b/runners/dockerrun/docker_user_test.go
@@ -1,0 +1,30 @@
+package dockerrun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+)
+
+// TestCreateContainerConfig_User verifies WithUser is threaded into the
+// container config so the container (and its execs) run as the given user.
+// This is what lets the proto companion write bind-mounted output owned by a
+// non-root host user rather than root. No docker daemon needed —
+// createContainerConfig just builds the container.Config struct.
+func TestCreateContainerConfig_User(t *testing.T) {
+	env := &DockerEnvironment{
+		name:  "proto",
+		image: &resources.DockerImage{Name: "codeflydev/proto", Tag: "0.0.11"},
+	}
+	ctx := context.Background()
+
+	if cfg := env.createContainerConfig(ctx); cfg.User != "" {
+		t.Fatalf("expected default (empty) user, got %q", cfg.User)
+	}
+
+	env.WithUser("1000:1000")
+	if cfg := env.createContainerConfig(ctx); cfg.User != "1000:1000" {
+		t.Fatalf("expected user 1000:1000, got %q", cfg.User)
+	}
+}


### PR DESCRIPTION
Closes #67.

## Summary
- The proto companion container defaulted to **root** on Linux, so `buf` wrote the generated tree as root into the bind mount and a non-root CI runner couldn't read it back (`inventory staged directory … permission denied`). We now run the companion as the invoking **host user** on Linux, so generated output is host-owned. Docker Desktop on macOS already remaps bind-mount ownership to the host user, which is why local dev worked but Codefly-native CI didn't — so the change is Linux-gated.
- Gave the image a writable `HOME=/tmp` (the Nix flake already did) so `buf`/`npm` caches work when the container runs as an arbitrary UID.
- Aligned the `protoc-gen-es` pin `2.11.0 → 2.12.0` to match `0.0.10`, so bumping the companion doesn't drift consumers' checked-in TS (issue ask #3).

Defect #1 from the issue (missing `protoc-gen-go` / `protoc-gen-go-grpc`) was already fixed in the `0.0.11` Dockerfile source, so no change there.

## Not addressed here (operational, outside this repo)
- **Ask #1 — publishing `codeflydev/proto:0.0.11` to Docker Hub and keeping it published.** That's a registry/credentials step, not a code change; this PR makes the image *correct* so that when it's published it ships working, non-root-readable output. Tracked separately for the CLI side (adding a first-class publish command + CI so embedded companion tags always exist in the registry).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./runners/companion/ ./companions/proto/ ./runners/dockerrun/`
- [x] `go test ./runners/dockerrun/ ./companions/proto/` (incl. new `docker_user_test.go` asserting `WithUser` reaches `container.Config.User`)
- [ ] Rebuild + publish `codeflydev/proto:0.0.11` and re-run codefly-dev/module-saas-starter#3 CI to confirm the generated tree is readable on a non-root runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)