### PR TITLE
Release Core v0.2.55

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.54
+version: 0.2.55


### PR DESCRIPTION
## Summary
- Release the typed environment GitOps topology contract required by deterministic module snapshots.

## Test plan
- [x] `go test ./...`
- [x] Core CI