### PR TITLE
Release core v0.2.52

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.51
+version: 0.2.52


### PR DESCRIPTION
## Summary

- publish the exact Kubernetes validation-target contract required by promotable GitOps output

## Test plan

- [x] `go test ./agents/services ./agents/testing`
- [x] full suite completed except one transient concurrent Nix assertion; its exact rerun passed