### PR TITLE
ci: use workflow token for coverage badges

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build
@@ -132,7 +135,7 @@ jobs:
           config: ./.testcoverage.yaml
           ## when token is not specified (value '') this feature is turned off
           ## in this example badge is created and committed only for main branch
-          git-token: ${{ github.ref_name == 'main' && secrets.GH_PAT || '' }}
+          git-token: ${{ github.ref_name == 'main' && github.token || '' }}
           ## name of branch where badges are stored
           ## ideally this should be orphan branch (see below how to create this branch)
           git-branch: badges

--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -2,9 +2,8 @@ profile: cover.out
 
 local-prefix: "github.com/codefly-dev/core"
 
-## in this example badge is created and committed only for main brach
-git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
-## name of branch where badges are stored
+## Authentication is supplied by the workflow only on main.
+## Name of branch where badges are stored.
 ## ideally this should be orphan branch (see below how to create this branch)
 git-branch: badges
 


### PR DESCRIPTION
The v0.2.36 main build passed tests and the 50.5% coverage threshold, then failed solely because the badge uploader used a stale `GH_PAT` and received `401 Bad credentials`.

- grant the workflow-scoped token `contents: write`
- use `github.token` only on main
- remove the inert token expression from the checked-in coverage config

PR runs still pass an empty token and therefore never write badges.