### PR TITLE
Isolate named runtime environments

### DIFF
--- a/configurations/local_reader.go
+++ b/configurations/local_reader.go
@@ -55,9 +55,14 @@ func NewConfigurationLocalReader(_ context.Context, workspace *resources.Workspa
 func (local *ConfigurationInformationLocalReader) Load(ctx context.Context, env *resources.Environment) error {
 	w := wool.Get(ctx).In("ConfigurationInformationLocalReader.Load")
 
+	configurationProfile, err := env.ConfigurationProfileName()
+	if err != nil {
+		return w.Wrapf(err, "cannot select configuration profile")
+	}
+
 	// Create a provider folder for local development
-	configurationDir := path.Join(local.workspace.Dir(), "configurations", env.Name)
-	_, err := shared.CheckDirectoryOrCreate(ctx, configurationDir)
+	configurationDir := path.Join(local.workspace.Dir(), "configurations", configurationProfile)
+	_, err = shared.CheckDirectoryOrCreate(ctx, configurationDir)
 	if err != nil {
 		return w.Wrapf(err, "cannot create configuration directory")
 	}
@@ -88,7 +93,7 @@ func (local *ConfigurationInformationLocalReader) Load(ctx context.Context, env 
 		if err != nil {
 			return w.Wrapf(err, "cannot get service identity")
 		}
-		serviceConfDir := path.Join(svc.Dir(), "configurations", env.Name)
+		serviceConfDir := path.Join(svc.Dir(), "configurations", configurationProfile)
 		exists, err := shared.DirectoryExists(ctx, serviceConfDir)
 		if err != nil {
 			return w.Wrapf(err, "cannot check service configuration directory")
@@ -111,7 +116,7 @@ func (local *ConfigurationInformationLocalReader) Load(ctx context.Context, env 
 			}
 		}
 		// Load DNS
-		serviceDNSDir := path.Join(svc.Dir(), "dns", env.Name)
+		serviceDNSDir := path.Join(svc.Dir(), "dns", configurationProfile)
 		dnsFile := path.Join(serviceDNSDir, "dns.codefly.yaml")
 		exists, err = shared.FileExists(ctx, dnsFile)
 		if err != nil {

--- a/configurations/local_reader_test.go
+++ b/configurations/local_reader_test.go
@@ -60,6 +60,41 @@ func TestLocalLoaderModulesLayout(t *testing.T) {
 	testLocalLoader(t, "testdata/module")
 }
 
+func TestEnvironmentCanUseAnExplicitConfigurationProfile(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeConfigurationFile(t, root, resources.WorkspaceConfigurationName, "name: test-workspace\nlayout: flat\n")
+	writeConfigurationFile(t, root, "configurations/local/internal-auth.secret.env", "TOKEN=local-runtime-token\n")
+
+	workspace, err := resources.LoadWorkspaceFromDir(ctx, root)
+	require.NoError(t, err)
+	loader, err := configurations.NewConfigurationLocalReader(ctx, workspace)
+	require.NoError(t, err)
+
+	environment := &resources.Environment{
+		Name:                 "production",
+		ConfigurationProfile: "local",
+	}
+	require.NoError(t, loader.Load(ctx, environment))
+
+	confs := loader.Configurations()
+	require.Len(t, confs, 1)
+	token, err := resources.GetConfigurationValue(ctx, confs[0], "internal-auth", "TOKEN")
+	require.NoError(t, err)
+	require.Equal(t, "local-runtime-token", token)
+}
+
+func TestEnvironmentConfigurationProfileRejectsTraversal(t *testing.T) {
+	environment := &resources.Environment{
+		Name:                 "production",
+		ConfigurationProfile: "../local",
+	}
+
+	_, err := environment.ConfigurationProfileName()
+
+	require.ErrorContains(t, err, "single path component")
+}
+
 func testLocalLoader(t *testing.T, dir string) {
 	wool.SetGlobalLogLevel(wool.DEBUG)
 	ctx := context.Background()

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -69,6 +69,14 @@ type Environment struct {
 	Description string `yaml:"description,omitempty"`
 	NamingScope string `yaml:"naming-scope,omitempty"`
 
+	// ConfigurationProfile selects the checked-in configuration directory
+	// independently from the environment identity sent to service agents.
+	// This is useful for a production execution profile running against local
+	// backing services: agents still receive environment.name=production while
+	// Codefly deliberately loads configurations/local. It is explicit and
+	// opt-in; the default remains the environment's own name.
+	ConfigurationProfile string `yaml:"configuration-profile,omitempty"`
+
 	// Deploy-target overrides (CLI-side; not serialized to proto).
 	// Empty values fall back to legacy defaults (local k3d, ~/.kube/config,
 	// the default namespace, the --org flag's hardcoded registry) so
@@ -84,6 +92,11 @@ type Environment struct {
 }
 
 func (env *Environment) Proto() (*basev0.Environment, error) {
+	if env.ConfigurationProfile != "" {
+		if err := validateResourcePathComponent("configuration profile", env.ConfigurationProfile); err != nil {
+			return nil, err
+		}
+	}
 	proto := &basev0.Environment{
 		Name:        env.Name,
 		Description: env.Description,
@@ -94,6 +107,17 @@ func (env *Environment) Proto() (*basev0.Environment, error) {
 		return nil, err
 	}
 	return proto, nil
+}
+
+func (env *Environment) ConfigurationProfileName() (string, error) {
+	name := strings.TrimSpace(env.ConfigurationProfile)
+	if name == "" {
+		name = env.Name
+	}
+	if err := validateResourcePathComponent("configuration profile", name); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 func (env *Environment) Local() bool {

--- a/runners/dockerrun/docker_cache_mount_test.go
+++ b/runners/dockerrun/docker_cache_mount_test.go
@@ -1,0 +1,123 @@
+package dockerrun
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/go-connections/nat"
+)
+
+func TestWithPersistentCacheMountScopesStateByEnvironmentName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(resources.CodeflyHomeEnv, home)
+
+	dev := &DockerEnvironment{name: "codefly-workspace-frontend-dev"}
+	stable := &DockerEnvironment{name: "codefly-workspace-frontend-stable"}
+	target := "/workspace/frontend/.next"
+
+	devCache, err := dev.WithPersistentCacheMount(context.Background(), "next-build", target)
+	if err != nil {
+		t.Fatalf("dev cache mount: %v", err)
+	}
+	stableCache, err := stable.WithPersistentCacheMount(context.Background(), "next-build", target)
+	if err != nil {
+		t.Fatalf("stable cache mount: %v", err)
+	}
+
+	if devCache == stableCache {
+		t.Fatalf("namespaced environments shared cache path %q", devCache)
+	}
+	if want := filepath.Join(home, "runtime-cache", dev.name, "next-build"); devCache != want {
+		t.Fatalf("dev cache = %q, want %q", devCache, want)
+	}
+	if len(dev.mounts) != 1 {
+		t.Fatalf("dev mounts = %d, want 1", len(dev.mounts))
+	}
+	if got := dev.mounts[0]; got.Type != mount.TypeBind || got.Source != devCache || got.Target != target {
+		t.Fatalf("dev mount = %#v, want bind %q -> %q", got, devCache, target)
+	}
+}
+
+func TestWithPersistentCacheMountRejectsUnsafeKeysAndTargets(t *testing.T) {
+	t.Setenv(resources.CodeflyHomeEnv, t.TempDir())
+	env := &DockerEnvironment{name: "codefly-workspace-frontend-dev"}
+
+	for _, key := range []string{"", ".", "..", "../escape", "nested/cache", `nested\cache`} {
+		if _, err := env.WithPersistentCacheMount(context.Background(), key, "/workspace/.next"); err == nil {
+			t.Errorf("key %q was accepted", key)
+		}
+	}
+	if _, err := env.WithPersistentCacheMount(context.Background(), "next-build", ".next"); err == nil {
+		t.Fatal("relative target was accepted")
+	}
+	if len(env.mounts) != 0 {
+		t.Fatalf("invalid requests added %d mounts", len(env.mounts))
+	}
+}
+
+func TestContainerConfigFingerprintDetectsReusableRuntimeDrift(t *testing.T) {
+	httpPort := nat.Port("3000/tcp")
+	config := &container.Config{
+		Image:      "codeflydev/node:0.0.12",
+		User:       "1000:1000",
+		Env:        []string{"PUBLIC=value", "SECRET=do-not-store-in-label"},
+		Cmd:        []string{"sleep", "infinity"},
+		WorkingDir: "/workspace",
+		Tty:        false,
+		ExposedPorts: nat.PortSet{
+			httpPort: struct{}{},
+		},
+		Labels: map[string]string{LabelCodeflyEphemeral: "true"},
+	}
+	host := &container.HostConfig{
+		Mounts: []mount.Mount{{
+			Type:   mount.TypeBind,
+			Source: "/host/source",
+			Target: "/workspace",
+		}},
+		PortBindings: nat.PortMap{
+			httpPort: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "10571"}},
+		},
+	}
+
+	original, err := containerConfigFingerprint(config, host)
+	if err != nil {
+		t.Fatalf("fingerprint original config: %v", err)
+	}
+	repeated, err := containerConfigFingerprint(config, host)
+	if err != nil {
+		t.Fatalf("fingerprint repeated config: %v", err)
+	}
+	if original != repeated {
+		t.Fatalf("unchanged config fingerprint drifted: %q != %q", original, repeated)
+	}
+
+	withNodeModules := *host
+	withNodeModules.Mounts = append(append([]mount.Mount(nil), host.Mounts...), mount.Mount{
+		Type:   mount.TypeBind,
+		Source: "/codefly/cache/node-modules",
+		Target: "/workspace/node_modules",
+	})
+	changedMount, err := containerConfigFingerprint(config, &withNodeModules)
+	if err != nil {
+		t.Fatalf("fingerprint changed mounts: %v", err)
+	}
+	if changedMount == original {
+		t.Fatal("adding a runtime cache mount did not change the fingerprint")
+	}
+
+	changedConfig := *config
+	changedConfig.Env = append([]string(nil), config.Env...)
+	changedConfig.Env[0] = "PUBLIC=changed"
+	changedEnvironment, err := containerConfigFingerprint(&changedConfig, host)
+	if err != nil {
+		t.Fatalf("fingerprint changed environment: %v", err)
+	}
+	if changedEnvironment == original {
+		t.Fatal("changing the runtime environment did not change the fingerprint")
+	}
+}

--- a/runners/dockerrun/docker_runner.go
+++ b/runners/dockerrun/docker_runner.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,6 +174,11 @@ func (docker *DockerEnvironment) Init(ctx context.Context) error {
 func (docker *DockerEnvironment) GetContainer(ctx context.Context) error {
 	w := wool.Get(ctx).In("Docker.GetContainer")
 
+	containerConfig, hostConfig, err := docker.desiredContainerConfigs(ctx)
+	if err != nil {
+		return w.Wrapf(err, "cannot prepare container configuration")
+	}
+
 	exists, err := docker.IsContainerPresent(ctx)
 	if err != nil {
 		return w.Wrapf(err, "cannot check if container is present")
@@ -184,10 +192,28 @@ func (docker *DockerEnvironment) GetContainer(ctx context.Context) error {
 	}()
 
 	if exists {
+		inspect, inspectErr := docker.client.ContainerInspect(ctx, docker.instance.ID)
+		if inspectErr != nil {
+			return w.Wrapf(inspectErr, "cannot inspect existing container")
+		}
+		actualFingerprint := ""
+		if inspect.Config != nil && inspect.Config.Labels != nil {
+			actualFingerprint = inspect.Config.Labels[LabelCodeflyConfig]
+		}
+		expectedFingerprint := containerConfig.Labels[LabelCodeflyConfig]
+		if actualFingerprint != expectedFingerprint {
+			w.Info("recreating container because runtime configuration changed",
+				wool.Field("container", docker.name))
+			if removeErr := docker.client.ContainerRemove(ctx, docker.instance.ID, container.RemoveOptions{Force: true}); removeErr != nil {
+				return w.Wrapf(removeErr, "cannot remove container with stale runtime configuration")
+			}
+			docker.instance = nil
+			return docker.createAndStartContainer(ctx, containerConfig, hostConfig)
+		}
 		return docker.ensureContainerRunning(ctx)
 	}
 
-	return docker.createAndStartContainer(ctx)
+	return docker.createAndStartContainer(ctx, containerConfig, hostConfig)
 }
 
 func (docker *DockerEnvironment) ensureContainerRunning(ctx context.Context) error {
@@ -291,11 +317,13 @@ func redactedContainerConfig(config *container.Config) *container.Config {
 	return &redacted
 }
 
-func (docker *DockerEnvironment) createAndStartContainer(ctx context.Context) error {
+func (docker *DockerEnvironment) createAndStartContainer(
+	ctx context.Context,
+	containerConfig *container.Config,
+	hostConfig *container.HostConfig,
+) error {
 	w := wool.Get(ctx).In("Docker.createAndStartContainer")
 
-	containerConfig := docker.createContainerConfig(ctx)
-	hostConfig := docker.createHostConfig(ctx)
 	logConfig := redactedContainerConfig(containerConfig)
 
 	w.Debug("create container config",
@@ -329,6 +357,96 @@ func (docker *DockerEnvironment) createAndStartContainer(ctx context.Context) er
 
 	docker.running = true
 	return nil
+}
+
+// desiredContainerConfigs constructs the complete Docker declaration and tags
+// it with a non-reversible fingerprint. Named containers may survive an agent
+// restart so they can be reused, but reusing one whose image, environment,
+// mounts, command, or ports changed is incorrect. The fingerprint lets
+// GetContainer distinguish a reusable container from stale runtime state
+// without storing secret environment values in Docker labels.
+func (docker *DockerEnvironment) desiredContainerConfigs(ctx context.Context) (*container.Config, *container.HostConfig, error) {
+	containerConfig := docker.createContainerConfig(ctx)
+	hostConfig := docker.createHostConfig(ctx)
+	fingerprint, err := containerConfigFingerprint(containerConfig, hostConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	if containerConfig.Labels == nil {
+		containerConfig.Labels = make(map[string]string)
+	}
+	containerConfig.Labels[LabelCodeflyConfig] = fingerprint
+	return containerConfig, hostConfig, nil
+}
+
+type containerPortBindingFingerprint struct {
+	Port     string `json:"port"`
+	HostIP   string `json:"host_ip"`
+	HostPort string `json:"host_port"`
+}
+
+type containerRuntimeFingerprint struct {
+	Image        string                            `json:"image"`
+	User         string                            `json:"user"`
+	Environment  []string                          `json:"environment"`
+	Command      []string                          `json:"command"`
+	WorkingDir   string                            `json:"working_dir"`
+	TTY          bool                              `json:"tty"`
+	ExposedPorts []string                          `json:"exposed_ports"`
+	Mounts       []mount.Mount                     `json:"mounts"`
+	PortBindings []containerPortBindingFingerprint `json:"port_bindings"`
+	Ephemeral    bool                              `json:"ephemeral"`
+}
+
+func containerConfigFingerprint(containerConfig *container.Config, hostConfig *container.HostConfig) (string, error) {
+	if containerConfig == nil || hostConfig == nil {
+		return "", fmt.Errorf("container and host configurations are required")
+	}
+
+	exposedPorts := make([]string, 0, len(containerConfig.ExposedPorts))
+	for port := range containerConfig.ExposedPorts {
+		exposedPorts = append(exposedPorts, string(port))
+	}
+	sort.Strings(exposedPorts)
+
+	portBindings := make([]containerPortBindingFingerprint, 0, len(hostConfig.PortBindings))
+	for port, bindings := range hostConfig.PortBindings {
+		for _, binding := range bindings {
+			portBindings = append(portBindings, containerPortBindingFingerprint{
+				Port:     string(port),
+				HostIP:   binding.HostIP,
+				HostPort: binding.HostPort,
+			})
+		}
+	}
+	sort.Slice(portBindings, func(i, j int) bool {
+		if portBindings[i].Port != portBindings[j].Port {
+			return portBindings[i].Port < portBindings[j].Port
+		}
+		if portBindings[i].HostIP != portBindings[j].HostIP {
+			return portBindings[i].HostIP < portBindings[j].HostIP
+		}
+		return portBindings[i].HostPort < portBindings[j].HostPort
+	})
+
+	spec := containerRuntimeFingerprint{
+		Image:        containerConfig.Image,
+		User:         containerConfig.User,
+		Environment:  append([]string(nil), containerConfig.Env...),
+		Command:      append([]string(nil), containerConfig.Cmd...),
+		WorkingDir:   containerConfig.WorkingDir,
+		TTY:          containerConfig.Tty,
+		ExposedPorts: exposedPorts,
+		Mounts:       append([]mount.Mount(nil), hostConfig.Mounts...),
+		PortBindings: portBindings,
+		Ephemeral:    containerConfig.Labels[LabelCodeflyEphemeral] == "true",
+	}
+	encoded, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("encode container runtime fingerprint: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", sum[:]), nil
 }
 
 func (docker *DockerEnvironment) createContainerConfig(ctx context.Context) *container.Config {
@@ -387,6 +505,7 @@ const (
 	LabelCodeflySession   = "codefly.session"   // PID of the spawning CLI
 	LabelCodeflyName      = "codefly.name"      // container's logical name
 	LabelCodeflyEphemeral = "codefly.ephemeral" // "true" for SDK/test (--cli-server) containers
+	LabelCodeflyConfig    = "codefly.config"    // hash of reusable runtime configuration
 	// EphemeralContainersEnvironment carries ephemeral lifecycle intent across
 	// the CLI → agent process boundary: the CLI owns orchestration, but service
 	// agents create the containers. The CLI plants this marker before spawning
@@ -550,6 +669,51 @@ func (docker *DockerEnvironment) WithMount(sourceDir string, targetDir string) {
 		Source: sourceDir,
 		Target: targetDir,
 	})
+}
+
+// WithPersistentCacheMount layers a Codefly-owned, persistent host directory
+// over a mutable path inside the container.
+//
+// Service source is normally bind-mounted so editors and hot reload keep
+// working. Some tools also write runtime state below that source tree (for
+// example Next.js writes .next/dev/lock). Two independently namespaced
+// Codefly runs must not share that mutable state even though they intentionally
+// share the same source checkout.
+//
+// The caller supplies only a stable logical key and the container target. Core
+// owns the host path and scopes it by the Docker environment name, which already
+// includes workspace, service, and Codefly naming scope. Caches survive normal
+// container teardown and may be reclaimed centrally in the future.
+func (docker *DockerEnvironment) WithPersistentCacheMount(ctx context.Context, key, targetDir string) (string, error) {
+	if err := validateCacheMountKey(key); err != nil {
+		return "", err
+	}
+	if targetDir == "" || !filepath.IsAbs(targetDir) {
+		return "", fmt.Errorf("cache mount target must be an absolute path: %q", targetDir)
+	}
+
+	cacheDir := filepath.Join(resources.CodeflyHomeDir(), "runtime-cache", docker.name, key)
+	if _, err := shared.CheckDirectoryOrCreate(ctx, cacheDir); err != nil {
+		return "", fmt.Errorf("create persistent runtime cache %q: %w", key, err)
+	}
+	docker.WithMount(cacheDir, targetDir)
+	return cacheDir, nil
+}
+
+func validateCacheMountKey(key string) error {
+	if key == "" || key == "." || key == ".." {
+		return fmt.Errorf("cache mount key must not be empty or relative traversal: %q", key)
+	}
+	for _, character := range key {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return fmt.Errorf("cache mount key contains unsupported character %q: %q", character, key)
+	}
+	return nil
 }
 
 // WithDockerSocket explicitly grants the container control of the host Docker


### PR DESCRIPTION
## Summary
- select checked-in configuration profiles independently from typed environment identity
- isolate mutable container caches by workspace/service/naming scope
- fingerprint reusable Docker containers and recreate them when runtime configuration changes

## Validation
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- concurrent Warden dev/stable stacks use distinct Next.js and dependency caches, containers, ports, and stores