### PR TITLE
Declare environment GitOps topology (#117)

### DIFF
--- a/resources/environment.go
+++ b/resources/environment.go
@@ -63,6 +63,50 @@ type EnvironmentSecretProvider struct {
 	Account string `yaml:"account,omitempty"`
 }
 
+// EnvironmentGitops identifies the reviewed repository snapshot reconciled for
+// one environment.
+type EnvironmentGitops struct {
+	RepoURL      string `yaml:"repo-url"`
+	FetchRepoURL string `yaml:"fetch-repo-url,omitempty"`
+	Path         string `yaml:"path"`
+	Branch       string `yaml:"branch"`
+	Revision     string `yaml:"revision"`
+	Checkout     string `yaml:"checkout,omitempty"`
+	Inventory    string `yaml:"inventory"`
+}
+
+// EnvironmentIngressRoute binds one public service endpoint to exact hosts.
+type EnvironmentIngressRoute struct {
+	Name     string   `yaml:"name"`
+	Service  string   `yaml:"service"`
+	Endpoint string   `yaml:"endpoint"`
+	Hosts    []string `yaml:"hosts"`
+}
+
+// EnvironmentSecretStoreReference selects the External Secrets store that
+// resolves a managed-service handoff.
+type EnvironmentSecretStoreReference struct {
+	Name string `yaml:"name"`
+	Kind string `yaml:"kind"`
+}
+
+// EnvironmentManagedSecretReference maps a remote managed secret into a
+// namespaced Kubernetes Secret.
+type EnvironmentManagedSecretReference struct {
+	Name        string                          `yaml:"name"`
+	RemoteKey   string                          `yaml:"remote-key"`
+	SecretStore EnvironmentSecretStoreReference `yaml:"secret-store"`
+}
+
+// EnvironmentManagedService describes an environment-owned replacement for a
+// service that is otherwise part of the module graph.
+type EnvironmentManagedService struct {
+	Kind             string                              `yaml:"kind"`
+	ExternalName     string                              `yaml:"external-name"`
+	EgressCIDRs      []string                            `yaml:"egress-cidrs,omitempty"`
+	SecretReferences []EnvironmentManagedSecretReference `yaml:"secret-references,omitempty"`
+}
+
 // Environment is a configuration for an environment
 type Environment struct {
 	Name        string `yaml:"name"`
@@ -84,6 +128,10 @@ type Environment struct {
 	Cluster   *EnvironmentCluster  `yaml:"cluster,omitempty"`
 	Registry  *EnvironmentRegistry `yaml:"registry,omitempty"`
 	Namespace string               `yaml:"namespace,omitempty"`
+	Gitops    *EnvironmentGitops   `yaml:"gitops,omitempty"`
+
+	Ingress         []EnvironmentIngressRoute            `yaml:"ingress,omitempty"`
+	ManagedServices map[string]EnvironmentManagedService `yaml:"managed-services,omitempty"`
 
 	// Secrets lists the secret backends for this environment. Reference-only
 	// manifests fail when their backend is absent. Legacy plaintext *.secret.*

--- a/resources/environment_test.go
+++ b/resources/environment_test.go
@@ -1,5 +1,76 @@
 package resources_test
 
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+)
+
+func TestEnvironmentGitopsTopologyLoadsFromWorkspace(t *testing.T) {
+	root := t.TempDir()
+	workspace := `name: platform
+layout: modules
+environments:
+  - name: aws
+    namespace: platform
+    cluster:
+      kind: eks
+    registry:
+      url: registry.example.com/platform
+      auth: ecr
+    gitops:
+      repo-url: https://github.com/acme/platform.git
+      path: clusters/aws
+      branch: production
+      revision: release-v1
+      checkout: .
+      inventory: clusters/aws/deployments/modules/users/.codefly-render.json
+    ingress:
+      - name: edge
+        service: gateway
+        endpoint: https
+        hosts:
+          - api.example.com
+    managed-services:
+      store:
+        kind: rds-postgresql
+        external-name: store.internal.example.com
+        egress-cidrs:
+          - 10.12.0.0/16
+        secret-references:
+          - name: store-secrets
+            remote-key: platform/users/store
+            secret-store:
+              name: aws-secrets-manager
+              kind: ClusterSecretStore
+`
+	if err := os.WriteFile(filepath.Join(root, resources.WorkspaceConfigurationName), []byte(workspace), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := resources.LoadWorkspaceFromDir(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Environments) != 1 {
+		t.Fatalf("environments = %d, want 1", len(loaded.Environments))
+	}
+	environment := loaded.Environments[0]
+	if environment.Gitops == nil || environment.Gitops.Revision != "release-v1" {
+		t.Fatalf("gitops = %+v", environment.Gitops)
+	}
+	if len(environment.Ingress) != 1 || environment.Ingress[0].Hosts[0] != "api.example.com" {
+		t.Fatalf("ingress = %+v", environment.Ingress)
+	}
+	store, ok := environment.ManagedServices["store"]
+	if !ok || store.Kind != "rds-postgresql" || len(store.SecretReferences) != 1 {
+		t.Fatalf("managed store = %+v, present = %t", store, ok)
+	}
+}
+
 //
 //func TestEnvironment(t *testing.T) {
 //	ctx := context.Background()


### PR DESCRIPTION
Closes #117.

## Summary
- Give CLI and module agents one typed environment contract for GitOps publication, ingress, and managed-service handoffs.
- Preserve exact repository, revision, route, CIDR, and external-secret reference inputs when loading a workspace.

## Test plan
- [x] `go test ./resources`
- [x] `go test ./...`