### PR TITLE
Retry transient Docker layer export loss

### DIFF
--- a/agents/helpers/docker/build.go
+++ b/agents/helpers/docker/build.go
@@ -32,6 +32,12 @@ type BuilderConfiguration struct {
 
 type Builder struct {
 	BuilderConfiguration
+	newClient func() (imageBuildClient, error)
+}
+
+type imageBuildClient interface {
+	ImageBuild(context.Context, io.Reader, types.ImageBuildOptions) (types.ImageBuildResponse, error)
+	Close() error
 }
 
 func IsValidDockerImageName(_ string) bool {
@@ -40,7 +46,12 @@ func IsValidDockerImageName(_ string) bool {
 }
 
 func NewBuilder(cfg BuilderConfiguration) (*Builder, error) {
-	return &Builder{BuilderConfiguration: cfg}, nil
+	return &Builder{
+		BuilderConfiguration: cfg,
+		newClient: func() (imageBuildClient, error) {
+			return dockerrun.NewClient()
+		},
+	}, nil
 }
 
 type BuilderOutput struct {
@@ -50,7 +61,7 @@ type BuilderOutput struct {
 
 func (builder *Builder) Build(ctx context.Context) (*BuilderOutput, error) {
 	w := wool.Get(ctx).In("Builder.Build", wool.DirField(builder.Root))
-	cli, err := dockerrun.NewClient()
+	cli, err := builder.newClient()
 	if err != nil {
 		return nil, w.Wrapf(err, "cannot create docker client")
 	}
@@ -62,7 +73,21 @@ func (builder *Builder) Build(ctx context.Context) (*BuilderOutput, error) {
 	}
 	buildContext := buildContextBuffer.Bytes()
 
-	// Build the Docker image
+	for attempt := 1; attempt <= 2; attempt++ {
+		err = builder.build(ctx, cli, buildContext)
+		if err == nil {
+			return &BuilderOutput{Image: builder.Destination.FullName()}, nil
+		}
+		if attempt == 2 || !isRetryableDockerLayerExportError(err) {
+			return nil, err
+		}
+		w.Warn("Docker lost an intermediate layer while exporting the image; retrying the identical immutable build context once")
+	}
+	return nil, err
+}
+
+func (builder *Builder) build(ctx context.Context, cli imageBuildClient, buildContext []byte) error {
+	w := wool.Get(ctx).In("Builder.Build", wool.DirField(builder.Root))
 	imageBuildResponse, err := cli.ImageBuild(
 		ctx,
 		bytes.NewReader(buildContext),
@@ -73,7 +98,7 @@ func (builder *Builder) Build(ctx context.Context) (*BuilderOutput, error) {
 		},
 	)
 	if err != nil {
-		return nil, w.Wrapf(err, "cannot build image")
+		return w.Wrapf(err, "cannot build image")
 	}
 
 	defer func(Body io.ReadCloser) {
@@ -124,15 +149,31 @@ func (builder *Builder) Build(ctx context.Context) (*BuilderOutput, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, w.Wrapf(err, "cannot read docker build output")
+		return w.Wrapf(err, "cannot read docker build output")
 	}
 	if buildErr != "" {
 		if detail := diagnostics.String(); detail != "" {
-			return nil, w.NewError("docker build failed: %s\nlast build output:\n%s", buildErr, detail)
+			return w.NewError("docker build failed: %s\nlast build output:\n%s", buildErr, detail)
 		}
-		return nil, w.NewError("docker build failed: %s", buildErr)
+		return w.NewError("docker build failed: %s", buildErr)
 	}
-	return &BuilderOutput{Image: builder.Destination.FullName()}, nil
+	return nil
+}
+
+// isRetryableDockerLayerExportError recognizes one narrow Docker daemon
+// storage failure. The classic builder can occasionally delete or lose an
+// intermediate layer before the final image export. Repeating the exact build
+// context reuses the surviving cache and repairs the export. Other Dockerfile,
+// network, disk, and application failures remain single-attempt and fail
+// closed.
+func isRetryableDockerLayerExportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "failed to export image") &&
+		strings.Contains(message, "failed to get layer") &&
+		strings.Contains(message, "layer does not exist")
 }
 
 type buildDiagnostics struct {

--- a/agents/helpers/docker/build_test.go
+++ b/agents/helpers/docker/build_test.go
@@ -1,8 +1,15 @@
 package docker
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/docker/docker/api/types"
 )
 
 func TestIsValidDockerImageName(t *testing.T) {
@@ -32,4 +39,111 @@ func TestBuildDiagnosticsPreservesCauseAndBoundsOutput(t *testing.T) {
 	if len(got) > 120 {
 		t.Fatalf("diagnostics length = %d, want at most 120", len(got))
 	}
+}
+
+func TestBuilderRetriesOnlyLostLayerExportOnce(t *testing.T) {
+	client := &scriptedImageBuildClient{
+		responses: []string{
+			`{"errorDetail":{"message":"failed to export image: failed to create image: failed to get layer sha256:abc: layer does not exist"}}` + "\n",
+			`{"stream":"Step 1/1 : FROM scratch\n"}` + "\n",
+		},
+	}
+	builder, err := NewBuilder(BuilderConfiguration{
+		Root:        t.TempDir(),
+		Dockerfile:  "Dockerfile",
+		Destination: resources.NewDockerImage("test/retry:v1"),
+		Output:      io.Discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder.newClient = func() (imageBuildClient, error) { return client, nil }
+
+	output, err := builder.Build(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.calls != 2 {
+		t.Fatalf("image build calls = %d, want 2", client.calls)
+	}
+	if len(client.contexts) != 2 || !bytes.Equal(client.contexts[0], client.contexts[1]) {
+		t.Fatal("retry did not reuse the exact immutable build context")
+	}
+	if output.Image != "test/retry:v1" {
+		t.Fatalf("image = %q", output.Image)
+	}
+	if !client.closed {
+		t.Fatal("docker client was not closed")
+	}
+}
+
+func TestBuilderDoesNotRetryOrdinaryBuildFailure(t *testing.T) {
+	client := &scriptedImageBuildClient{
+		responses: []string{
+			`{"errorDetail":{"message":"Dockerfile parse error: unknown instruction"}}` + "\n",
+		},
+	}
+	builder, err := NewBuilder(BuilderConfiguration{
+		Root:        t.TempDir(),
+		Dockerfile:  "Dockerfile",
+		Destination: resources.NewDockerImage("test/no-retry:v1"),
+		Output:      io.Discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder.newClient = func() (imageBuildClient, error) { return client, nil }
+
+	if _, err := builder.Build(context.Background()); err == nil {
+		t.Fatal("ordinary Dockerfile failure unexpectedly succeeded")
+	}
+	if client.calls != 1 {
+		t.Fatalf("image build calls = %d, want 1", client.calls)
+	}
+}
+
+func TestRetryableDockerLayerExportErrorIsNarrow(t *testing.T) {
+	retryable := errors.New("failed to export image: failed to create image: failed to get layer sha256:abc: layer does not exist")
+	if !isRetryableDockerLayerExportError(retryable) {
+		t.Fatal("lost-layer export was not classified as retryable")
+	}
+	for _, message := range []string{
+		"layer does not exist",
+		"failed to export image: disk quota exceeded",
+		"failed to get layer: unauthorized",
+	} {
+		if isRetryableDockerLayerExportError(errors.New(message)) {
+			t.Fatalf("ordinary failure %q was classified as retryable", message)
+		}
+	}
+}
+
+type scriptedImageBuildClient struct {
+	responses []string
+	contexts  [][]byte
+	calls     int
+	closed    bool
+}
+
+func (client *scriptedImageBuildClient) ImageBuild(
+	_ context.Context,
+	buildContext io.Reader,
+	_ types.ImageBuildOptions,
+) (types.ImageBuildResponse, error) {
+	payload, err := io.ReadAll(buildContext)
+	if err != nil {
+		return types.ImageBuildResponse{}, err
+	}
+	client.contexts = append(client.contexts, payload)
+	if client.calls >= len(client.responses) {
+		return types.ImageBuildResponse{}, errors.New("unexpected image build call")
+	}
+	response := client.responses[client.calls]
+	client.calls++
+	return types.ImageBuildResponse{Body: io.NopCloser(bytes.NewBufferString(response))}, nil
+}
+
+func (client *scriptedImageBuildClient) Close() error {
+	client.closed = true
+	return nil
 }


### PR DESCRIPTION
## Summary
- retry exactly one Docker daemon storage failure: final export losing an intermediate layer
- reuse byte-identical build context on retry
- keep Dockerfile, network, disk, and application failures single-attempt and fail closed
- add injected-client tests for retry count, immutable context, client lifecycle, and narrow classification

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=20 ./agents/helpers/docker`

## Dogfood evidence
SaaS Starter PR #15 passed 41 Codefly checks twice, then failed at the same Postgres image export with distinct missing layer digests. This fixes the shared agent helper instead of bypassing the release gate.