### PR TITLE
Support workspace-root Go Docker contexts (#114)

### DIFF
--- a/runners/golang/agent_builder.go
+++ b/runners/golang/agent_builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"io"
+	"path/filepath"
 	"strings"
 
 	dockerhelpers "github.com/codefly-dev/core/agents/helpers/docker"
@@ -25,6 +27,8 @@ type DockerTemplating struct {
 	SourceDir     string // e.g. "code/cmd/server" — the Go main package location
 	ModuleRoot    string // e.g. "code" — where go.mod lives
 	BuildTarget   string // e.g. "./cmd/server" — package to build (relative to ModuleRoot)
+	ContextRoot   string // optional exact Docker context root; defaults to the service directory
+	Workspace     bool   // template hint for workspace-aware source copying
 }
 
 // DockerEnv is a key-value pair for Docker environment variables.
@@ -69,13 +73,11 @@ func BuildGoDocker(ctx context.Context, builder *services.BuilderWrapper,
 		return builder.BuildError(err)
 	}
 
-	b, err := dockerhelpers.NewBuilder(dockerhelpers.BuilderConfiguration{
-		Root:        location,
-		Dockerfile:  "builder/Dockerfile",
-		Ignorefile:  "builder/dockerignore",
-		Destination: image,
-		Output:      w,
-	})
+	configuration, err := goDockerBuilderConfiguration(location, image, w, docker)
+	if err != nil {
+		return builder.BuildError(err)
+	}
+	b, err := dockerhelpers.NewBuilder(configuration)
 	if err != nil {
 		return builder.BuildError(err)
 	}
@@ -85,6 +87,41 @@ func BuildGoDocker(ctx context.Context, builder *services.BuilderWrapper,
 	}
 	builder.WithDockerImages(image)
 	return builder.BuildResponse()
+}
+
+func goDockerBuilderConfiguration(
+	location string,
+	image *resources.DockerImage,
+	output io.Writer,
+	docker DockerTemplating,
+) (dockerhelpers.BuilderConfiguration, error) {
+	contextRoot := docker.ContextRoot
+	if contextRoot == "" {
+		contextRoot = location
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(contextRoot)
+	if err != nil {
+		return dockerhelpers.BuilderConfiguration{}, fmt.Errorf("resolve Docker context root: %w", err)
+	}
+	resolvedLocation, err := filepath.EvalSymlinks(location)
+	if err != nil {
+		return dockerhelpers.BuilderConfiguration{}, fmt.Errorf("resolve service directory: %w", err)
+	}
+	relative, err := filepath.Rel(resolvedRoot, resolvedLocation)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return dockerhelpers.BuilderConfiguration{}, fmt.Errorf(
+			"service directory %q is outside Docker context root %q",
+			resolvedLocation,
+			resolvedRoot,
+		)
+	}
+	return dockerhelpers.BuilderConfiguration{
+		Root:        resolvedRoot,
+		Dockerfile:  filepath.ToSlash(filepath.Join(relative, "builder", "Dockerfile")),
+		Ignorefile:  filepath.ToSlash(filepath.Join(relative, "builder", "dockerignore")),
+		Destination: image,
+		Output:      output,
+	}, nil
 }
 
 // DeployGoKubernetes deploys a Go service to Kubernetes.

--- a/runners/golang/agent_builder_test.go
+++ b/runners/golang/agent_builder_test.go
@@ -1,0 +1,43 @@
+package golang
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoDockerBuilderConfigurationUsesExactWorkspaceContext(t *testing.T) {
+	workspace := t.TempDir()
+	service := filepath.Join(workspace, "modules", "users", "services", "forge-edge")
+	require.NoError(t, os.MkdirAll(service, 0o755))
+
+	configuration, err := goDockerBuilderConfiguration(
+		service,
+		&resources.DockerImage{Name: "registry.example.com/forge-edge", Tag: "test"},
+		io.Discard,
+		DockerTemplating{ContextRoot: workspace, Workspace: true},
+	)
+	require.NoError(t, err)
+	resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+	require.NoError(t, err)
+	require.Equal(t, resolvedWorkspace, configuration.Root)
+	require.Equal(t, "modules/users/services/forge-edge/builder/Dockerfile", configuration.Dockerfile)
+	require.Equal(t, "modules/users/services/forge-edge/builder/dockerignore", configuration.Ignorefile)
+}
+
+func TestGoDockerBuilderConfigurationRejectsServiceOutsideContext(t *testing.T) {
+	workspace := t.TempDir()
+	service := t.TempDir()
+
+	_, err := goDockerBuilderConfiguration(
+		service,
+		&resources.DockerImage{Name: "registry.example.com/forge-edge", Tag: "test"},
+		io.Discard,
+		DockerTemplating{ContextRoot: workspace, Workspace: true},
+	)
+	require.ErrorContains(t, err, "outside Docker context root")
+}


### PR DESCRIPTION
Closes #114.

## Summary

- Let Go agents select an exact ancestor Docker context while keeping Dockerfile and ignore paths anchored to the service.
- Resolve symlinks and reject any service outside the declared build root.
- Preserve the existing service-directory context by default.

## Test plan

- [x] `go test ./runners/golang -run TestGoDockerBuilderConfiguration -count=1`
- [x] Existing golang/docker package tests run; unrelated full-package fixture tests reached their existing Docker/Nix paths.
- [x] Exact workspace path and escape rejection are covered.