### PR TITLE
Preserve protocol output roots during generation

### DIFF
--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -30,9 +30,11 @@ type Buf struct {
 	// internal cache for hash
 	cache string
 
-	// generatedDirs are generator-owned output roots removed immediately
+	// generatedDirs are generator-owned output roots emptied immediately
 	// before buf generate. Cleaning prevents package or service renames from
-	// leaving stale generated Go packages in an otherwise green build.
+	// leaving stale generated Go packages in an otherwise green build. The
+	// roots themselves remain present because local protoc plugins require
+	// their configured output directories to exist.
 	generatedDirs []string
 
 	// generatedRoot is the service boundary that contains every generated
@@ -278,6 +280,9 @@ func (g *Buf) cleanGeneratedDirs() error {
 		}
 		if err := os.RemoveAll(output); err != nil {
 			return fmt.Errorf("remove generated directory %q: %w", output, err)
+		}
+		if err := os.MkdirAll(output, 0o755); err != nil {
+			return fmt.Errorf("recreate generated directory %q: %w", output, err)
 		}
 	}
 	return nil

--- a/companions/proto/proto.go
+++ b/companions/proto/proto.go
@@ -144,6 +144,14 @@ func (g *Buf) Generate(ctx context.Context) error {
 		}
 	}()
 
+	// Prepare output roots before a Docker companion bind-mounts the source
+	// tree. Removing and recreating directories after container initialization
+	// can leave Docker Desktop with stale directory inodes, causing local
+	// plugins to fail while opening otherwise valid nested output paths.
+	if err := g.cleanGeneratedDirs(); err != nil {
+		return w.Wrapf(err, "cannot clean stale generated output")
+	}
+
 	if err := runner.Init(ctx); err != nil {
 		return w.Wrapf(err, "cannot init runner")
 	}
@@ -156,10 +164,6 @@ func (g *Buf) Generate(ctx context.Context) error {
 	err = proc.Run(ctx)
 	if err != nil {
 		return w.Wrapf(err, "cannot update buf")
-	}
-
-	if err := g.cleanGeneratedDirs(); err != nil {
-		return w.Wrapf(err, "cannot clean stale generated output")
 	}
 
 	proc, err = runner.NewProcess("buf", "generate")

--- a/companions/proto/proto_dependencies_test.go
+++ b/companions/proto/proto_dependencies_test.go
@@ -144,8 +144,12 @@ func TestBufCleanGeneratedDirsIsStrictlyScoped(t *testing.T) {
 	if err := generator.cleanGeneratedDirs(); err != nil {
 		t.Fatalf("cleanGeneratedDirs: %v", err)
 	}
-	if _, err := os.Stat(generated); !os.IsNotExist(err) {
-		t.Fatalf("generated directory still exists or stat failed unexpectedly: %v", err)
+	entries, err := os.ReadDir(generated)
+	if err != nil {
+		t.Fatalf("generated directory was not recreated: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("generated directory was not emptied: %v", entries)
 	}
 
 	outside := t.TempDir()
@@ -180,8 +184,12 @@ func TestBufCleanGeneratedDirsSupportsNestedProtocolRoots(t *testing.T) {
 	if err := generator.cleanGeneratedDirs(); err != nil {
 		t.Fatalf("cleanGeneratedDirs: %v", err)
 	}
-	if _, err := os.Stat(generated); !os.IsNotExist(err) {
-		t.Fatalf("generated directory still exists or stat failed unexpectedly: %v", err)
+	entries, err := os.ReadDir(generated)
+	if err != nil {
+		t.Fatalf("generated directory was not recreated: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("generated directory was not emptied: %v", entries)
 	}
 
 	outside := t.TempDir()


### PR DESCRIPTION
## Summary
- empty and recreate generator-owned output roots before Buf generation
- support bundled local protoc plugins that require declared output directories
- retain strict service-boundary validation and stale-output cleanup

## Validation
- `go test ./companions/proto/...`
- `go test ./...`