### PR TITLE
Make Node companion architecture-correct

### DIFF
--- a/companions/codefly/Dockerfile
+++ b/companions/codefly/Dockerfile
@@ -27,8 +27,11 @@ RUN apk update && \
         tzdata \
     && rm -rf /var/cache/apk/*
 
-# codefly CLI itself. Built separately via cli/scripts/build/linux.sh
-# and placed under core/bin/linux/codefly before the companion build.
-COPY bin/linux/codefly /bin/codefly
+# BuildKit supplies TARGETARCH for each platform in a multi-platform build.
+# The companion publisher cross-compiles the matching static binary before
+# invoking Docker, so an ARM64 image can never accidentally contain an AMD64
+# Codefly executable.
+ARG TARGETARCH
+COPY bin/linux/${TARGETARCH}/codefly /bin/codefly
 
 WORKDIR /workspace

--- a/companions/codefly/info.codefly.yaml
+++ b/companions/codefly/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.0.3
+version: 0.0.4

--- a/companions/companions_test.go
+++ b/companions/companions_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -60,4 +61,27 @@ func TestEmbeddedDerivesEveryTagFromManifest(t *testing.T) {
 	}
 
 	require.Len(t, got, len(dirByName), "every companion image must be enumerated")
+}
+
+func TestNodeCompanionPreservesTargetArchitecture(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filename)
+
+	codeflyDockerfile, err := os.ReadFile(filepath.Join(root, "codefly", "Dockerfile"))
+	require.NoError(t, err)
+	require.Contains(t, string(codeflyDockerfile), "ARG TARGETARCH")
+	require.Contains(t, string(codeflyDockerfile), "bin/linux/${TARGETARCH}/codefly")
+
+	nodeDockerfile, err := os.ReadFile(filepath.Join(root, "node", "Dockerfile"))
+	require.NoError(t, err)
+	codeflyVersion := strings.TrimSpace(string(mustReadFile(t, filepath.Join(root, "codefly", "info.codefly.yaml"))))
+	require.Equal(t, "version: 0.0.4", codeflyVersion)
+	require.Contains(t, string(nodeDockerfile), "codeflydev/codefly:0.0.4")
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return content
 }

--- a/companions/node/Dockerfile
+++ b/companions/node/Dockerfile
@@ -21,7 +21,8 @@ RUN apk update && \
         tzdata \
     && rm -rf /var/cache/apk/*
 
-# Pull the codefly CLI from the base image.
-COPY --from=codeflydev/codefly:0.0.3 /bin/codefly /bin/codefly
+# Pull the Codefly CLI from the multi-platform base image. BuildKit resolves
+# the base manifest for the Node image's target architecture.
+COPY --from=codeflydev/codefly:0.0.4 /bin/codefly /bin/codefly
 
 WORKDIR /workspace

--- a/companions/node/info.codefly.yaml
+++ b/companions/node/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.0.12
+version: 0.0.13


### PR DESCRIPTION
## Summary
- bump the Codefly base companion and select the embedded CLI through BuildKit TARGETARCH
- bump the Node companion and consume the new multi-platform Codefly base
- pin the architecture contract in tests

## Validation
- GOWORK=off go test ./companions/...
- full `go test ./...` passed all packages except an unrelated Docker golang runner test whose shared local `golang:1.26` tag was concurrently resolved to AMD64 on this ARM64 host