### PR TITLE
Fix Python DAP companion: bake in debugpy, derive tag from info.codefly.yaml (#73)

### DIFF
--- a/companions/dap/python.go
+++ b/companions/dap/python.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/codefly-dev/core/companions/python"
 	"github.com/codefly-dev/core/languages"
 	"github.com/codefly-dev/core/resources"
 	"github.com/codefly-dev/core/runners/companion"
@@ -12,9 +13,10 @@ import (
 
 func init() {
 	Register(languages.PYTHON, &LanguageConfig{
-		CompanionImage: func(_ context.Context) (*resources.DockerImage, error) {
-			// Use the Python companion image (which includes debugpy).
-			return &resources.DockerImage{Name: "codeflydev/python", Tag: "0.0.5"}, nil
+		CompanionImage: func(ctx context.Context) (*resources.DockerImage, error) {
+			// The Python companion image carries debugpy; its tag comes from
+			// the companion's info.codefly.yaml (mirrors go via golang).
+			return python.CompanionImage(ctx)
 		},
 		DAPBinary: "python",
 		DAPListenArgs: func(port int) []string {

--- a/companions/python/Dockerfile
+++ b/companions/python/Dockerfile
@@ -38,6 +38,13 @@ COPY --from=codeflydev/codefly:0.0.3 /bin/codefly /bin/codefly
 # editing this version path AND info.codefly.yaml together.
 RUN curl -LsSf https://astral.sh/uv/0.5.29/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
+# debugpy is the DAP adapter this companion launches
+# (`python -m debugpy.adapter`, see companions/dap/python.go). Install it
+# into the system interpreter so it is importable by the container's default
+# `python` regardless of any project venv mounted at runtime. --break-system-packages
+# is required because the alpine base marks the system env as externally managed.
+RUN pip install --no-cache-dir --break-system-packages debugpy
+
 # uv venv convention used by python-fastapi (see DockerEnvPath in its
 # runtime). Plugins mount /venv so venvs survive container restarts.
 ENV UV_PROJECT_ENVIRONMENT=/venv

--- a/companions/python/info.codefly.yaml
+++ b/companions/python/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.0.1
+version: 0.0.2

--- a/companions/python/version.go
+++ b/companions/python/version.go
@@ -1,0 +1,51 @@
+package python
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Masterminds/semver"
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/wool"
+)
+
+// Info holds companion version metadata.
+type Info struct {
+	Version string `yaml:"version"`
+}
+
+func version(ctx context.Context) (string, error) {
+	w := wool.Get(ctx).In("python.version")
+
+	content, err := fs.ReadFile(infoFS, "info.codefly.yaml")
+	if err != nil {
+		return "", w.Wrapf(err, "cannot read file")
+	}
+	var info Info
+	if err = yaml.Unmarshal(content, &info); err != nil {
+		return "", w.Wrapf(err, "cannot unmarshal file")
+	}
+	v, err := semver.NewVersion(info.Version)
+	if err != nil {
+		return "", w.Wrapf(err, "cannot parse version <%s>", info.Version)
+	}
+	return v.String(), nil
+}
+
+// CompanionImage returns the Docker image for the Python companion. The tag
+// is read from info.codefly.yaml so the image agents pull can never drift
+// from the one `codefly companion build/publish` produces.
+func CompanionImage(ctx context.Context) (*resources.DockerImage, error) {
+	w := wool.Get(ctx).In("python.CompanionImage")
+	v, err := version(ctx)
+	if err != nil {
+		return nil, w.Wrapf(err, "cannot get version")
+	}
+	return &resources.DockerImage{Name: "codeflydev/python", Tag: v}, nil
+}
+
+//go:embed info.codefly.yaml
+var infoFS embed.FS


### PR DESCRIPTION
Closes #73.

## Summary
- `companions/dap/python.go` hardcoded `codeflydev/python:0.0.5`, a tag that was **never published** — Docker Hub only has `codeflydev/python:0.0.1`. Python debugging therefore died at the companion pull (the same referenced-but-unpublished failure as `proto:0.0.11`).
- The published `0.0.1` image also lacked `debugpy`, which the DAP adapter (`python -m debugpy.adapter`) requires — so no existing tag could actually satisfy DAP. This bakes `debugpy` into the image and points the runtime at a real, buildable tag.
- Derives the image tag from `info.codefly.yaml` (new `python.CompanionImage`, mirroring `proto`/`golang`) so the tag agents pull can never again drift from the one `codefly companion build/publish` produces.

## Changes
- `companions/python/Dockerfile`: `pip install debugpy` into the system interpreter (importable by the container's default `python` regardless of a mounted project venv).
- `companions/python/version.go` (new): `python.CompanionImage(ctx)` reading `info.codefly.yaml`.
- `companions/dap/python.go`: use `python.CompanionImage(ctx)` instead of the literal.
- `companions/python/info.codefly.yaml`: `0.0.1` → `0.0.2` (first tag carrying debugpy).

## Test plan
- [x] `go build ./...`, `gofmt`/`go vet` clean
- [x] `docker build -f companions/python/Dockerfile` succeeds (debugpy 1.8.21 from a musllinux wheel — no build tools added)
- [x] `python -m debugpy.adapter --help` runs in the built image, on `/usr/local/bin/python`
- [ ] Publish `codeflydev/python:0.0.2` on release (via `codefly companion publish python`, codefly-dev/cli#116) so the new embedded tag exists in the registry
- [ ] Smoke-test a Python DAP session end to end

## Notes
- The `go`/`golang` dual-info-source item from #73 is **not** addressed here (it's latent, not broken today) — left for a follow-up to keep this PR to the one live breakage.
- Publishing is intentionally left to the release path (cli#116's companions workflow) rather than pushed from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
