### PR TITLE
Declare question defaults and serialize Trivy cache access

### DIFF
--- a/agents/communicate/answers.go
+++ b/agents/communicate/answers.go
@@ -6,6 +6,98 @@ import (
 	agentv0 "github.com/codefly-dev/core/generated/go/codefly/services/agent/v0"
 )
 
+// AnswerDefault resolves a question using only its protocol-declared default.
+// It is the shared non-interactive policy for CI, MCP, pipes, and orchestration:
+// callers must never guess a choice that the plugin did not declare.
+func AnswerDefault(question *agentv0.Question) (*agentv0.Answer, error) {
+	if question == nil {
+		return nil, fmt.Errorf("cannot answer nil question")
+	}
+	name := "<unnamed>"
+	if question.Message != nil && question.Message.Name != "" {
+		name = question.Message.Name
+	}
+	switch value := question.Value.(type) {
+	case *agentv0.Question_Confirm:
+		if value.Confirm == nil {
+			return nil, fmt.Errorf("headless question %q has no confirm definition", name)
+		}
+		return &agentv0.Answer{
+			Value: &agentv0.Answer_Confirm{
+				Confirm: &agentv0.ConfirmAnswer{Confirmed: value.Confirm.GetDefault()},
+			},
+		}, nil
+	case *agentv0.Question_Input:
+		if value.Input == nil || value.Input.Default == nil {
+			return nil, fmt.Errorf("headless question %q requires input but declares no default", name)
+		}
+		switch defaultValue := value.Input.Default.(type) {
+		case *agentv0.Input_StringDefault:
+			return &agentv0.Answer{
+				Value: &agentv0.Answer_Input{
+					Input: &agentv0.InputAnswer{
+						Answer: &agentv0.InputAnswer_StringValue{StringValue: defaultValue.StringDefault},
+					},
+				},
+			}, nil
+		case *agentv0.Input_IntDefault:
+			return &agentv0.Answer{
+				Value: &agentv0.Answer_Input{
+					Input: &agentv0.InputAnswer{
+						Answer: &agentv0.InputAnswer_IntValue{IntValue: defaultValue.IntDefault},
+					},
+				},
+			}, nil
+		default:
+			return nil, fmt.Errorf("headless question %q has an unsupported input default %T", name, defaultValue)
+		}
+	case *agentv0.Question_Choice:
+		if value.Choice == nil || value.Choice.GetDefaultOption() == "" {
+			return nil, fmt.Errorf("headless question %q requires a choice but declares no default option", name)
+		}
+		defaultOption := value.Choice.GetDefaultOption()
+		if !containsOption(value.Choice.GetOptions(), defaultOption) {
+			return nil, fmt.Errorf("headless question %q declares unknown default option %q", name, defaultOption)
+		}
+		return &agentv0.Answer{
+			Value: &agentv0.Answer_Choice{
+				Choice: &agentv0.ChoiceAnswer{Option: defaultOption},
+			},
+		}, nil
+	case *agentv0.Question_Selection:
+		if value.Selection == nil || value.Selection.GetDefault() == nil {
+			return nil, fmt.Errorf("headless question %q requires a selection but declares no default selection", name)
+		}
+		selected := append([]string(nil), value.Selection.GetDefault().GetOptions()...)
+		seen := make(map[string]struct{}, len(selected))
+		for _, option := range selected {
+			if !containsOption(value.Selection.GetOptions(), option) {
+				return nil, fmt.Errorf("headless question %q declares unknown default selection %q", name, option)
+			}
+			if _, duplicate := seen[option]; duplicate {
+				return nil, fmt.Errorf("headless question %q declares duplicate default selection %q", name, option)
+			}
+			seen[option] = struct{}{}
+		}
+		return &agentv0.Answer{
+			Value: &agentv0.Answer_Selection{
+				Selection: &agentv0.SelectionAnswer{Selected: selected},
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("headless question %q has no protocol-declared default for %T", name, question.Value)
+	}
+}
+
+func containsOption(options []*agentv0.Message, name string) bool {
+	for _, option := range options {
+		if option != nil && option.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // Default value extractors from question definitions.
 
 func GetDefaultConfirm(options []*agentv0.Question, name string) (bool, error) {

--- a/agents/communicate/answers_test.go
+++ b/agents/communicate/answers_test.go
@@ -1,0 +1,55 @@
+package communicate
+
+import (
+	"testing"
+
+	agentv0 "github.com/codefly-dev/core/generated/go/codefly/services/agent/v0"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnswerDefaultResolvesDeclaredChoiceAndSelection(t *testing.T) {
+	options := []*agentv0.Message{
+		{Name: "development"},
+		{Name: "production"},
+	}
+
+	choice, err := AnswerDefault(NewChoiceWithDefault(
+		&agentv0.Message{Name: "runtime"},
+		"production",
+		options...,
+	))
+	require.NoError(t, err)
+	require.Equal(t, "production", choice.GetChoice().GetOption())
+
+	selection, err := AnswerDefault(NewSelectionWithDefault(
+		&agentv0.Message{Name: "targets"},
+		[]string{"development", "production"},
+		options...,
+	))
+	require.NoError(t, err)
+	require.Equal(t, []string{"development", "production"}, selection.GetSelection().GetSelected())
+
+	empty, err := AnswerDefault(NewSelectionWithDefault(
+		&agentv0.Message{Name: "targets"},
+		nil,
+		options...,
+	))
+	require.NoError(t, err)
+	require.Empty(t, empty.GetSelection().GetSelected())
+}
+
+func TestAnswerDefaultRejectsMissingOrInvalidDeclaredDecisions(t *testing.T) {
+	option := &agentv0.Message{Name: "development"}
+	tests := []*agentv0.Question{
+		NewChoice(&agentv0.Message{Name: "runtime"}, option),
+		NewChoiceWithDefault(&agentv0.Message{Name: "runtime"}, "unknown", option),
+		NewSelection(&agentv0.Message{Name: "targets"}, option),
+		NewSelectionWithDefault(&agentv0.Message{Name: "targets"}, []string{"unknown"}, option),
+		NewSelectionWithDefault(&agentv0.Message{Name: "targets"}, []string{"development", "development"}, option),
+	}
+	for _, question := range tests {
+		_, err := AnswerDefault(question)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "headless question")
+	}
+}

--- a/agents/communicate/questions.go
+++ b/agents/communicate/questions.go
@@ -71,3 +71,34 @@ func NewChoice(msg *agentv0.Message, options ...*agentv0.Message) *agentv0.Quest
 		},
 	}
 }
+
+// NewChoiceWithDefault declares the deterministic option selected by
+// non-interactive callers. defaultOption is the stable Message.Name, not its
+// display label.
+func NewChoiceWithDefault(msg *agentv0.Message, defaultOption string, options ...*agentv0.Message) *agentv0.Question {
+	return &agentv0.Question{
+		Message: msg,
+		Value: &agentv0.Question_Choice{
+			Choice: &agentv0.Choice{
+				Options:       options,
+				DefaultOption: defaultOption,
+			},
+		},
+	}
+}
+
+// NewSelectionWithDefault declares the deterministic set selected by
+// non-interactive callers. Each value is a stable Message.Name.
+func NewSelectionWithDefault(msg *agentv0.Message, defaultOptions []string, options ...*agentv0.Message) *agentv0.Question {
+	return &agentv0.Question{
+		Message: msg,
+		Value: &agentv0.Question_Selection{
+			Selection: &agentv0.Selection{
+				Options: options,
+				Default: &agentv0.SelectionDefault{
+					Options: append([]string(nil), defaultOptions...),
+				},
+			},
+		},
+	}
+}

--- a/agents/communicate/questions_test.go
+++ b/agents/communicate/questions_test.go
@@ -1,0 +1,27 @@
+package communicate
+
+import (
+	"testing"
+
+	agentv0 "github.com/codefly-dev/core/generated/go/codefly/services/agent/v0"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChoiceAndSelectionDefaultsUseStableOptionNames(t *testing.T) {
+	message := &agentv0.Message{Name: "runtime"}
+	development := &agentv0.Message{Name: "development", Message: "Development"}
+	production := &agentv0.Message{Name: "production", Message: "Production"}
+
+	choice := NewChoiceWithDefault(message, "development", development, production)
+	require.Equal(t, "development", choice.GetChoice().GetDefaultOption())
+	require.Equal(t, []*agentv0.Message{development, production}, choice.GetChoice().GetOptions())
+
+	selection := NewSelectionWithDefault(message, []string{"production"}, development, production)
+	require.Equal(t, []string{"production"}, selection.GetSelection().GetDefault().GetOptions())
+	require.Equal(t, []*agentv0.Message{development, production}, selection.GetSelection().GetOptions())
+
+	empty := NewSelectionWithDefault(message, nil, development, production)
+	require.NotNil(t, empty.GetSelection().GetDefault())
+	require.Empty(t, empty.GetSelection().GetDefault().GetOptions())
+	require.Nil(t, NewSelection(message, development, production).GetSelection().GetDefault())
+}

--- a/agents/services/audit/docker.go
+++ b/agents/services/audit/docker.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/gofrs/flock"
 )
 
 const (
@@ -29,19 +31,31 @@ func Docker(ctx context.Context, image string) (*Result, error) {
 		return nil, fmt.Errorf("trivy audit requires a container image reference")
 	}
 	name := "trivy"
-	args := []string{"image", "--quiet", "--format", "json", "--severity", "HIGH,CRITICAL", image}
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve Trivy cache: %w", err)
+	}
+	cache := filepath.Join(userCache, "codefly", "trivy")
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		return nil, fmt.Errorf("create Trivy cache: %w", err)
+	}
+	// Trivy's filesystem cache is single-writer. Codefly audits services in
+	// parallel and each service agent is a separate process, so an in-process
+	// mutex cannot protect the shared BoltDB cache. Use a cross-process lock
+	// around the scan for both native and containerized Trivy. This preserves
+	// one reusable vulnerability database without nondeterministic lock
+	// timeouts or multiplying the database per service.
+	cacheLock, err := lockTrivyCache(ctx, cache)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cacheLock.Unlock() }()
+
+	args := []string{"--cache-dir", cache, "image", "--quiet", "--format", "json", "--severity", "HIGH,CRITICAL", image}
 	res.Tool = "trivy"
 	if !have(name) {
 		if !have("docker") {
 			return nil, fmt.Errorf("trivy audit unavailable: neither trivy nor docker is installed")
-		}
-		cache, err := os.UserCacheDir()
-		if err != nil {
-			return nil, fmt.Errorf("resolve Trivy cache: %w", err)
-		}
-		cache = filepath.Join(cache, "codefly", "trivy")
-		if err := os.MkdirAll(cache, 0o700); err != nil {
-			return nil, fmt.Errorf("create Trivy cache: %w", err)
 		}
 		name = "docker"
 		args = []string{"run", "--rm", "--network", "bridge", "-v", cache + ":/root/.cache/trivy", TrivyImage,
@@ -63,6 +77,21 @@ func Docker(ctx context.Context, image string) (*Result, error) {
 	}
 	res.Findings = parseTrivy(out)
 	return res, nil
+}
+
+func lockTrivyCache(ctx context.Context, cache string) (*flock.Flock, error) {
+	lock := flock.New(filepath.Join(cache, ".codefly.lock"))
+	locked, err := lock.TryLockContext(ctx, 250*time.Millisecond)
+	if err != nil {
+		return nil, fmt.Errorf("lock Trivy cache: %w", err)
+	}
+	if !locked {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("lock Trivy cache: %w", err)
+		}
+		return nil, fmt.Errorf("lock Trivy cache: lock was not acquired")
+	}
+	return lock, nil
 }
 
 // trivyOutput captures the subset of `trivy image --format json` we need.

--- a/agents/services/audit/docker_test.go
+++ b/agents/services/audit/docker_test.go
@@ -1,0 +1,26 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrivyCacheLockSerializesAgentProcesses(t *testing.T) {
+	cache := t.TempDir()
+
+	first, err := lockTrivyCache(context.Background(), cache)
+	require.NoError(t, err)
+
+	waitContext, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = lockTrivyCache(waitContext, cache)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	require.NoError(t, first.Unlock())
+	second, err := lockTrivyCache(context.Background(), cache)
+	require.NoError(t, err)
+	require.NoError(t, second.Unlock())
+}

--- a/generated/go/codefly/services/agent/v0/communicate.pb.go
+++ b/generated/go/codefly/services/agent/v0/communicate.pb.go
@@ -402,7 +402,10 @@ func (*InputAnswer_IntValue) isInputAnswer_Answer() {}
 type Choice struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// options are the choices shown to the user.
-	Options       []*Message `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"`
+	Options []*Message `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"`
+	// default_option is the stable option name selected by non-interactive
+	// callers. Empty means no default was declared.
+	DefaultOption string `protobuf:"bytes,2,opt,name=default_option,json=defaultOption,proto3" json:"default_option,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -442,6 +445,13 @@ func (x *Choice) GetOptions() []*Message {
 		return x.Options
 	}
 	return nil
+}
+
+func (x *Choice) GetDefaultOption() string {
+	if x != nil {
+		return x.DefaultOption
+	}
+	return ""
 }
 
 // ChoiceAnswer returns the selected option name.
@@ -490,18 +500,68 @@ func (x *ChoiceAnswer) GetOption() string {
 	return ""
 }
 
+// SelectionDefault distinguishes an explicitly empty default selection from
+// the absence of a declared default.
+type SelectionDefault struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// options are stable Message.name values.
+	Options       []string `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SelectionDefault) Reset() {
+	*x = SelectionDefault{}
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SelectionDefault) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SelectionDefault) ProtoMessage() {}
+
+func (x *SelectionDefault) ProtoReflect() protoreflect.Message {
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SelectionDefault.ProtoReflect.Descriptor instead.
+func (*SelectionDefault) Descriptor() ([]byte, []int) {
+	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SelectionDefault) GetOptions() []string {
+	if x != nil {
+		return x.Options
+	}
+	return nil
+}
+
 // Selection asks the user to select zero or more options.
 type Selection struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// options are the choices shown to the user.
-	Options       []*Message `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"`
+	Options []*Message `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"`
+	// default is the selection used by non-interactive callers. A present
+	// message with no options is an explicitly empty default.
+	Default       *SelectionDefault `protobuf:"bytes,2,opt,name=default,proto3" json:"default,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Selection) Reset() {
 	*x = Selection{}
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[8]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -513,7 +573,7 @@ func (x *Selection) String() string {
 func (*Selection) ProtoMessage() {}
 
 func (x *Selection) ProtoReflect() protoreflect.Message {
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[8]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -526,12 +586,19 @@ func (x *Selection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Selection.ProtoReflect.Descriptor instead.
 func (*Selection) Descriptor() ([]byte, []int) {
-	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{8}
+	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Selection) GetOptions() []*Message {
 	if x != nil {
 		return x.Options
+	}
+	return nil
+}
+
+func (x *Selection) GetDefault() *SelectionDefault {
+	if x != nil {
+		return x.Default
 	}
 	return nil
 }
@@ -547,7 +614,7 @@ type SelectionAnswer struct {
 
 func (x *SelectionAnswer) Reset() {
 	*x = SelectionAnswer{}
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[9]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -559,7 +626,7 @@ func (x *SelectionAnswer) String() string {
 func (*SelectionAnswer) ProtoMessage() {}
 
 func (x *SelectionAnswer) ProtoReflect() protoreflect.Message {
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[9]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -572,7 +639,7 @@ func (x *SelectionAnswer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectionAnswer.ProtoReflect.Descriptor instead.
 func (*SelectionAnswer) Descriptor() ([]byte, []int) {
-	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{9}
+	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SelectionAnswer) GetSelected() []string {
@@ -603,7 +670,7 @@ type Question struct {
 
 func (x *Question) Reset() {
 	*x = Question{}
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[10]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +682,7 @@ func (x *Question) String() string {
 func (*Question) ProtoMessage() {}
 
 func (x *Question) ProtoReflect() protoreflect.Message {
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[10]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +695,7 @@ func (x *Question) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Question.ProtoReflect.Descriptor instead.
 func (*Question) Descriptor() ([]byte, []int) {
-	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{10}
+	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Question) GetMessage() *Message {
@@ -747,7 +814,7 @@ type Answer struct {
 
 func (x *Answer) Reset() {
 	*x = Answer{}
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[11]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -759,7 +826,7 @@ func (x *Answer) String() string {
 func (*Answer) ProtoMessage() {}
 
 func (x *Answer) ProtoReflect() protoreflect.Message {
-	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[11]
+	mi := &file_codefly_services_agent_v0_communicate_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -772,7 +839,7 @@ func (x *Answer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Answer.ProtoReflect.Descriptor instead.
 func (*Answer) Descriptor() ([]byte, []int) {
-	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{11}
+	return file_codefly_services_agent_v0_communicate_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Answer) GetValue() isAnswer_Value {
@@ -876,13 +943,17 @@ const file_codefly_services_agent_v0_communicate_proto_rawDesc = "" +
 	"\vInputAnswer\x12#\n" +
 	"\fstring_value\x18\x01 \x01(\tH\x00R\vstringValue\x12\x1d\n" +
 	"\tint_value\x18\x02 \x01(\x05H\x00R\bintValueB\b\n" +
-	"\x06answer\"F\n" +
+	"\x06answer\"m\n" +
 	"\x06Choice\x12<\n" +
-	"\aoptions\x18\x01 \x03(\v2\".codefly.services.agent.v0.MessageR\aoptions\"&\n" +
+	"\aoptions\x18\x01 \x03(\v2\".codefly.services.agent.v0.MessageR\aoptions\x12%\n" +
+	"\x0edefault_option\x18\x02 \x01(\tR\rdefaultOption\"&\n" +
 	"\fChoiceAnswer\x12\x16\n" +
-	"\x06option\x18\x01 \x01(\tR\x06option\"I\n" +
+	"\x06option\x18\x01 \x01(\tR\x06option\",\n" +
+	"\x10SelectionDefault\x12\x18\n" +
+	"\aoptions\x18\x01 \x03(\tR\aoptions\"\x90\x01\n" +
 	"\tSelection\x12<\n" +
-	"\aoptions\x18\x01 \x03(\v2\".codefly.services.agent.v0.MessageR\aoptions\"-\n" +
+	"\aoptions\x18\x01 \x03(\v2\".codefly.services.agent.v0.MessageR\aoptions\x12E\n" +
+	"\adefault\x18\x02 \x01(\v2+.codefly.services.agent.v0.SelectionDefaultR\adefault\"-\n" +
 	"\x0fSelectionAnswer\x12\x1a\n" +
 	"\bselected\x18\x01 \x03(\tR\bselected\"\x8e\x03\n" +
 	"\bQuestion\x12<\n" +
@@ -913,41 +984,43 @@ func file_codefly_services_agent_v0_communicate_proto_rawDescGZIP() []byte {
 	return file_codefly_services_agent_v0_communicate_proto_rawDescData
 }
 
-var file_codefly_services_agent_v0_communicate_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_codefly_services_agent_v0_communicate_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_codefly_services_agent_v0_communicate_proto_goTypes = []any{
-	(*Message)(nil),         // 0: codefly.services.agent.v0.Message
-	(*Display)(nil),         // 1: codefly.services.agent.v0.Display
-	(*Confirm)(nil),         // 2: codefly.services.agent.v0.Confirm
-	(*ConfirmAnswer)(nil),   // 3: codefly.services.agent.v0.ConfirmAnswer
-	(*Input)(nil),           // 4: codefly.services.agent.v0.Input
-	(*InputAnswer)(nil),     // 5: codefly.services.agent.v0.InputAnswer
-	(*Choice)(nil),          // 6: codefly.services.agent.v0.Choice
-	(*ChoiceAnswer)(nil),    // 7: codefly.services.agent.v0.ChoiceAnswer
-	(*Selection)(nil),       // 8: codefly.services.agent.v0.Selection
-	(*SelectionAnswer)(nil), // 9: codefly.services.agent.v0.SelectionAnswer
-	(*Question)(nil),        // 10: codefly.services.agent.v0.Question
-	(*Answer)(nil),          // 11: codefly.services.agent.v0.Answer
-	nil,                     // 12: codefly.services.agent.v0.Display.DataEntry
+	(*Message)(nil),          // 0: codefly.services.agent.v0.Message
+	(*Display)(nil),          // 1: codefly.services.agent.v0.Display
+	(*Confirm)(nil),          // 2: codefly.services.agent.v0.Confirm
+	(*ConfirmAnswer)(nil),    // 3: codefly.services.agent.v0.ConfirmAnswer
+	(*Input)(nil),            // 4: codefly.services.agent.v0.Input
+	(*InputAnswer)(nil),      // 5: codefly.services.agent.v0.InputAnswer
+	(*Choice)(nil),           // 6: codefly.services.agent.v0.Choice
+	(*ChoiceAnswer)(nil),     // 7: codefly.services.agent.v0.ChoiceAnswer
+	(*SelectionDefault)(nil), // 8: codefly.services.agent.v0.SelectionDefault
+	(*Selection)(nil),        // 9: codefly.services.agent.v0.Selection
+	(*SelectionAnswer)(nil),  // 10: codefly.services.agent.v0.SelectionAnswer
+	(*Question)(nil),         // 11: codefly.services.agent.v0.Question
+	(*Answer)(nil),           // 12: codefly.services.agent.v0.Answer
+	nil,                      // 13: codefly.services.agent.v0.Display.DataEntry
 }
 var file_codefly_services_agent_v0_communicate_proto_depIdxs = []int32{
-	12, // 0: codefly.services.agent.v0.Display.data:type_name -> codefly.services.agent.v0.Display.DataEntry
+	13, // 0: codefly.services.agent.v0.Display.data:type_name -> codefly.services.agent.v0.Display.DataEntry
 	0,  // 1: codefly.services.agent.v0.Choice.options:type_name -> codefly.services.agent.v0.Message
 	0,  // 2: codefly.services.agent.v0.Selection.options:type_name -> codefly.services.agent.v0.Message
-	0,  // 3: codefly.services.agent.v0.Question.message:type_name -> codefly.services.agent.v0.Message
-	1,  // 4: codefly.services.agent.v0.Question.display:type_name -> codefly.services.agent.v0.Display
-	2,  // 5: codefly.services.agent.v0.Question.confirm:type_name -> codefly.services.agent.v0.Confirm
-	4,  // 6: codefly.services.agent.v0.Question.input:type_name -> codefly.services.agent.v0.Input
-	6,  // 7: codefly.services.agent.v0.Question.choice:type_name -> codefly.services.agent.v0.Choice
-	8,  // 8: codefly.services.agent.v0.Question.selection:type_name -> codefly.services.agent.v0.Selection
-	3,  // 9: codefly.services.agent.v0.Answer.confirm:type_name -> codefly.services.agent.v0.ConfirmAnswer
-	5,  // 10: codefly.services.agent.v0.Answer.input:type_name -> codefly.services.agent.v0.InputAnswer
-	7,  // 11: codefly.services.agent.v0.Answer.choice:type_name -> codefly.services.agent.v0.ChoiceAnswer
-	9,  // 12: codefly.services.agent.v0.Answer.selection:type_name -> codefly.services.agent.v0.SelectionAnswer
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	8,  // 3: codefly.services.agent.v0.Selection.default:type_name -> codefly.services.agent.v0.SelectionDefault
+	0,  // 4: codefly.services.agent.v0.Question.message:type_name -> codefly.services.agent.v0.Message
+	1,  // 5: codefly.services.agent.v0.Question.display:type_name -> codefly.services.agent.v0.Display
+	2,  // 6: codefly.services.agent.v0.Question.confirm:type_name -> codefly.services.agent.v0.Confirm
+	4,  // 7: codefly.services.agent.v0.Question.input:type_name -> codefly.services.agent.v0.Input
+	6,  // 8: codefly.services.agent.v0.Question.choice:type_name -> codefly.services.agent.v0.Choice
+	9,  // 9: codefly.services.agent.v0.Question.selection:type_name -> codefly.services.agent.v0.Selection
+	3,  // 10: codefly.services.agent.v0.Answer.confirm:type_name -> codefly.services.agent.v0.ConfirmAnswer
+	5,  // 11: codefly.services.agent.v0.Answer.input:type_name -> codefly.services.agent.v0.InputAnswer
+	7,  // 12: codefly.services.agent.v0.Answer.choice:type_name -> codefly.services.agent.v0.ChoiceAnswer
+	10, // 13: codefly.services.agent.v0.Answer.selection:type_name -> codefly.services.agent.v0.SelectionAnswer
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_codefly_services_agent_v0_communicate_proto_init() }
@@ -963,14 +1036,14 @@ func file_codefly_services_agent_v0_communicate_proto_init() {
 		(*InputAnswer_StringValue)(nil),
 		(*InputAnswer_IntValue)(nil),
 	}
-	file_codefly_services_agent_v0_communicate_proto_msgTypes[10].OneofWrappers = []any{
+	file_codefly_services_agent_v0_communicate_proto_msgTypes[11].OneofWrappers = []any{
 		(*Question_Display)(nil),
 		(*Question_Confirm)(nil),
 		(*Question_Input)(nil),
 		(*Question_Choice)(nil),
 		(*Question_Selection)(nil),
 	}
-	file_codefly_services_agent_v0_communicate_proto_msgTypes[11].OneofWrappers = []any{
+	file_codefly_services_agent_v0_communicate_proto_msgTypes[12].OneofWrappers = []any{
 		(*Answer_Confirm)(nil),
 		(*Answer_Input)(nil),
 		(*Answer_Choice)(nil),
@@ -982,7 +1055,7 @@ func file_codefly_services_agent_v0_communicate_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_codefly_services_agent_v0_communicate_proto_rawDesc), len(file_codefly_services_agent_v0_communicate_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/proto/codefly/services/agent/v0/communicate.proto
+++ b/proto/codefly/services/agent/v0/communicate.proto
@@ -63,6 +63,9 @@ message InputAnswer {
 message Choice {
   // options are the choices shown to the user.
   repeated Message options = 1;
+  // default_option is the stable option name selected by non-interactive
+  // callers. Empty means no default was declared.
+  string default_option = 2;
 }
 
 // ChoiceAnswer returns the selected option name.
@@ -72,10 +75,20 @@ message ChoiceAnswer {
 }
 
 
+// SelectionDefault distinguishes an explicitly empty default selection from
+// the absence of a declared default.
+message SelectionDefault {
+  // options are stable Message.name values.
+  repeated string options = 1;
+}
+
 // Selection asks the user to select zero or more options.
 message Selection {
   // options are the choices shown to the user.
   repeated Message options = 1;
+  // default is the selection used by non-interactive callers. A present
+  // message with no options is an explicitly empty default.
+  SelectionDefault default = 2;
 }
 
 // SelectionAnswer returns all selected option names.


### PR DESCRIPTION
## Summary
- add protocol-declared defaults to choice and selection questions
- preserve absent versus explicitly empty multi-selection defaults
- centralize deterministic headless answering in the Core SDK
- serialize Trivy filesystem-cache access across parallel service-agent processes

## Why
Fresh agent conformance must be able to run `codefly add service --default` without inventing choices, while plugins must declare the decisions they want automation to take. Parallel Codefly audits also need one reusable Trivy database without racing its single-writer filesystem cache.

## Validation
- generated through `codefly generate proto --proto ./proto --output ./generated --local`
- focused tests and vet pass with and without `go.work`
- regression coverage for choice, explicit empty selection, invalid defaults, and cross-process Trivy serialization