### PR TITLE
Bind validation to declared cluster (#105)

### DIFF
--- a/agents/services/base_builder.go
+++ b/agents/services/base_builder.go
@@ -735,6 +735,8 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 		kubernetes.GetNamespace(),
 		profile,
 		kubernetes.GetValidateServerSide(),
+		kubernetes.GetValidationKubeconfig(),
+		kubernetes.GetValidationContext(),
 	)
 	output.GetKubernetes().Validation = validation
 	if validation.GetStaticValidation() == builderv0.KubernetesManifestValidation_STATUS_FAILED ||

--- a/agents/services/deployment_test.go
+++ b/agents/services/deployment_test.go
@@ -301,6 +301,26 @@ func TestDeployKustomizeRendersSecretFreeGitOpsTreeAndRejectsWithoutServerValida
 	require.Contains(t, string(configMapManifest), `CODEFLY__SERVICE_CONFIGURATION__MODULE__SERVICE__CONNECTION__URL: "redis://service"`)
 }
 
+func TestServerSideValidationRequiresExplicitClusterTarget(t *testing.T) {
+	err := validateKubernetesManifestServerSide(
+		context.Background(),
+		nil,
+		"codefly",
+		"",
+		"k3d-codefly",
+	)
+	require.EqualError(t, err, "server-side validation requires an explicit kubeconfig")
+
+	err = validateKubernetesManifestServerSide(
+		context.Background(),
+		nil,
+		"codefly",
+		"/tmp/kubeconfig",
+		"",
+	)
+	require.EqualError(t, err, "server-side validation requires an explicit Kubernetes context")
+}
+
 func TestDeployKustomizeDoesNotRetainSecretsBetweenRequests(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")

--- a/agents/services/kubernetes_manifest.go
+++ b/agents/services/kubernetes_manifest.go
@@ -100,6 +100,8 @@ func ValidateKubernetesManifestTree(
 	namespace string,
 	profile builderv0.KubernetesOutputProfile,
 	validateServerSide bool,
+	validationKubeconfig string,
+	validationContext string,
 ) *builderv0.KubernetesManifestValidation {
 	result := &builderv0.KubernetesManifestValidation{
 		StaticValidation:     builderv0.KubernetesManifestValidation_STATUS_PASSED,
@@ -125,12 +127,19 @@ func ValidateKubernetesManifestTree(
 	}
 
 	if validateServerSide {
-		if err := validateKubernetesManifestServerSide(ctx, manifest, namespace); err != nil {
+		if err := validateKubernetesManifestServerSide(
+			ctx,
+			manifest,
+			namespace,
+			validationKubeconfig,
+			validationContext,
+		); err != nil {
 			result.ServerSideValidation = builderv0.KubernetesManifestValidation_STATUS_FAILED
 			result.Violations = []string{err.Error()}
 			return result
 		}
 		result.ServerSideValidation = builderv0.KubernetesManifestValidation_STATUS_PASSED
+		result.ValidatedContext = validationContext
 	}
 
 	result.Promotable = profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 &&
@@ -708,12 +717,35 @@ func validateContainerHealth(container map[string]any, ref string, requireProbes
 	return violations
 }
 
-func validateKubernetesManifestServerSide(ctx context.Context, manifest []byte, namespace string) error {
+func validateKubernetesManifestServerSide(
+	ctx context.Context,
+	manifest []byte,
+	namespace,
+	kubeconfig,
+	kubeContext string,
+) error {
+	if kubeconfig == "" {
+		return fmt.Errorf("server-side validation requires an explicit kubeconfig")
+	}
+	if kubeContext == "" {
+		return fmt.Errorf("server-side validation requires an explicit Kubernetes context")
+	}
 	kubectl, err := exec.LookPath("kubectl")
 	if err != nil {
 		return fmt.Errorf("server-side validation requires kubectl: %w", err)
 	}
-	command := exec.CommandContext(ctx, kubectl, "apply", "--server-side", "--dry-run=server", "--validate=strict", "--namespace", namespace, "-f", "-")
+	command := exec.CommandContext(
+		ctx,
+		kubectl,
+		"--kubeconfig", kubeconfig,
+		"--context", kubeContext,
+		"apply",
+		"--server-side",
+		"--dry-run=server",
+		"--validate=strict",
+		"--namespace", namespace,
+		"-f", "-",
+	)
 	command.Stdin = bytes.NewReader(manifest)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/agents/testing/composition.go
+++ b/agents/testing/composition.go
@@ -169,7 +169,7 @@ func assertKustomizeProfile(
 		t.Fatalf("render %s kustomize templates: %v", profile, err)
 	}
 
-	validation := services.ValidateKubernetesManifestTree(ctx, destination, "test", "codefly-test", profile, false)
+	validation := services.ValidateKubernetesManifestTree(ctx, destination, "test", "codefly-test", profile, false, "", "")
 	if validation.GetStaticValidation() != builderv0.KubernetesManifestValidation_STATUS_PASSED {
 		t.Fatalf("%s static conformance failed:\n%s", profile, strings.Join(validation.GetViolations(), "\n"))
 	}
@@ -477,6 +477,8 @@ func assertInvalidKustomization(t *testing.T) {
 			"codefly-test",
 			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
 			false,
+			"",
+			"",
 		)
 		if validation.GetStaticValidation() != builderv0.KubernetesManifestValidation_STATUS_FAILED {
 			t.Fatalf("status = %s, want failed", validation.GetStaticValidation())
@@ -529,6 +531,8 @@ resources:
 			"codefly-test",
 			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
 			false,
+			"",
+			"",
 		)
 		if validation.GetStaticValidation() != builderv0.KubernetesManifestValidation_STATUS_FAILED {
 			t.Fatalf("status = %s, want failed; violations: %v", validation.GetStaticValidation(), validation.GetViolations())
@@ -582,6 +586,8 @@ resources:
 			"codefly-test",
 			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
 			false,
+			"",
+			"",
 		)
 		if validation.GetStaticValidation() != expected {
 			t.Fatalf("status = %s, want %s; violations: %v", validation.GetStaticValidation(), expected, validation.GetViolations())

--- a/generated/go/codefly/services/builder/v0/deployment.pb.go
+++ b/generated/go/codefly/services/builder/v0/deployment.pb.go
@@ -369,10 +369,14 @@ type KubernetesDeployment struct {
 	Profile KubernetesOutputProfile `protobuf:"varint,4,opt,name=profile,proto3,enum=codefly.services.builder.v0.KubernetesOutputProfile" json:"profile,omitempty"`
 	// secret_references contains identifiers only and never secret values.
 	SecretReferences map[string]*KubernetesSecretKeyReference `protobuf:"bytes,5,rep,name=secret_references,json=secretReferences,proto3" json:"secret_references,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// validate_server_side requests a server-side dry-run against the active Kubernetes cluster.
+	// validate_server_side requests a server-side dry-run against the explicit validation target.
 	ValidateServerSide bool `protobuf:"varint,6,opt,name=validate_server_side,json=validateServerSide,proto3" json:"validate_server_side,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// validation_kubeconfig selects the kubeconfig used for server-side validation.
+	ValidationKubeconfig string `protobuf:"bytes,7,opt,name=validation_kubeconfig,json=validationKubeconfig,proto3" json:"validation_kubeconfig,omitempty"`
+	// validation_context selects the exact kubeconfig context used for server-side validation.
+	ValidationContext string `protobuf:"bytes,8,opt,name=validation_context,json=validationContext,proto3" json:"validation_context,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *KubernetesDeployment) Reset() {
@@ -445,6 +449,20 @@ func (x *KubernetesDeployment) GetValidateServerSide() bool {
 		return x.ValidateServerSide
 	}
 	return false
+}
+
+func (x *KubernetesDeployment) GetValidationKubeconfig() string {
+	if x != nil {
+		return x.ValidationKubeconfig
+	}
+	return ""
+}
+
+func (x *KubernetesDeployment) GetValidationContext() string {
+	if x != nil {
+		return x.ValidationContext
+	}
+	return ""
 }
 
 // DeploymentOutput selects the deployment artifact emitted by the builder.
@@ -527,9 +545,11 @@ type KubernetesManifestValidation struct {
 	// promotable is true only for a GitOps profile that passed every required stage.
 	Promotable bool `protobuf:"varint,3,opt,name=promotable,proto3" json:"promotable,omitempty"`
 	// violations contains stable, human-readable rejection reasons.
-	Violations    []string `protobuf:"bytes,4,rep,name=violations,proto3" json:"violations,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Violations []string `protobuf:"bytes,4,rep,name=violations,proto3" json:"violations,omitempty"`
+	// validated_context is the exact kubeconfig context used for server-side validation.
+	ValidatedContext string `protobuf:"bytes,5,opt,name=validated_context,json=validatedContext,proto3" json:"validated_context,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *KubernetesManifestValidation) Reset() {
@@ -588,6 +608,13 @@ func (x *KubernetesManifestValidation) GetViolations() []string {
 		return x.Violations
 	}
 	return nil
+}
+
+func (x *KubernetesManifestValidation) GetValidatedContext() string {
+	if x != nil {
+		return x.ValidatedContext
+	}
+	return ""
 }
 
 // KubernetesDeploymentOutput describes generated Kubernetes deployment artifacts.
@@ -677,14 +704,16 @@ const file_codefly_services_builder_v0_deployment_proto_rawDesc = "" +
 	"\x1cKubernetesSecretKeyReference\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03key\x18\x02 \x01(\tR\x03key\x12\x1a\n" +
-	"\boptional\x18\x03 \x01(\bR\boptional\"\xa4\x04\n" +
+	"\boptional\x18\x03 \x01(\bR\boptional\"\x88\x05\n" +
 	"\x14KubernetesDeployment\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12 \n" +
 	"\vdestination\x18\x02 \x01(\tR\vdestination\x12T\n" +
 	"\rbuild_context\x18\x03 \x01(\v2/.codefly.services.builder.v0.DockerBuildContextR\fbuildContext\x12N\n" +
 	"\aprofile\x18\x04 \x01(\x0e24.codefly.services.builder.v0.KubernetesOutputProfileR\aprofile\x12t\n" +
 	"\x11secret_references\x18\x05 \x03(\v2G.codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntryR\x10secretReferences\x120\n" +
-	"\x14validate_server_side\x18\x06 \x01(\bR\x12validateServerSide\x1a~\n" +
+	"\x14validate_server_side\x18\x06 \x01(\bR\x12validateServerSide\x123\n" +
+	"\x15validation_kubeconfig\x18\a \x01(\tR\x14validationKubeconfig\x12-\n" +
+	"\x12validation_context\x18\b \x01(\tR\x11validationContext\x1a~\n" +
 	"\x15SecretReferencesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
 	"\x05value\x18\x02 \x01(\v29.codefly.services.builder.v0.KubernetesSecretKeyReferenceR\x05value:\x028\x01\"u\n" +
@@ -692,7 +721,7 @@ const file_codefly_services_builder_v0_deployment_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\x02 \x01(\v27.codefly.services.builder.v0.KubernetesDeploymentOutputH\x00R\n" +
 	"kubernetesB\x06\n" +
-	"\x04kind\"\xa1\x03\n" +
+	"\x04kind\"\xce\x03\n" +
 	"\x1cKubernetesManifestValidation\x12m\n" +
 	"\x11static_validation\x18\x01 \x01(\x0e2@.codefly.services.builder.v0.KubernetesManifestValidation.StatusR\x10staticValidation\x12v\n" +
 	"\x16server_side_validation\x18\x02 \x01(\x0e2@.codefly.services.builder.v0.KubernetesManifestValidation.StatusR\x14serverSideValidation\x12\x1e\n" +
@@ -701,7 +730,8 @@ const file_codefly_services_builder_v0_deployment_proto_rawDesc = "" +
 	"promotable\x12\x1e\n" +
 	"\n" +
 	"violations\x18\x04 \x03(\tR\n" +
-	"violations\"Z\n" +
+	"violations\x12+\n" +
+	"\x11validated_context\x18\x05 \x01(\tR\x10validatedContext\"Z\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSTATUS_PASSED\x10\x01\x12\x11\n" +

--- a/proto/codefly/services/builder/v0/deployment.proto
+++ b/proto/codefly/services/builder/v0/deployment.proto
@@ -50,8 +50,12 @@ message KubernetesDeployment {
   KubernetesOutputProfile profile = 4;
   // secret_references contains identifiers only and never secret values.
   map<string, KubernetesSecretKeyReference> secret_references = 5;
-  // validate_server_side requests a server-side dry-run against the active Kubernetes cluster.
+  // validate_server_side requests a server-side dry-run against the explicit validation target.
   bool validate_server_side = 6;
+  // validation_kubeconfig selects the kubeconfig used for server-side validation.
+  string validation_kubeconfig = 7;
+  // validation_context selects the exact kubeconfig context used for server-side validation.
+  string validation_context = 8;
 }
 
 // DeploymentOutput selects the deployment artifact emitted by the builder.
@@ -84,6 +88,8 @@ message KubernetesManifestValidation {
   bool promotable = 3;
   // violations contains stable, human-readable rejection reasons.
   repeated string violations = 4;
+  // validated_context is the exact kubeconfig context used for server-side validation.
+  string validated_context = 5;
 }
 
 // KubernetesDeploymentOutput describes generated Kubernetes deployment artifacts.


### PR DESCRIPTION
Closes #105.

## Summary

- Bind promotable server-side validation to the environment's declared kubeconfig and context so an ambient local context cannot certify remote output.
- Return the exact validated context as contract evidence and fail closed when the target is incomplete.

## Test plan

- [x] `go test ./agents/services ./agents/testing`
- [x] `go test ./runners/golang -run '^TestNixRunWithMod$' -count=1 -v`
- [ ] `go test ./...` (one concurrent Nix runner assertion failed; the exact test passed alone)
