### PR TITLE
Run every proto-image companion as the host user (#74)

### DIFF
--- a/companions/proto/grpc.go
+++ b/companions/proto/grpc.go
@@ -71,6 +71,7 @@ func GenerateGRPC(ctx context.Context, language languages.Language, destination 
 	runner.WithMount(destination, "/workspace/output")
 	runner.WithMount(tmpDir, "/workspace")
 	runner.WithWorkDir("/workspace")
+	runner.WithUser(hostUserSpec())
 	runner.WithPause()
 
 	defer func() {

--- a/companions/proto/host_user_test.go
+++ b/companions/proto/host_user_test.go
@@ -1,0 +1,26 @@
+package proto
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestHostUserSpec pins the platform contract the proto companions rely on:
+// on Linux the companion must run as the invoking host user so bind-mounted
+// generated output is host-owned (readable by a non-root CI runner); on other
+// platforms it keeps the image default.
+func TestHostUserSpec(t *testing.T) {
+	spec := hostUserSpec()
+	if runtime.GOOS == "linux" {
+		want := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+		if spec != want {
+			t.Fatalf("expected %q on linux, got %q", want, spec)
+		}
+		return
+	}
+	if spec != "" {
+		t.Fatalf("expected empty user spec off linux, got %q", spec)
+	}
+}

--- a/companions/proto/openapi.go
+++ b/companions/proto/openapi.go
@@ -100,6 +100,7 @@ func generateOpenAPIGo(ctx context.Context, unique string, image *resources.Dock
 	runner.WithMount(openapiDir, "/workspace/openapi")
 	runner.WithMount(root, "/workspace")
 	runner.WithWorkDir("/workspace")
+	runner.WithUser(hostUserSpec())
 	defer func() {
 		if shutErr := runner.Shutdown(ctx); shutErr != nil {
 			w.Warn("cannot shutdown runner", wool.ErrField(shutErr))
@@ -154,6 +155,7 @@ func generateOpenAPITypeScript(ctx context.Context, unique string, image *resour
 	runner.WithMount(openapiDir, "/workspace/openapi")
 	runner.WithMount(destinationDir, "/workspace/output")
 	runner.WithWorkDir("/workspace")
+	runner.WithUser(hostUserSpec())
 	runner.WithPause()
 
 	defer func() {

--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -61,6 +61,19 @@ func NewBuf(ctx context.Context, dir string) (*Buf, error) {
 	}, nil
 }
 
+// hostUserSpec returns the "UID:GID" a proto companion should run as, or ""
+// to keep the image's default user. On Linux the container otherwise runs as
+// root and writes the generated tree as root into the bind mount, leaving it
+// unreadable by a non-root host such as a CI runner. It is empty off Linux:
+// Docker Desktop on macOS already remaps bind-mount ownership to the host
+// user, and the non-Docker backends run as the host user to begin with.
+func hostUserSpec() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+}
+
 // WithGeneratedRoot declares the service root that owns generated outputs.
 // This is distinct from Dir for nested protocol layouts such as code/proto:
 // Buf runs from code/, while generated OpenAPI may still live at the service
@@ -117,14 +130,7 @@ func (g *Buf) Generate(ctx context.Context) error {
 	if runner.Backend() == companion.BackendDocker {
 		runner.WithMount(g.Dir, "/workspace")
 		runner.WithWorkDir("/workspace/proto")
-		// On Linux, containers default to root, so buf writes the generated
-		// tree as root into the bind mount. A non-root host (e.g. a CI
-		// runner) then can't read it back. Run as the host user so the
-		// output is host-owned. Docker Desktop on macOS remaps bind-mount
-		// ownership to the host user already, so this is Linux-only.
-		if runtime.GOOS == "linux" {
-			runner.WithUser(fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()))
-		}
+		runner.WithUser(hostUserSpec())
 	} else {
 		runner.WithWorkDir(path.Join(g.Dir, "proto"))
 	}


### PR DESCRIPTION
Closes #74.

## Summary
- The proto companion runs `buf`/`swagger generate` in a Docker container that defaults to **root** on Linux, so generated output lands in the bind mount owned by root — unreadable by a non-root CI runner (`lstat …/code/pkg/gen: permission denied`).
- #68 fixed this for `Buf.Generate` only. The sibling proto-image paths (`GenerateGRPC`, `generateOpenAPIGo`, `generateOpenAPITypeScript`) still wrote their output as root, reproducing the same bug for gRPC-client and OpenAPI generation.
- This applies the host-user override (issue's "option 2") to **every** proto-image companion path, via a shared `hostUserSpec()` helper so the rationale and the Linux-only guard live in one place.

Scoped deliberately to the proto companion image, which is already prepared to run as an arbitrary non-root UID (`HOME=/tmp`). The go/node/python/execution companion images still assume root, so a blanket runner-level override would break them — generalizing further needs those images made non-root-ready first.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./companions/proto/ ./runners/dockerrun/`
- [x] `go test ./companions/proto/ ./runners/dockerrun/` — passes, including the new `TestHostUserSpec` (Linux → `uid:gid`, else empty) and the existing `TestCreateContainerConfig_User` proving the spec threads through to `container.Config.User`.
- [ ] Non-root Linux CI: `codefly generate proto` produces a host-readable generated tree (verifiable only on a real non-root Linux runner; macOS Docker Desktop remaps ownership regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)