### PR TITLE
Release Core v0.2.53 (#111)

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.52
+version: 0.2.53


### PR DESCRIPTION
Closes #111.

## Summary

- publish the authoritative environment namespace contract for GitOps consumers

## Test plan

- [x] `go test ./... -count=1`
- [x] Core CI, including race detection and vulnerability audit