### PR TITLE
Release promotable Kubernetes contract (#103)

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.50
+version: 0.2.51


### PR DESCRIPTION
Closes #103.

## Summary

- Publish a stable Core version containing the reviewed promotable Kubernetes manifest contract.
- Give the CLI and official service plugins one semantic version to pin for the Mind GitOps integration train.

## Test plan

- [x] go test ./...
- [x] Generated builder API exposes both Kubernetes output profiles and typed secret references.