### PR TITLE
Make caller timeout authoritative over racing tool error (#70)

### DIFF
--- a/toolbox/session/session.go
+++ b/toolbox/session/session.go
@@ -550,6 +550,16 @@ func (s *ToolboxSession) Call(ctx context.Context, input CallRequest) (*CallResu
 		RequestID: requestID, ObjectiveID: input.ObjectiveID, TaskID: input.TaskID,
 		TraceID: traceID, ReleaseID: s.scope.ReleaseID,
 	}
+	// A caller deadline or cancellation is authoritative over any racing tool
+	// response. The disposable process may observe ctx.Done() and answer with a
+	// tool error, and that response can win the race back to the client before
+	// the transport surfaces the deadline; the caller must still see the stable
+	// timeout/canceled category, never tool_error.
+	if callErr == nil {
+		if ctxErr := callCtx.Err(); ctxErr != nil {
+			callErr = ctxErr
+		}
+	}
 	if callErr != nil {
 		code := classifyTransport(callCtx, callErr)
 		retry := retryFor(approved.Idempotency, code)


### PR DESCRIPTION
Closes #70.

## Summary
- `TestSessionTimeoutAndCancellationAreStableCategories` intermittently saw the timeout path classified as `tool_error` under full-coverage CI. The conformance `wait` handler returns a *tool error* when it observes `ctx.Done()`; when the caller's deadline fires, that error response can win the race back to the client before the gRPC transport surfaces `DeadlineExceeded`, leaving `callErr == nil` and a populated `response.GetError()` — classified as `tool_error`.
- The caller's own deadline/cancellation is authoritative over any racing tool response. `Call` now promotes a non-nil `callCtx.Err()` to the call error whenever `CallTool` returns without a transport error, so the deadline/cancellation routes through the existing timeout/canceled path (including retry classification and the `AuditCancel` event) and the category is deterministic regardless of who wins the race.

## Test plan
- [x] `GOWORK=off go test ./toolbox/session/ -run TestSessionTimeoutAndCancellationAreStableCategories -count=10`
- [x] Same test under `-race -count=5`
- [x] Same test `-count=15` under saturating CPU load (four `yes` loops) to mimic full-coverage contention
- [x] Full `GOWORK=off go test ./toolbox/session/` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)