### PR TITLE
Permit offline reviewed GitOps rendering (#108)

### DIFF
--- a/agents/services/base_builder.go
+++ b/agents/services/base_builder.go
@@ -746,7 +746,7 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 	}
 	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 &&
 		!validation.GetPromotable() {
-		return fail(fmt.Errorf("promotable GitOps rendering requires successful server-side validation"))
+		return fail(fmt.Errorf("promotable GitOps rendering requires successful validation"))
 	}
 	return s.DeployResponse(deploymentContext.exportedConfiguration, output)
 }

--- a/agents/services/deployment_test.go
+++ b/agents/services/deployment_test.go
@@ -237,7 +237,7 @@ func TestDeployKustomizeRejectsSecretConfigurationDataForGitOps(t *testing.T) {
 	require.Empty(t, entries)
 }
 
-func TestDeployKustomizeRendersSecretFreeGitOpsTreeAndRejectsWithoutServerValidation(t *testing.T) {
+func TestDeployKustomizeRendersPromotableSecretFreeGitOpsTreeWithoutClusterAccess(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")
 	require.NoError(t, err)
@@ -281,13 +281,12 @@ func TestDeployKustomizeRendersSecretFreeGitOpsTreeAndRejectsWithoutServerValida
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
-	require.Contains(t, response.GetState().GetMessage(), "requires successful server-side validation")
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState())
 	output := response.GetDeployment().GetKubernetes()
 	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1, output.GetProfile())
 	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_PASSED, output.GetValidation().GetStaticValidation())
 	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_NOT_RUN, output.GetValidation().GetServerSideValidation())
-	require.False(t, output.GetValidation().GetPromotable())
+	require.True(t, output.GetValidation().GetPromotable())
 	secretManifest, err := os.ReadFile(filepath.Join(destination, "base", "secret.yaml"))
 	require.NoError(t, err)
 	require.Empty(t, strings.TrimSpace(string(secretManifest)))
@@ -380,8 +379,7 @@ func TestDeployKustomizeDoesNotRetainSecretsBetweenRequests(t *testing.T) {
 		Parameters:           struct{ Name string }{Name: "gitops"},
 	})
 	require.NoError(t, err)
-	require.Equal(t, builderv0.DeploymentStatus_ERROR, gitOpsResponse.GetState().GetState())
-	require.Contains(t, gitOpsResponse.GetState().GetMessage(), "requires successful server-side validation")
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, gitOpsResponse.GetState().GetState())
 	require.NotContains(t, gitOpsResponse.GetState().GetMessage(), "cannot receive secret values")
 	secretManifest, err := os.ReadFile(filepath.Join(gitOpsDestination, "base", "secret.yaml"))
 	require.NoError(t, err)

--- a/agents/services/kubernetes_manifest.go
+++ b/agents/services/kubernetes_manifest.go
@@ -144,7 +144,8 @@ func ValidateKubernetesManifestTree(
 
 	result.Promotable = profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 &&
 		result.StaticValidation == builderv0.KubernetesManifestValidation_STATUS_PASSED &&
-		result.ServerSideValidation == builderv0.KubernetesManifestValidation_STATUS_PASSED
+		(!validateServerSide ||
+			result.ServerSideValidation == builderv0.KubernetesManifestValidation_STATUS_PASSED)
 	return result
 }
 


### PR DESCRIPTION
Closes #108.

## Summary

- preserve exact kubeconfig/context admission validation whenever it is requested
- allow production manifests to be statically qualified without granting render jobs live production-cluster authority

## Test plan

- [x] `go test ./agents/services ./agents/testing -count=1`