### PR TITLE
Reuse dependencies from managed service tests

### DIFF
--- a/sdk/dependencies.go
+++ b/sdk/dependencies.go
@@ -35,6 +35,7 @@ type Dependencies struct {
 	runtimeContext *basev0.RuntimeContext
 	keepRunning    bool
 	attached       bool
+	inherited      bool
 }
 
 type Option struct {
@@ -118,6 +119,14 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 	for _, o := range opts {
 		o(opt)
 	}
+	if hasManagedDependencyEnvironment(os.Environ()) {
+		wool.Get(ctx).In("sdk.WithDependencies").
+			Debug("reusing dependencies injected by the managed Codefly runtime")
+		return &Dependencies{
+			runtimeContext: resources.RuntimeContextFromEnv(),
+			inherited:      true,
+		}, nil
+	}
 	args := []string{"run", "service"}
 	if opt.Debug {
 		args = append(args, "-d")
@@ -151,10 +160,15 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 		}
 	}
 
+	// Test-owned dependency stacks run in independent package processes, so
+	// their in-memory RuntimeManagers cannot coordinate deterministic named
+	// port allocations. Ask the CLI to use OS-probed ephemeral ports for these
+	// short-lived flows. Normal CLI stable/dev flows retain named ports.
+	//
 	// --headless prevents the CLI from trying to open /dev/tty for
 	// interactive context selection. Always needed when running as a
 	// subprocess (go test, CI, MCP, pipes).
-	args = append(args, "--exclude-root", "--cli-server", "--headless")
+	args = append(args, "--temporary-ports", "--exclude-root", "--cli-server", "--headless")
 	cmd := exec.CommandContext(ctx, codeflyBinary(), args...)
 	// ARCHITECTURE: the SDK owns the control channel for the child it starts.
 	// Pass the exact selected port to the CLI instead of asking two separately
@@ -234,6 +248,34 @@ func WithDependencies(ctx context.Context, opts ...OptionFunc) (*Dependencies, e
 	}
 	success = true
 	return l, nil
+}
+
+// hasManagedDependencyEnvironment recognizes the environment installed by a
+// parent Codefly service runner. Tests executed through a service agent already
+// have live dependency endpoints; starting another nested flow would duplicate
+// containers and contend for the parent's assigned ports.
+//
+// CODEFLY__RUNNING alone is intentionally insufficient because --stand-alone
+// services may not have dependencies. Reuse is allowed only when the runtime
+// also injected at least one non-empty typed endpoint. Direct `go test` remains
+// unchanged: SetEnvironment does not synthesize the parent-runner marker.
+func hasManagedDependencyEnvironment(environment []string) bool {
+	running := false
+	hasEndpoint := false
+	endpointPrefix := resources.EndpointPrefix + "__"
+	for _, entry := range environment {
+		name, value, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		switch {
+		case name == resources.RunningPrefix:
+			running = strings.EqualFold(strings.TrimSpace(value), "true")
+		case strings.HasPrefix(name, endpointPrefix) && strings.TrimSpace(value) != "":
+			hasEndpoint = true
+		}
+	}
+	return running && hasEndpoint
 }
 
 func cliServerAddress(ctx context.Context, namingScope string) string {
@@ -340,6 +382,9 @@ func Connection(service, name string) string {
 }
 
 func (l *Dependencies) WaitForReady(ctx context.Context, opt *Option) error {
+	if l.inherited {
+		return nil
+	}
 	readyCtx, cancel := context.WithTimeout(ctx, opt.Timeout)
 	defer cancel()
 
@@ -406,6 +451,9 @@ func Inject(env *resources.EnvironmentVariable) {
 }
 
 func (l *Dependencies) SetEnvironment(ctx context.Context) error {
+	if l.inherited {
+		return nil
+	}
 	w := wool.Get(ctx).In("sdk.SetEnvironment")
 	svc, err := Service()
 	if err != nil {
@@ -497,6 +545,10 @@ func (l *Dependencies) SetEnvironment(ctx context.Context) error {
 // tree down.
 func (l *Dependencies) Stop(ctx context.Context) error {
 	w := wool.Get(ctx).In("sdk.Stop")
+	if l.inherited {
+		w.Debug("leaving dependencies owned by the parent Codefly runtime running")
+		return nil
+	}
 	if l.keepRunning {
 		if l.conn != nil {
 			_ = l.conn.Close()
@@ -529,6 +581,10 @@ func (l *Dependencies) Stop(ctx context.Context) error {
 // stopping processes) before killing the subprocess group.
 func (l *Dependencies) Destroy(ctx context.Context) error {
 	w := wool.Get(ctx).In("sdk.Destroy")
+	if l.inherited {
+		w.Debug("leaving dependencies owned by the parent Codefly runtime running")
+		return nil
+	}
 	if l.keepRunning {
 		if l.conn != nil {
 			_ = l.conn.Close()

--- a/sdk/dependencies_test.go
+++ b/sdk/dependencies_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/codefly-dev/core/resources"
 )
 
 // TestWithDependencies_KillsProcessGroupOnCancellation verifies that when a
@@ -69,7 +71,11 @@ func TestWithDependencies_KillsProcessGroupOnCancellation(t *testing.T) {
 func TestWithDependencies_ReturnsWhenCLIExitsBeforeReady(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "codefly")
-	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 23\n"), 0o755); err != nil {
+	argsPath := filepath.Join(dir, "args")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"" + argsPath + "\"\n" +
+		"exit 23\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake binary: %v", err)
 	}
 	t.Setenv("CODEFLY_BINARY", binPath)
@@ -87,6 +93,13 @@ func TestWithDependencies_ReturnsWhenCLIExitsBeforeReady(t *testing.T) {
 	// configured 10-second readiness deadline.
 	if elapsed := time.Since(started); elapsed > 6*time.Second {
 		t.Fatalf("early CLI exit took %s to report", elapsed)
+	}
+	args, readErr := os.ReadFile(argsPath)
+	if readErr != nil {
+		t.Fatalf("read fake CLI arguments: %v", readErr)
+	}
+	if !slices.Contains(strings.Fields(string(args)), "--temporary-ports") {
+		t.Fatalf("SDK-owned dependency flow did not request temporary ports: %s", args)
 	}
 }
 
@@ -129,6 +142,97 @@ func TestWithFixtureSelectsDependencyStackFixture(t *testing.T) {
 	WithFixture("dev-admin")(option)
 	if option.Fixture != "dev-admin" {
 		t.Fatalf("fixture = %q, want dev-admin", option.Fixture)
+	}
+}
+
+func TestManagedDependencyEnvironmentRequiresRunnerAndEndpoint(t *testing.T) {
+	endpoint := resources.EndpointPrefix + "__SAAS_STARTER__STORE__TCP__TCP"
+	tests := []struct {
+		name        string
+		environment []string
+		want        bool
+	}{
+		{
+			name: "managed runtime with endpoint",
+			environment: []string{
+				resources.RunningPrefix + "=true",
+				resources.RuntimeContextPrefix + "=" + resources.RuntimeContextNative,
+				endpoint + "=localhost:5432",
+			},
+			want: true,
+		},
+		{
+			name: "standalone managed runtime",
+			environment: []string{
+				resources.RunningPrefix + "=true",
+				resources.RuntimeContextPrefix + "=" + resources.RuntimeContextNative,
+			},
+		},
+		{
+			name: "direct test with endpoint-shaped value",
+			environment: []string{
+				endpoint + "=localhost:5432",
+			},
+		},
+		{
+			name: "empty endpoint",
+			environment: []string{
+				resources.RunningPrefix + "=true",
+				endpoint + "=",
+			},
+		},
+		{
+			name: "false runner marker",
+			environment: []string{
+				resources.RunningPrefix + "=false",
+				endpoint + "=localhost:5432",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasManagedDependencyEnvironment(tt.environment); got != tt.want {
+				t.Fatalf("hasManagedDependencyEnvironment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithDependenciesReusesParentManagedRuntime(t *testing.T) {
+	dir := t.TempDir()
+	started := filepath.Join(dir, "nested-flow-started")
+	binPath := filepath.Join(dir, "codefly")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\ntouch \""+started+"\"\nexit 23\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	t.Setenv("CODEFLY_BINARY", binPath)
+	t.Setenv(resources.RunningPrefix, "true")
+	t.Setenv(resources.RuntimeContextPrefix, resources.RuntimeContextNative)
+	t.Setenv(resources.EndpointPrefix+"__SAAS_STARTER__STORE__TCP__TCP", "localhost:5432")
+
+	deps, err := WithDependencies(context.Background())
+	if err != nil {
+		t.Fatalf("WithDependencies() error = %v", err)
+	}
+	if !deps.inherited {
+		t.Fatal("managed dependencies were not marked as inherited")
+	}
+	if err := deps.WaitForReady(context.Background(), &Option{Timeout: time.Second}); err != nil {
+		t.Fatalf("WaitForReady() error = %v", err)
+	}
+	if err := deps.SetEnvironment(context.Background()); err != nil {
+		t.Fatalf("SetEnvironment() error = %v", err)
+	}
+	if err := deps.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if err := deps.Destroy(context.Background()); err != nil {
+		t.Fatalf("Destroy() error = %v", err)
+	}
+	if _, err := os.Stat(started); !os.IsNotExist(err) {
+		t.Fatalf("nested Codefly flow was started; stat error = %v", err)
 	}
 }
 


### PR DESCRIPTION
Prevents `sdk.WithDependencies` from nesting a second Codefly flow when a service agent already injected live typed endpoints. The returned lifecycle handle is explicitly inherited, so Stop/Destroy never tears down the parent runtime. Direct tests and standalone services keep existing behavior.

Validation:
- `go test -race ./sdk`
- `go test -count=5 ./sdk`
- `go vet ./sdk`
- `go vet ./...`
- complete suite passed all affected packages; the unrestricted all-package run reproduced existing load-sensitive timing failures that pass in scoped runs