### PR TITLE
ci: propagate typed test fail-fast to Go runner

### DIFF
--- a/generated/go/codefly/services/runtime/v0/runtime.pb.go
+++ b/generated/go/codefly/services/runtime/v0/runtime.pb.go
@@ -2222,7 +2222,13 @@ type TestRequest struct {
 	// reject a response that does not echo the expected identity. This makes an
 	// older peer that ignores the additive selection field fail closed instead
 	// of accidentally certifying a broad test run.
-	SelectionId   string `protobuf:"bytes,11,opt,name=selection_id,json=selectionId,proto3" json:"selection_id,omitempty"`
+	SelectionId string `protobuf:"bytes,11,opt,name=selection_id,json=selectionId,proto3" json:"selection_id,omitempty"`
+	// Stop the underlying test runner after its first failure. CI uses this to
+	// avoid spending the remainder of a long suite after a fail-closed external
+	// replay miss or any other decisive runtime failure. Agents map this to the
+	// native runner's fail-fast behavior; it is false for interactive/default
+	// test requests so callers can still collect the complete failure set.
+	FailFast      bool `protobuf:"varint,12,opt,name=fail_fast,json=failFast,proto3" json:"fail_fast,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2332,6 +2338,13 @@ func (x *TestRequest) GetSelectionId() string {
 		return x.SelectionId
 	}
 	return ""
+}
+
+func (x *TestRequest) GetFailFast() bool {
+	if x != nil {
+		return x.FailFast
+	}
+	return false
 }
 
 // TestFormula is a fully-described test invocation as DATA — and it is
@@ -4530,7 +4543,7 @@ const file_codefly_services_runtime_v0_runtime_proto_rawDesc = "" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x14\n" +
 	"\x05suite\x18\x03 \x01(\tR\x05suite\x12%\n" +
-	"\x0equalified_name\x18\x04 \x03(\tR\rqualifiedName\"\x89\x03\n" +
+	"\x0equalified_name\x18\x04 \x03(\tR\rqualifiedName\"\xa6\x03\n" +
 	"\vTestRequest\x12\x16\n" +
 	"\x06target\x18\x01 \x01(\tR\x06target\x12\x18\n" +
 	"\averbose\x18\x02 \x01(\bR\averbose\x12\x12\n" +
@@ -4544,7 +4557,8 @@ const file_codefly_services_runtime_v0_runtime_proto_rawDesc = "" +
 	"\aformula\x18\t \x01(\v2(.codefly.services.runtime.v0.TestFormulaR\aformula\x12H\n" +
 	"\tselection\x18\n" +
 	" \x01(\v2*.codefly.services.runtime.v0.TestSelectionR\tselection\x12!\n" +
-	"\fselection_id\x18\v \x01(\tR\vselectionId\"\xdd\x02\n" +
+	"\fselection_id\x18\v \x01(\tR\vselectionId\x12\x1b\n" +
+	"\tfail_fast\x18\f \x01(\bR\bfailFast\"\xdd\x02\n" +
 	"\vTestFormula\x12\x18\n" +
 	"\acommand\x18\x01 \x03(\tR\acommand\x12\x16\n" +
 	"\x06output\x18\x02 \x01(\tR\x06output\x12C\n" +

--- a/proto/codefly/services/runtime/v0/runtime.proto
+++ b/proto/codefly/services/runtime/v0/runtime.proto
@@ -379,6 +379,13 @@ message TestRequest {
   // older peer that ignores the additive selection field fail closed instead
   // of accidentally certifying a broad test run.
   string selection_id = 11;
+
+  // Stop the underlying test runner after its first failure. CI uses this to
+  // avoid spending the remainder of a long suite after a fail-closed external
+  // replay miss or any other decisive runtime failure. Agents map this to the
+  // native runner's fail-fast behavior; it is false for interactive/default
+  // test requests so callers can still collect the complete failure set.
+  bool fail_fast = 12;
 }
 
 // TestFormula is a fully-described test invocation as DATA — and it is

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -250,12 +252,40 @@ func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation st
 		return nil, err
 	}
 
-	// Stream when a callback is provided; otherwise buffer only (the
-	// original behavior). Both paths use LineCapture.String() at the end
-	// to feed ParseTestJSON.
+	// Stream when a callback is provided or fail-fast needs to observe the
+	// first structured failure. Go's native -failfast stops tests inside an
+	// individual package binary, but `go test ./...` may already have other
+	// package binaries in flight. Stop the whole runner process tree on the
+	// first failing test event so CI does not keep burning through packages.
+	// Both paths use LineCapture.String() at the end to feed ParseTestJSON.
 	var capture *LineCapture
-	if opt.OnEvent != nil {
-		streaming := &StreamingTestWriter{OnEvent: opt.OnEvent}
+	if opt.OnEvent != nil || opt.FailFast {
+		onEvent := opt.OnEvent
+		if opt.FailFast {
+			var stopOnce sync.Once
+			onEvent = func(ev TestEvent) {
+				if opt.OnEvent != nil {
+					opt.OnEvent(ev)
+				}
+				if ev.Action != "fail" || ev.Test == "" {
+					return
+				}
+				stopOnce.Do(func() {
+					// The writer runs on a process-output goroutine. Stop
+					// asynchronously because native Stop waits for output
+					// forwarding to drain before it returns.
+					go func() {
+						stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+						defer stopCancel()
+						if err := proc.Stop(stopCtx); err != nil {
+							wool.Get(ctx).In("RunGoTests").
+								Debug("could not stop fail-fast test process (non-fatal)", wool.ErrField(err))
+						}
+					}()
+				})
+			}
+		}
+		streaming := &StreamingTestWriter{OnEvent: onEvent}
 		proc.WithOutput(streaming)
 		capture = &streaming.LineCapture
 	} else {

--- a/runners/golang/agent_runtime.go
+++ b/runners/golang/agent_runtime.go
@@ -141,6 +141,11 @@ type TestOptions struct {
 	// roughly doubles test-binary compile time; opt in per TestRequest.
 	Coverage bool
 
+	// FailFast stops each native Go test binary after its first failure.
+	// CI enables it to surface decisive runtime failures (including
+	// fail-closed replay misses) without running the rest of a long suite.
+	FailFast bool
+
 	// Filters are name regex patterns (multiple combined with OR) passed
 	// to `go test -run`. Equivalent to `-run "(p1|p2|...)"`.
 	Filters []string
@@ -210,6 +215,9 @@ func RunGoTests(ctx context.Context, env *GoRunnerEnvironment, sourceLocation st
 	args = append(args, "-timeout", timeout)
 	if opt.Coverage {
 		args = append(args, "-cover")
+	}
+	if opt.FailFast {
+		args = append(args, "-failfast")
 	}
 
 	// Determine package target. Target is now strictly directory scope —

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -65,6 +65,9 @@ func buildTestArgs(opt TestOptions) []string {
 	if opt.Coverage {
 		args = append(args, "-cover")
 	}
+	if opt.FailFast {
+		args = append(args, "-failfast")
+	}
 	pkg := "./..."
 	if opt.Target != "" {
 		if isPackagePath(opt.Target) {
@@ -128,6 +131,18 @@ func TestGoTestArgs_CoverageOptIn(t *testing.T) {
 				t.Errorf("args=%q: -race present=%v, want=%v", joined, got, tc.wantRace)
 			}
 		})
+	}
+}
+
+func TestGoTestArgs_FailFastOptIn(t *testing.T) {
+	defaultArgs := strings.Join(buildTestArgs(TestOptions{}), " ")
+	if strings.Contains(defaultArgs, " -failfast") {
+		t.Fatalf("fail-fast must remain opt-in: %q", defaultArgs)
+	}
+
+	failFastArgs := strings.Join(buildTestArgs(TestOptions{FailFast: true}), " ")
+	if !strings.Contains(failFastArgs, " -failfast") {
+		t.Fatalf("typed fail-fast was not mapped to go test: %q", failFastArgs)
 	}
 }
 

--- a/runners/golang/agent_runtime_test.go
+++ b/runners/golang/agent_runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
 	"github.com/codefly-dev/core/resources"
@@ -293,6 +294,63 @@ func TestRunGoTestsStandaloneModuleIgnoresParentWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(summary.RawOutput, `"Test":"TestGeneratedService"`) {
 		t.Fatalf("raw output does not contain the executed test event: %q", summary.RawOutput)
+	}
+}
+
+func TestRunGoTestsFailFastStopsWholeProcessTree(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	for _, dir := range []string{filepath.Join(root, "aaa"), filepath.Join(root, "zzz")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	marker := filepath.Join(root, "slow-test-completed")
+	files := map[string]string{
+		filepath.Join(root, "go.mod"): "module example.com/failfast\n\ngo 1.24.0\n",
+		filepath.Join(root, "aaa", "failure_test.go"): `package aaa
+
+import "testing"
+
+func TestImmediateFailure(t *testing.T) { t.Fatal("stop now") }
+`,
+		filepath.Join(root, "zzz", "slow_test.go"): fmt.Sprintf(`package zzz
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSlowPackage(t *testing.T) {
+	time.Sleep(8 * time.Second)
+	if err := os.WriteFile(%q, []byte("too late"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+`, marker),
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(name, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	env, err := NewNativeGoRunner(ctx, root, ".")
+	if err != nil {
+		t.Fatalf("new native runner: %v", err)
+	}
+	env.WithWorkspace(false)
+	started := time.Now()
+	execution, _ := RunGoTests(ctx, env, root, nil, TestOptions{FailFast: true})
+	if execution == nil || execution.Failed == 0 {
+		t.Fatalf("execution = %+v, want the first failure preserved", execution)
+	}
+	if elapsed := time.Since(started); elapsed >= 6*time.Second {
+		t.Fatalf("fail-fast took %s; slow package was not stopped", elapsed)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("slow package completed after fail-fast: stat error=%v", err)
 	}
 }
 

--- a/runners/golang/formula.go
+++ b/runners/golang/formula.go
@@ -29,9 +29,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/codefly-dev/core/failures"
 	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
 	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
-	"github.com/codefly-dev/core/failures"
 )
 
 // OutputGoTestJSON is the formula output format produced by `go test -json`.

--- a/runners/golang/formula.go
+++ b/runners/golang/formula.go
@@ -125,10 +125,14 @@ func ClassifyEnvError(raw string, runErr error) (reason, detail string) {
 // regexp-escaped and anchored into `-run`, so "TestFoo" never selects
 // "TestFooBar" and bracketed subtest names stay literal.
 //
+// When failFast is true, the typed CI setting is mapped to Go's native
+// `-failfast` flag. The optional argument preserves source compatibility for
+// callers that do not yet send the additive TestRequest field.
+//
 // The run always sets GOWORK=off: a formula run tests THIS module in
 // isolation, and a go.work in any parent directory (common when fixtures
 // live inside a bigger repo) must not leak into module resolution.
-func RunFormula(ctx context.Context, sourceDir string, command []string, selectors []string) (*runtimev0.TestResponse, error) {
+func RunFormula(ctx context.Context, sourceDir string, command []string, selectors []string, failFast ...bool) (*runtimev0.TestResponse, error) {
 	start := time.Now()
 	if len(command) == 0 {
 		derived, _, ok := DeriveFormula(sourceDir)
@@ -174,6 +178,9 @@ func RunFormula(ctx context.Context, sourceDir string, command []string, selecto
 	// run — inject the flag right after the subcommand.
 	if len(args) > 0 && args[0] == "test" && !slices.Contains(args, "-json") {
 		args = slices.Insert(args, 1, "-json")
+	}
+	if len(args) > 0 && args[0] == "test" && len(failFast) > 0 && failFast[0] && !slices.Contains(args, "-failfast") {
+		args = append(args, "-failfast")
 	}
 	args = append(args, pkgs...)
 

--- a/runners/golang/formula_test.go
+++ b/runners/golang/formula_test.go
@@ -129,6 +129,26 @@ func TestRunFormula_FailingTestIsFailedNotBlocked(t *testing.T) {
 	}
 }
 
+func TestRunFormula_FailFastStopsAfterFirstFailure(t *testing.T) {
+	dir := writeModule(t, map[string]string{
+		"go.mod": "module example.com/failfast\n\ngo 1.21\n",
+		"failfast_test.go": `package failfast
+
+import "testing"
+
+func TestFirstFailure(t *testing.T) { t.Fatal("first") }
+func TestSecondFailure(t *testing.T) { t.Fatal("second") }
+`,
+	})
+	resp, err := RunFormula(formulaCtx(t), dir, nil, nil, true)
+	if err != nil {
+		t.Fatalf("RunFormula: %v", err)
+	}
+	if resp.GetCounts().GetFailed() != 1 || resp.GetCounts().GetTotal() != 1 {
+		t.Fatalf("fail-fast counts = %+v, want only the first failing test", resp.GetCounts())
+	}
+}
+
 func TestRunFormula_SelectorTargetsSingleTest(t *testing.T) {
 	dir := writeModule(t, map[string]string{
 		"go.mod":           "module example.com/stringsx\n\ngo 1.21\n",


### PR DESCRIPTION
## Summary
- add an additive `TestRequest.fail_fast` runtime field
- map the typed option to Go’s native `-failfast` runner flag
- keep interactive/default test requests unchanged

Missing LLM, embedding, and tool recordings continue to fail from the existing replay runtime; this adds no cassette preflight.

## Verification
- `codefly test source --dir . --target ./runners/golang --timeout 10m` (72/72)