### PR TITLE
Bake debugpy into the Python companion image

### DIFF
--- a/companions/python/Dockerfile
+++ b/companions/python/Dockerfile
@@ -38,6 +38,13 @@ COPY --from=codeflydev/codefly:0.0.3 /bin/codefly /bin/codefly
 # editing this version path AND info.codefly.yaml together.
 RUN curl -LsSf https://astral.sh/uv/0.5.29/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
+# debugpy is the DAP adapter this companion launches
+# (`python -m debugpy.adapter`, see companions/dap/python.go). Install it
+# into the system interpreter so it is importable by the container's default
+# `python` regardless of any project venv mounted at runtime. --break-system-packages
+# is required because the alpine base marks the system env as externally managed.
+RUN pip install --no-cache-dir --break-system-packages debugpy
+
 # uv venv convention used by python-fastapi (see DockerEnvPath in its
 # runtime). Plugins mount /venv so venvs survive container restarts.
 ENV UV_PROJECT_ENVIRONMENT=/venv

--- a/companions/python/Dockerfile
+++ b/companions/python/Dockerfile
@@ -39,11 +39,21 @@ COPY --from=codeflydev/codefly:0.0.3 /bin/codefly /bin/codefly
 RUN curl -LsSf https://astral.sh/uv/0.5.29/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
 # debugpy is the DAP adapter this companion launches
-# (`python -m debugpy.adapter`, see companions/dap/python.go). Install it
-# into the system interpreter so it is importable by the container's default
-# `python` regardless of any project venv mounted at runtime. --break-system-packages
-# is required because the alpine base marks the system env as externally managed.
-RUN pip install --no-cache-dir --break-system-packages debugpy
+# (`python -m debugpy.adapter`, see companions/dap/python.go). Pinned like the
+# base image and uv above — bump deliberately, and only to a version that
+# still ships a prebuilt musllinux wheel (build-base is intentionally absent,
+# see the note above, so there is no compiler to build from source).
+#
+# Installed into the system interpreter (/usr/local/bin/python). The DAP runner
+# mounts only /workspace and the uv cache — never a project venv at /venv (see
+# companions/dap/client.go) — so `python` on PATH resolves here and can import
+# debugpy. If a /venv is ever mounted for a debug session, the ENV PATH below
+# would shadow this interpreter and the adapter must be launched via an
+# absolute /usr/local/bin/python instead.
+#
+# --break-system-packages is required because the alpine base marks the system
+# env as externally managed.
+RUN pip install --no-cache-dir --break-system-packages debugpy==1.8.21
 
 # uv venv convention used by python-fastapi (see DockerEnvPath in its
 # runtime). Plugins mount /venv so venvs survive container restarts.


### PR DESCRIPTION
Closes one of the two Python-companion gaps left on `main` after #76 (the other — publishing the pinned tag — is handled out of band, see Notes).

## Context
#75 originally bundled this fix but was closed as a duplicate of #76. #76 landed `companions.Embedded` + `python.CompanionImage` (tag derived from `info.codefly.yaml`) and the go/golang fix, but **not** the debugpy install. So on `main` today the Python DAP adapter (`python -m debugpy.adapter`, `companions/dap/python.go`) launches against an image whose interpreter can't import debugpy — every Python debug session dies at adapter import.

## Change
- `companions/python/Dockerfile`: `pip install --no-cache-dir --break-system-packages debugpy` into the system interpreter, so the container's default `/usr/local/bin/python` can import it regardless of any project venv mounted at runtime. `--break-system-packages` is required because the alpine base marks the system env as externally managed.

The embedded tag is left at `codeflydev/python:0.0.5` (from `info.codefly.yaml`) — unchanged. No Go code changes.

## Test plan
- [x] `go build ./...`, `gofmt` clean
- [x] `docker build --platform linux/amd64 -f companions/python/Dockerfile` succeeds (debugpy 1.8.21, musllinux wheel — no build tools added)
- [x] In the built image, on `/usr/local/bin/python`: `import debugpy` OK and `python -m debugpy.adapter --help` runs
- [ ] Smoke-test a Python DAP session end to end

## Notes
- **Second gap (separate):** `codeflydev/python:0.0.5` (the tag `main` pins) is still not published. That's being handled out of band — this PR deliberately does not touch the tag, so once `0.0.5` is (re)published from this Dockerfile, main's reference resolves.
- Refs #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)