### PR TITLE
Typed runtime evidence and clean validation artifacts

### DIFF
--- a/code/server.go
+++ b/code/server.go
@@ -785,12 +785,26 @@ func (s *DefaultCodeServer) untrackedWorkingTreeDiff(ctx context.Context, pathFi
 		if p == "" {
 			continue
 		}
+		if isGeneratedUntrackedPath(p) {
+			continue
+		}
 		if pathFilter != "" && p != pathFilter && !strings.HasPrefix(p, strings.TrimSuffix(pathFilter, "/")+"/") {
 			continue
 		}
 		blocks.WriteString(s.gitDiffNoIndexNewFile(ctx, p))
 	}
 	return blocks.String()
+}
+
+func isGeneratedUntrackedPath(path string) bool {
+	for _, component := range strings.Split(filepath.ToSlash(path), "/") {
+		switch component {
+		case "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache",
+			"node_modules", "vendor", "target", "dist", "build", ".cache":
+			return true
+		}
+	}
+	return false
 }
 
 // gitDiffNoIndexNewFile shells `git diff --no-index -- /dev/null <path>`.

--- a/code/server_test.go
+++ b/code/server_test.go
@@ -39,6 +39,30 @@ func TestListFilesSkipsGeneratedDependencyTrees(t *testing.T) {
 	}
 }
 
+func TestGeneratedUntrackedPathClassification(t *testing.T) {
+	for _, path := range []string{
+		"__pycache__/module.pyc",
+		"pkg/.pytest_cache/state",
+		"web/node_modules/pkg/index.js",
+		"crate/target/debug/app",
+		"nested/build/output.bin",
+	} {
+		if !isGeneratedUntrackedPath(path) {
+			t.Errorf("isGeneratedUntrackedPath(%q) = false, want true", path)
+		}
+	}
+	for _, path := range []string{
+		"main.py",
+		"src/cache/client.go",
+		"build.go",
+		"distribution/readme.md",
+	} {
+		if isGeneratedUntrackedPath(path) {
+			t.Errorf("isGeneratedUntrackedPath(%q) = true, want false", path)
+		}
+	}
+}
+
 type serverTestCase struct {
 	name      string
 	setupFunc func(t *testing.T) (string, *DefaultCodeServer)

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -178,10 +178,16 @@ const defaultTestTimeout = "30m"
 // When env.LocalCacheDir(ctx) is non-empty, the full raw stdout from
 // `go test -json` is persisted to <cacheDir>/last-test.json after the
 // run regardless of pass/fail. This gives operators a debug surface
-// richer than the TestSummary we return to the caller: failing tests
+// richer than the TestExecution we return to the caller: failing tests
 // can be re-parsed by hand, exit-2 collection errors are recoverable,
 // and the exact set of events the agent saw is reproducible.
-func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...TestOptions) (*TestSummary, error) {
+type TestExecution struct {
+	*TestSummary
+	Structured *StructuredTestRun
+	RawOutput  string
+}
+
+func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation string, envVars []*resources.EnvironmentVariable, opts ...TestOptions) (*TestExecution, error) {
 	_ = env.Env().WithBinary("codefly")
 
 	args := []string{"test", "-json", "-p", fmt.Sprint(defaultTestPackageParallelism)}
@@ -262,6 +268,11 @@ func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation st
 	runErr := proc.Run(ctx)
 	rawOutput := capture.String()
 	summary := ParseTestJSON(rawOutput)
+	execution := &TestExecution{
+		TestSummary: summary,
+		Structured:  ParseTestJSONStructured(rawOutput),
+		RawOutput:   rawOutput,
+	}
 
 	// Persist the raw JSON stream for post-mortem. Best-effort —
 	// failure here should never mask a test result. Path is documented
@@ -275,9 +286,9 @@ func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation st
 	}
 
 	if runErr != nil {
-		return summary, runErr
+		return execution, runErr
 	}
-	return summary, nil
+	return execution, nil
 }
 
 func goTestWorkDir(sourceLocation string) string {

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -273,6 +273,12 @@ func TestRunGoTestsStandaloneModuleIgnoresParentWorkspace(t *testing.T) {
 	if summary.Passed != 1 || summary.Failed != 0 {
 		t.Fatalf("summary = %+v, want one passing test", summary)
 	}
+	if summary.Structured == nil || len(summary.Structured.Suites) != 1 {
+		t.Fatalf("structured summary = %+v, want one package suite", summary.Structured)
+	}
+	if !strings.Contains(summary.RawOutput, `"Test":"TestGeneratedService"`) {
+		t.Fatalf("raw output does not contain the executed test event: %q", summary.RawOutput)
+	}
 }
 
 func TestCombineRunRegex(t *testing.T) {

--- a/runners/python/formula_run.go
+++ b/runners/python/formula_run.go
@@ -364,19 +364,21 @@ func RunFormulaStructured(ctx context.Context, sourceDir string, spec TestFormul
 		spec.venvPython = venvPython
 	}
 
+	// Formula evidence and interpreter caches are adapter artifacts, not source.
+	// Allocate one external directory for the full run regardless of output
+	// format so unittest-based formulas also cannot leave __pycache__ behind.
+	runtimeDir, err := os.MkdirTemp("", "codefly-python-formula-*")
+	if err != nil {
+		return nil, fmt.Errorf("create formula evidence directory: %w", err)
+	}
+	defer os.RemoveAll(runtimeDir)
+
 	var junitFile string
 	if spec.Output == OutputJUnitXML {
-		junitDir := filepath.Join(sourceDir, ".cache")
-		if err := os.MkdirAll(junitDir, 0o755); err != nil {
-			junitDir = os.TempDir()
-		}
-		junitFile = filepath.Join(junitDir, fmt.Sprintf("formula-junit-%d.xml", time.Now().UnixNano()))
-		// cmd.Dir may differ from the caller's cwd (spec.Cwd) — make the junit
-		// path absolute so pytest writes it where we read it.
-		if abs, err := filepath.Abs(junitFile); err == nil {
-			junitFile = abs
-		}
-		defer os.Remove(junitFile)
+		junitFile = filepath.Join(runtimeDir, fmt.Sprintf("formula-junit-%d.xml", time.Now().UnixNano()))
+		// JUnit output is emitted by pytest. Disable its checkout-local cache;
+		// the run remains fully described by the structured response.
+		spec.ExtraArgs = append(spec.ExtraArgs, "-p", "no:cacheprovider")
 	}
 
 	args := BuildUvArgs(spec, junitFile)
@@ -421,7 +423,10 @@ func RunFormulaStructured(ctx context.Context, sourceDir string, spec TestFormul
 		cmd.Stdout = &raw
 		cmd.Stderr = &raw
 	}
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(),
+		"PYTHONPYCACHEPREFIX="+filepath.Join(runtimeDir, "pycache"),
+		"COVERAGE_FILE="+filepath.Join(runtimeDir, "coverage"),
+	)
 	if probe {
 		// Force unbuffered child output so the materialization marker reaches the
 		// watcher immediately — python BLOCK-buffers stdout to a pipe, which
@@ -441,7 +446,7 @@ func RunFormulaStructured(ctx context.Context, sourceDir string, spec TestFormul
 
 	var run *StructuredTestRun
 	if spec.Output == OutputJUnitXML {
-		xmlBytes, _ := os.ReadFile(junitFile) //nolint:gosec // path under sourceDir
+		xmlBytes, _ := os.ReadFile(junitFile) //nolint:gosec // private temporary path
 		run = ParsePytestJUnit(string(xmlBytes), scrapeCoverageFromOutput(rawStr))
 	} else {
 		run = ParseUnittestText(rawStr)

--- a/runners/python/formula_run_test.go
+++ b/runners/python/formula_run_test.go
@@ -242,6 +242,9 @@ func TestRunFormulaStructured_CwdMovesRunDirectory(t *testing.T) {
 	if run.caseCount() != 1 {
 		t.Fatalf("expected 1 executed case, got %d\nraw: %s", run.caseCount(), run.RawOutput)
 	}
+	if _, err := os.Stat(filepath.Join(root, "tests", "__pycache__")); !os.IsNotExist(err) {
+		t.Fatalf("formula run generated source-tree bytecode cache: %v", err)
+	}
 
 	// Same formula WITHOUT cwd: test_sample is not importable from the repo
 	// root — unittest surfaces it as a loader-error case (or nothing at all).

--- a/runners/python/pytest.go
+++ b/runners/python/pytest.go
@@ -177,17 +177,29 @@ func RunPythonTestsStructured(ctx context.Context, sourceDir string, envVars []*
 		opt = opts[0]
 	}
 
-	// Allocate the JUnit output path under the project's .cache dir
-	// (gitignored by default). Falls back to system temp when the
-	// project tree isn't writable.
-	junitDir := filepath.Join(sourceDir, ".cache")
-	if err := os.MkdirAll(junitDir, 0o755); err != nil {
-		junitDir = os.TempDir()
+	// Runtime evidence is an adapter artifact, not project source. Keep the
+	// JUnit file outside the checkout so a read-only test run never dirties the
+	// workspace or depends on its write permissions.
+	junitDir, err := os.MkdirTemp("", "codefly-pytest-*")
+	if err != nil {
+		return nil, fmt.Errorf("create pytest evidence directory: %w", err)
 	}
+	defer os.RemoveAll(junitDir)
 	junitFile := filepath.Join(junitDir, fmt.Sprintf("pytest-junit-%d.xml", time.Now().UnixNano()))
-	defer os.Remove(junitFile) // structured response replaces the file
 
-	pytestArgs := []string{"run", "pytest", "--tb=short", "--junitxml=" + junitFile}
+	// --no-project prevents uv from creating/updating uv.lock or .venv in the
+	// user's checkout. Pytest and an optional editable project overlay are
+	// materialized in uv's external cache.
+	pytestArgs := []string{"run", "--no-project", "--with", "pytest"}
+	if info, statErr := os.Stat(filepath.Join(sourceDir, "pyproject.toml")); statErr == nil && !info.IsDir() {
+		pytestArgs = append(pytestArgs, "--with-editable", ".")
+	}
+	pytestArgs = append(pytestArgs,
+		"pytest",
+		"--tb=short",
+		"--junitxml="+junitFile,
+		"-p", "no:cacheprovider",
+	)
 
 	// Default to verbose unless the caller explicitly set Verbose=false.
 	// Verbose feeds the OnEvent stream; the JUnit XML is parsed regardless.
@@ -261,8 +273,12 @@ func RunPythonTestsStructured(ctx context.Context, sourceDir string, envVars []*
 		cmd.Stderr = &raw
 	}
 
-	// Inherit parent env, then overlay codefly env vars.
-	cmd.Env = os.Environ()
+	// Python bytecode, pytest cache, coverage data, and JUnit evidence are
+	// validation artifacts. Keep all of them outside the source checkout.
+	cmd.Env = append(os.Environ(),
+		"PYTHONPYCACHEPREFIX="+filepath.Join(junitDir, "pycache"),
+		"COVERAGE_FILE="+filepath.Join(junitDir, "coverage"),
+	)
 	for _, ev := range envVars {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", ev.Key, ev.Value))
 	}
@@ -273,7 +289,7 @@ func RunPythonTestsStructured(ctx context.Context, sourceDir string, envVars []*
 	// Parse JUnit XML. If pytest didn't write one (collection error,
 	// pytest itself crashed), the structured run will be empty —
 	// runErr indicates something went wrong; the caller surfaces it.
-	xmlBytes, _ := os.ReadFile(junitFile) //nolint:gosec // path under sourceDir
+	xmlBytes, _ := os.ReadFile(junitFile) //nolint:gosec // private temporary path
 	coverage := scrapeCoverageFromOutput(rawStr)
 	run := ParsePytestJUnit(string(xmlBytes), coverage)
 	run.RawOutput = rawStr
@@ -364,11 +380,37 @@ func RunPythonLint(ctx context.Context, sourceDir string, targets ...string) (st
 	if len(targets) > 0 && targets[0] != "" {
 		target = targets[0]
 	}
-	cmd := exec.CommandContext(ctx, "uv", "run", "ruff", "check", "--", target)
+	// Ruff configuration is still discovered from sourceDir, but uv's project
+	// mode is disabled so a read-only lint never creates uv.lock or .venv in
+	// the checkout.
+	cmd := exec.CommandContext(ctx, "uv", "run", "--no-project", "--with", "ruff", "ruff", "check", "--", target)
 	cmd.Dir = sourceDir
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err := cmd.Run()
+	return out.String(), err
+}
+
+// RunPythonBuild performs the Python compile gate without requiring a valid
+// package declaration. Source-only repositories and partially edited
+// pyproject.toml files still need syntax validation, so --no-project keeps the
+// check independent from dependency materialization.
+func RunPythonBuild(ctx context.Context, sourceDir, target string) (string, error) {
+	if target == "" {
+		target = "."
+	}
+	bytecodeDir, err := os.MkdirTemp("", "codefly-python-bytecode-*")
+	if err != nil {
+		return "", fmt.Errorf("create Python bytecode directory: %w", err)
+	}
+	defer os.RemoveAll(bytecodeDir)
+	cmd := exec.CommandContext(ctx, "uv", "run", "--no-project", "python", "-m", "compileall", "-q", "--", target)
+	cmd.Dir = sourceDir
+	cmd.Env = append(os.Environ(), "PYTHONPYCACHEPREFIX="+bytecodeDir)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
 	return out.String(), err
 }


### PR DESCRIPTION
## Summary
- return structured and raw Go test evidence alongside the legacy summary
- keep Python test, lint, build, cache, and JUnit artifacts outside source checkouts
- omit generated untracked trees from workspace diffs

## Validation
- `GOWORK=off codefly test source --dir . --target ./code` — 272 passed
- `GOWORK=off codefly test source --dir . --target ./runners/golang` — 71 passed
- `GOWORK=off codefly test source --dir . --target ./runners/python` — 79 passed

The local OpenTelemetry `go.mod`/`go.sum` edits are intentionally excluded.