### PR TITLE
Honor declared deployment namespaces (#111)

### DIFF
--- a/network/remote_manager.go
+++ b/network/remote_manager.go
@@ -36,6 +36,9 @@ func (m *RemoteManager) Stop() {
 }
 
 func (m *RemoteManager) GetNamespace(_ context.Context, env *resources.Environment, workspace *resources.Workspace, service *resources.ServiceIdentity) (string, error) {
+	if env.Namespace != "" {
+		return env.Namespace, nil
+	}
 	if workspace.Layout == resources.LayoutKindFlat {
 		return fmt.Sprintf("%s-%s", workspace.Name, env.Name), nil
 	}

--- a/network/remote_manager_test.go
+++ b/network/remote_manager_test.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+)
+
+func TestRemoteManagerUsesDeclaredEnvironmentNamespace(t *testing.T) {
+	manager := &RemoteManager{}
+	environment := &resources.Environment{Name: "production", Namespace: "platform"}
+	service := &resources.ServiceIdentity{Module: "users", Name: "accounts"}
+
+	for _, layout := range []resources.LayoutKind{resources.LayoutKindModules, resources.LayoutKindFlat} {
+		workspace := &resources.Workspace{Name: "mind", Layout: layout}
+		namespace, err := manager.GetNamespace(context.Background(), environment, workspace, service)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if namespace != "platform" {
+			t.Fatalf("layout %s namespace = %q, want platform", layout, namespace)
+		}
+	}
+}
+
+func TestRemoteManagerSynthesizesLegacyNamespaceWhenUndeclared(t *testing.T) {
+	manager := &RemoteManager{}
+	environment := &resources.Environment{Name: "local"}
+	service := &resources.ServiceIdentity{Module: "users", Name: "accounts"}
+
+	tests := []struct {
+		layout resources.LayoutKind
+		want   string
+	}{
+		{layout: resources.LayoutKindModules, want: "mind-users-local"},
+		{layout: resources.LayoutKindFlat, want: "mind-local"},
+	}
+	for _, test := range tests {
+		workspace := &resources.Workspace{Name: "mind", Layout: test.layout}
+		namespace, err := manager.GetNamespace(context.Background(), environment, workspace, service)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if namespace != test.want {
+			t.Fatalf("layout %s namespace = %q, want %q", test.layout, namespace, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #111.

## Summary

- make the environment namespace declaration authoritative for remote service topology
- retain synthesized namespaces only for undeclared legacy environments

## Test plan

- [x] `go test ./network -count=1`
- [ ] repository CI