### PR TITLE
Preserve canonical generated OpenAPI output

### DIFF
--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -174,11 +174,9 @@ func (g *Buf) Generate(ctx context.Context) error {
 	openapi := path.Join(g.Dir, "openapi/api.swagger.json")
 	if ok, err := shared.FileExists(ctx, openapi); err == nil && ok {
 		destination := path.Join(g.Dir, standards.OpenAPIPath)
-		err = shared.CopyFile(ctx, openapi, destination)
-		if err != nil {
+		if err = moveGeneratedOpenAPI(ctx, openapi, destination); err != nil {
 			return w.Wrapf(err, "cannot copy file")
 		}
-		_ = os.Remove(openapi)
 	}
 
 	// Generate TypeScript types from OpenAPI spec if swagger files exist.
@@ -235,6 +233,21 @@ func (g *Buf) Generate(ctx context.Context) error {
 		return w.Wrapf(err, "cannot update cache")
 	}
 	return nil
+}
+
+// moveGeneratedOpenAPI preserves the generated document when the generator's
+// output and Codefly's canonical OpenAPI path are the same file. The two paths
+// used to differ; after standards.OpenAPIPath converged on
+// openapi/api.swagger.json, blindly copying and then removing the source
+// deleted the canonical artifact after every successful generation.
+func moveGeneratedOpenAPI(ctx context.Context, source, destination string) error {
+	if filepath.Clean(source) == filepath.Clean(destination) {
+		return nil
+	}
+	if err := shared.CopyFile(ctx, source, destination); err != nil {
+		return err
+	}
+	return os.Remove(source)
 }
 
 func (g *Buf) cleanGeneratedDirs() error {

--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -228,11 +228,20 @@ func (g *Buf) Generate(ctx context.Context) error {
 		}
 	}
 
-	err = g.dependencies.UpdateCache(ctx)
-	if err != nil {
+	if err = g.updateGenerationCache(ctx); err != nil {
 		return w.Wrapf(err, "cannot update cache")
 	}
 	return nil
+}
+
+// updateGenerationCache hashes inputs after generation. `buf dep update` may
+// rewrite buf.lock, so persisting the pre-generation hash would force one
+// unnecessary second generation and another round of BSR requests.
+func (g *Buf) updateGenerationCache(ctx context.Context) error {
+	if _, err := g.dependencies.Updated(ctx); err != nil {
+		return err
+	}
+	return g.dependencies.UpdateCache(ctx)
 }
 
 // moveGeneratedOpenAPI preserves the generated document when the generator's

--- a/companions/proto/proto_dependencies_test.go
+++ b/companions/proto/proto_dependencies_test.go
@@ -7,6 +7,54 @@ import (
 	"testing"
 )
 
+func TestMoveGeneratedOpenAPIPreservesCanonicalSamePath(t *testing.T) {
+	canonical := filepath.Join(t.TempDir(), "openapi", "api.swagger.json")
+	if err := os.MkdirAll(filepath.Dir(canonical), 0o755); err != nil {
+		t.Fatalf("mkdir canonical directory: %v", err)
+	}
+	const document = `{"swagger":"2.0"}`
+	if err := os.WriteFile(canonical, []byte(document), 0o644); err != nil {
+		t.Fatalf("write canonical OpenAPI: %v", err)
+	}
+
+	if err := moveGeneratedOpenAPI(context.Background(), canonical, canonical); err != nil {
+		t.Fatalf("moveGeneratedOpenAPI same path: %v", err)
+	}
+	content, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("canonical OpenAPI was deleted: %v", err)
+	}
+	if string(content) != document {
+		t.Fatalf("canonical OpenAPI content = %q, want %q", content, document)
+	}
+}
+
+func TestMoveGeneratedOpenAPIMovesLegacyPath(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "generated", "api.swagger.json")
+	destination := filepath.Join(root, "openapi", "api.swagger.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source directory: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("openapi"), 0o644); err != nil {
+		t.Fatalf("write generated OpenAPI: %v", err)
+	}
+
+	if err := moveGeneratedOpenAPI(context.Background(), source, destination); err != nil {
+		t.Fatalf("moveGeneratedOpenAPI legacy path: %v", err)
+	}
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Fatalf("legacy source still exists or stat failed unexpectedly: %v", err)
+	}
+	content, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read canonical OpenAPI: %v", err)
+	}
+	if string(content) != "openapi" {
+		t.Fatalf("canonical OpenAPI content = %q", content)
+	}
+}
+
 func TestNewBufTracksEveryGenerationInput(t *testing.T) {
 	generator, err := NewBuf(context.Background(), t.TempDir())
 	if err != nil {

--- a/companions/proto/proto_dependencies_test.go
+++ b/companions/proto/proto_dependencies_test.go
@@ -76,6 +76,56 @@ func TestNewBufTracksEveryGenerationInput(t *testing.T) {
 	}
 }
 
+func TestBufGenerationCacheUsesPostGenerationInputs(t *testing.T) {
+	root := t.TempDir()
+	protoDir := filepath.Join(root, "proto")
+	cacheDir := filepath.Join(root, ".codefly", "cache")
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
+		t.Fatalf("mkdir proto directory: %v", err)
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir cache directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(protoDir, "api.proto"), []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatalf("write proto: %v", err)
+	}
+	lock := filepath.Join(protoDir, "buf.lock")
+	if err := os.WriteFile(lock, []byte("deps: []\n"), 0o644); err != nil {
+		t.Fatalf("write initial lock: %v", err)
+	}
+
+	generator, err := NewBuf(context.Background(), root)
+	if err != nil {
+		t.Fatalf("NewBuf: %v", err)
+	}
+	generator.WithCache(cacheDir)
+	updated, err := generator.dependencies.Updated(context.Background())
+	if err != nil || !updated {
+		t.Fatalf("initial Updated = %t, %v; want true", updated, err)
+	}
+
+	// Mirrors buf dep update rewriting a generation input after Updated ran.
+	if err := os.WriteFile(lock, []byte("deps:\n  - commit: updated\n"), 0o644); err != nil {
+		t.Fatalf("rewrite lock: %v", err)
+	}
+	if err := generator.updateGenerationCache(context.Background()); err != nil {
+		t.Fatalf("updateGenerationCache: %v", err)
+	}
+
+	reloaded, err := NewBuf(context.Background(), root)
+	if err != nil {
+		t.Fatalf("NewBuf reload: %v", err)
+	}
+	reloaded.WithCache(cacheDir)
+	updated, err = reloaded.dependencies.Updated(context.Background())
+	if err != nil {
+		t.Fatalf("Updated reload: %v", err)
+	}
+	if updated {
+		t.Fatal("post-generation inputs did not match the persisted cache")
+	}
+}
+
 func TestBufCleanGeneratedDirsIsStrictlyScoped(t *testing.T) {
 	root := t.TempDir()
 	generated := filepath.Join(root, "code", "pkg", "gen")


### PR DESCRIPTION
## Summary
- stop the proto companion from copying the canonical OpenAPI artifact onto itself and deleting it
- retain legacy move behavior when source and canonical destinations differ
- cover both same-path and legacy-path behavior

## Validation
- `GOWORK=off go test ./companions/proto`
- discovered by the Go gRPC fresh-service sync-drift conformance gate