### PR TITLE
Gate Go vulnerabilities on reachable symbols

### DIFF
--- a/agents/services/audit/audit_test.go
+++ b/agents/services/audit/audit_test.go
@@ -119,7 +119,7 @@ printf '%s\n' '{"dependencies":[]}'
 func TestParseGovulncheck_findings(t *testing.T) {
 	// Two-line stream: an OSV record followed by a finding referring to it.
 	out := `{"osv":{"id":"GO-2024-2887","summary":"Stack exhaustion in net/http","aliases":["CVE-2024-34155"]}}
-{"finding":{"osv":"GO-2024-2887","fixed_version":"v1.22.7","trace":[{"module":"std","version":"go1.22.5","package":"net/http"}]}}
+{"finding":{"osv":"GO-2024-2887","fixed_version":"v1.22.7","trace":[{"module":"std","version":"go1.22.5","package":"net/http","function":"net/http.(*http2serverConn).canonicalHeader"}]}}
 `
 	findings, err := runGovulncheckParse(out)
 	if err != nil {
@@ -138,8 +138,8 @@ func TestParseGovulncheck_findings(t *testing.T) {
 }
 
 func TestParseGovulncheckDeduplicatesReachableCallTraces(t *testing.T) {
-	out := `{"finding":{"osv":"GO-2026-4883","trace":[{"module":"github.com/docker/docker","version":"v28.5.2","package":"github.com/docker/docker/client"}]}}
-{"finding":{"osv":"GO-2026-4883","fixed_version":"v28.5.3","trace":[{"module":"github.com/docker/docker","version":"v28.5.2","package":"github.com/docker/docker/daemon"}]}}
+	out := `{"finding":{"osv":"GO-2026-4883","trace":[{"module":"github.com/docker/docker","version":"v28.5.2","package":"github.com/docker/docker/client","function":"github.com/docker/docker/client.(*Client).ContainerCreate"}]}}
+{"finding":{"osv":"GO-2026-4883","fixed_version":"v28.5.3","trace":[{"module":"github.com/docker/docker","version":"v28.5.2","package":"github.com/docker/docker/daemon","function":"github.com/docker/docker/daemon.(*Daemon).ContainerCreate"}]}}
 {"osv":{"id":"GO-2026-4883","summary":"Docker authorization bypass"}}
 `
 	findings, err := runGovulncheckParse(out)
@@ -152,6 +152,21 @@ func TestParseGovulncheckDeduplicatesReachableCallTraces(t *testing.T) {
 	finding := findings[0]
 	if finding.FixedVersion != "v28.5.3" || finding.Summary != "Docker authorization bypass" {
 		t.Fatalf("deduplicated finding lost metadata: %+v", finding)
+	}
+}
+
+func TestParseGovulncheckIgnoresInventoryOnlyFindings(t *testing.T) {
+	out := `{"osv":{"id":"GO-MODULE","summary":"module inventory only"}}
+{"finding":{"osv":"GO-MODULE","trace":[{"module":"golang.org/x/crypto","version":"v0.53.0"}]}}
+{"osv":{"id":"GO-PACKAGE","summary":"package inventory only"}}
+{"finding":{"osv":"GO-PACKAGE","trace":[{"module":"example.com/dependency","version":"v1.2.3","package":"example.com/dependency/unsafe"}]}}
+`
+	findings, err := runGovulncheckParse(out)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("inventory-only findings must not become reachable release evidence: %+v", findings)
 	}
 }
 

--- a/agents/services/audit/golang.go
+++ b/agents/services/audit/golang.go
@@ -51,15 +51,18 @@ func Golang(ctx context.Context, dir string, includeOutdated bool) (*Result, err
 // about the "finding" objects which contain CVE id + severity + the
 // affected module/version. The schema is documented at
 // https://pkg.go.dev/golang.org/x/vuln/internal/govulncheck.
+type govulncheckTrace struct {
+	Module   string `json:"module"`
+	Version  string `json:"version"`
+	Package  string `json:"package"`
+	Function string `json:"function"`
+}
+
 type govulncheckOutput struct {
 	Finding *struct {
-		OSV          string `json:"osv"`
-		FixedVersion string `json:"fixed_version"`
-		Trace        []struct {
-			Module  string `json:"module"`
-			Version string `json:"version"`
-			Package string `json:"package"`
-		} `json:"trace"`
+		OSV          string             `json:"osv"`
+		FixedVersion string             `json:"fixed_version"`
+		Trace        []govulncheckTrace `json:"trace"`
 	} `json:"finding,omitempty"`
 	OSV *struct {
 		ID      string   `json:"id"`
@@ -115,16 +118,28 @@ func runGovulncheckParseBytes(out []byte) ([]*builderv0.AuditFinding, error) {
 		if msg.OSV != nil {
 			summaries[msg.OSV.ID] = msg.OSV.Summary
 		}
-		if msg.Finding != nil && len(msg.Finding.Trace) > 0 {
-			t := msg.Finding.Trace[0]
-			key := msg.Finding.OSV + "\x00" + t.Module + "\x00" + t.Version
+		if msg.Finding != nil {
+			var reachable *govulncheckTrace
+			for index := range msg.Finding.Trace {
+				if msg.Finding.Trace[index].Function != "" {
+					reachable = &msg.Finding.Trace[index]
+					break
+				}
+			}
+			// govulncheck also emits module- and package-level inventory
+			// findings when the vulnerable symbol is not reachable. Those are
+			// useful scanner context, but they are not release-gating evidence.
+			if reachable == nil {
+				continue
+			}
+			key := msg.Finding.OSV + "\x00" + reachable.Module + "\x00" + reachable.Version
 			finding, exists := findingsByKey[key]
 			if !exists {
 				finding = &builderv0.AuditFinding{
 					Severity:       builderv0.AuditFinding_HIGH, // govulncheck only reports actually-reachable vulns
 					Id:             msg.Finding.OSV,
-					Package:        t.Module,
-					CurrentVersion: t.Version,
+					Package:        reachable.Module,
+					CurrentVersion: reachable.Version,
 					Url:            "https://pkg.go.dev/vuln/" + msg.Finding.OSV,
 				}
 				findingsByKey[key] = finding


### PR DESCRIPTION
## Summary
- distinguish symbol-reachable govulncheck evidence from module/package inventory notices
- keep release gating on findings with an actual vulnerable function in the trace
- add regression coverage for module-only and package-only findings, including the OpenPGP advisory shape

## Validation
- `GOWORK=off go test ./agents/services/audit ./agents/services`
- `GOWORK=off go test -race ./agents/services/audit ./agents/services`
- `GOWORK=off go vet ./...`
- full `GOWORK=off go test ./...` passed every package except one unrelated process-start timing test in `core/sdk`; immediate `go test -count=5 ./sdk` passed all five runs