### PR TITLE
Make Node audit dependency scope explicit

### DIFF
--- a/agents/services/audit/audit_test.go
+++ b/agents/services/audit/audit_test.go
@@ -4,10 +4,54 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
 )
+
+func TestNodeAuditDependencyScopeIsExplicit(t *testing.T) {
+	bin := t.TempDir()
+	argsPath := filepath.Join(t.TempDir(), "args")
+	npmPath := filepath.Join(bin, "npm")
+	npmScript := `#!/bin/sh
+printf '%s\n' "$*" >> "$CODEFLY_TEST_NPM_ARGS"
+if [ "$1" = "audit" ]; then
+  printf '%s\n' '{"vulnerabilities":{}}'
+else
+  printf '%s\n' '{}'
+fi
+`
+	if err := os.WriteFile(npmPath, []byte(npmScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	t.Setenv("CODEFLY_TEST_NPM_ARGS", argsPath)
+
+	result, err := NodeWithOptions(context.Background(), source, NodeOptions{
+		IncludeOutdated:        true,
+		IncludeDevDependencies: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Tool != "npm-audit-runtime+outdated" {
+		t.Fatalf("Tool = %q", result.Tool)
+	}
+	content, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 2 || !strings.Contains(lines[0], "audit --json --omit=dev") ||
+		!strings.Contains(lines[1], "outdated --json --package-lock-only --depth=0 --omit=dev") {
+		t.Fatalf("npm arguments = %q", lines)
+	}
+}
 
 func TestGolangUsesManagedScannerWhenOnlyGoIsAvailable(t *testing.T) {
 	bin := t.TempDir()

--- a/agents/services/audit/node.go
+++ b/agents/services/audit/node.go
@@ -12,13 +12,31 @@ import (
 	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
 )
 
+// NodeOptions controls the dependency scope and update evidence returned by a
+// Node audit.
+type NodeOptions struct {
+	IncludeOutdated        bool
+	IncludeDevDependencies bool
+}
+
 // Node scans a Node package rooted at dir (must contain package.json
-// + lockfile). Vulnerabilities: `npm audit --json`. Outdated:
-// `npm outdated --json` (returns {} when nothing outdated).
+// + lockfile), preserving the original all-dependencies behavior for existing
+// callers.
+func Node(ctx context.Context, dir string, includeOutdated bool) (*Result, error) {
+	return NodeWithOptions(ctx, dir, NodeOptions{
+		IncludeOutdated:        includeOutdated,
+		IncludeDevDependencies: true,
+	})
+}
+
+// NodeWithOptions scans vulnerabilities with `npm audit --json` and optionally
+// reports `npm outdated --json`. Runtime-only mode passes `--omit=dev` to both
+// commands so release gates describe dependencies shipped with the service;
+// development dependencies remain available as an explicit broader audit.
 //
 // Both commands exit non-zero on findings, which is normal — we still
 // parse the JSON output. Missing npm is an incomplete audit and fails.
-func Node(ctx context.Context, dir string, includeOutdated bool) (*Result, error) {
+func NodeWithOptions(ctx context.Context, dir string, options NodeOptions) (*Result, error) {
 	res := &Result{Language: "TYPESCRIPT", Tool: "npm-audit"}
 	if !have("npm") {
 		return nil, fmt.Errorf("npm audit unavailable: npm is not installed")
@@ -30,7 +48,12 @@ func Node(ctx context.Context, dir string, includeOutdated bool) (*Result, error
 		return nil, fmt.Errorf("inspect package-lock.json: %w", err)
 	}
 
-	out, err := runCmd(ctx, dir, "npm", "audit", "--json")
+	auditArgs := []string{"audit", "--json"}
+	if !options.IncludeDevDependencies {
+		auditArgs = append(auditArgs, "--omit=dev")
+		res.Tool = "npm-audit-runtime"
+	}
+	out, err := runCmd(ctx, dir, "npm", auditArgs...)
 	if err != nil && len(out) == 0 {
 		// `npm audit` failed completely (e.g. missing tool/lockfile);
 		// nothing to parse — non-zero exit on findings still yields output.
@@ -42,16 +65,20 @@ func Node(ctx context.Context, dir string, includeOutdated bool) (*Result, error
 	}
 	res.Findings = findings
 
-	if includeOutdated {
+	if options.IncludeOutdated {
 		// package-lock-only makes "current" come from the release lock rather
 		// than an arbitrary node_modules tree on the operator's machine.
-		o, err := runCmd(ctx, dir, "npm", "outdated", "--json", "--package-lock-only", "--depth=0")
+		outdatedArgs := []string{"outdated", "--json", "--package-lock-only", "--depth=0"}
+		if !options.IncludeDevDependencies {
+			outdatedArgs = append(outdatedArgs, "--omit=dev")
+		}
+		o, err := runCmd(ctx, dir, "npm", outdatedArgs...)
 		if err != nil && len(o) == 0 {
 			// `npm outdated` failed completely; skip outdated portion.
 			return nil, fmt.Errorf("npm outdated failed: %w", err)
 		}
 		res.Outdated = parseNpmOutdated(o)
-		res.Tool = "npm-audit+outdated"
+		res.Tool += "+outdated"
 	}
 	return res, nil
 }

--- a/generated/go/codefly/services/builder/v0/builder.pb.go
+++ b/generated/go/codefly/services/builder/v0/builder.pb.go
@@ -2362,9 +2362,13 @@ type AuditRequest struct {
 	IncludeOutdated bool `protobuf:"varint,1,opt,name=include_outdated,json=includeOutdated,proto3" json:"include_outdated,omitempty"`
 	// fail_on_vuln makes the agent return state=ERROR if any finding has
 	// severity HIGH or above. Default false (report-only).
-	FailOnVuln    bool `protobuf:"varint,2,opt,name=fail_on_vuln,json=failOnVuln,proto3" json:"fail_on_vuln,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	FailOnVuln bool `protobuf:"varint,2,opt,name=fail_on_vuln,json=failOnVuln,proto3" json:"fail_on_vuln,omitempty"`
+	// include_dev_dependencies includes development/test-only dependencies.
+	// The default false scopes release gates to shipped runtime dependencies;
+	// callers can opt into a broader supply-chain review.
+	IncludeDevDependencies bool `protobuf:"varint,3,opt,name=include_dev_dependencies,json=includeDevDependencies,proto3" json:"include_dev_dependencies,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *AuditRequest) Reset() {
@@ -2407,6 +2411,13 @@ func (x *AuditRequest) GetIncludeOutdated() bool {
 func (x *AuditRequest) GetFailOnVuln() bool {
 	if x != nil {
 		return x.FailOnVuln
+	}
+	return false
+}
+
+func (x *AuditRequest) GetIncludeDevDependencies() bool {
+	if x != nil {
+		return x.IncludeDevDependencies
 	}
 	return false
 }
@@ -3944,11 +3955,12 @@ const file_codefly_services_builder_v0_builder_proto_rawDesc = "" +
 	"\rconfiguration\x18\x02 \x01(\v2\x1e.codefly.base.v0.ConfigurationR\rconfiguration\x12M\n" +
 	"\n" +
 	"deployment\x18\x03 \x01(\v2-.codefly.services.builder.v0.DeploymentOutputR\n" +
-	"deployment\"[\n" +
+	"deployment\"\x95\x01\n" +
 	"\fAuditRequest\x12)\n" +
 	"\x10include_outdated\x18\x01 \x01(\bR\x0fincludeOutdated\x12 \n" +
 	"\ffail_on_vuln\x18\x02 \x01(\bR\n" +
-	"failOnVuln\"\xc8\x02\n" +
+	"failOnVuln\x128\n" +
+	"\x18include_dev_dependencies\x18\x03 \x01(\bR\x16includeDevDependencies\"\xc8\x02\n" +
 	"\fAuditFinding\x12N\n" +
 	"\bseverity\x18\x01 \x01(\x0e22.codefly.services.builder.v0.AuditFinding.SeverityR\bseverity\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x18\n" +

--- a/proto/codefly/services/builder/v0/builder.proto
+++ b/proto/codefly/services/builder/v0/builder.proto
@@ -368,6 +368,10 @@ message AuditRequest {
   // fail_on_vuln makes the agent return state=ERROR if any finding has
   // severity HIGH or above. Default false (report-only).
   bool fail_on_vuln = 2;
+  // include_dev_dependencies includes development/test-only dependencies.
+  // The default false scopes release gates to shipped runtime dependencies;
+  // callers can opt into a broader supply-chain review.
+  bool include_dev_dependencies = 3;
 }
 
 // AuditFinding is one vulnerability or security finding produced by an audit tool.


### PR DESCRIPTION
## Summary
- add an explicit `include_dev_dependencies` audit contract
- support runtime-only Node audits with `npm --omit=dev`
- preserve all-dependency behavior for existing agent callers
- verify audit and outdated commands receive the selected scope

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -race ./agents/services/audit/...`