### PR TITLE
Honor internal DNS contracts (#120)

### DIFF
--- a/network/remote_manager.go
+++ b/network/remote_manager.go
@@ -95,60 +95,16 @@ func (m *RemoteManager) GenerateNetworkMappings(ctx context.Context,
 			continue
 		}
 
-		// Internal endpoints. Lookup order:
-		//
-		//   1. Declared DNS (a dns/<env>/dns.codefly.yaml entry — the
-		//      historical override path used to point services at
-		//      host.docker.internal during `codefly run`).
-		//
-		//   2. Cluster-internal DNS synthesized from the service's
-		//      Kubernetes Service name + namespace. This is what
-		//      "modern deploy" wants by default — an in-cluster app
-		//      should reach `<svc>.<ns>.svc.cluster.local` regardless
-		//      of any user-authored YAML.
-		//
-		//   3. Localhost fallback for `local*` environments without a
-		//      declared DNS — preserves the legacy `codefly run`
-		//      behavior on dev machines.
+		// Internal endpoints use a declared environment DNS contract when
+		// present. Otherwise Kubernetes service discovery is synthesized.
 		port := standards.Port(endpoint.Api)
 		dns, dnsErr := m.dnsManager.GetDNS(ctx, service, endpoint.Name)
-		if dnsErr != nil && !env.Local() {
-			// Cluster envs: synthesize cluster-internal DNS so deploys
-			// don't depend on a user-authored dns.codefly.yaml file.
-			// Resolves issue #56 — saas-starter deploys hit "no DNS
-			// found" because their dns/ dirs are tuned for run, not
-			// for in-cluster k8s.
-			namespace, nsErr := m.GetNamespace(ctx, env, workspace, service)
-			if nsErr != nil {
-				return nil, nsErr
-			}
-			dns = &basev0.DNS{
-				Name:     service.Unique(),
-				Module:   service.Module,
-				Service:  service.Name,
-				Endpoint: endpoint.Name,
-				Host:     fmt.Sprintf("%s.%s.svc.cluster.local", service.Name, namespace),
-				Port:     uint32(port),
-				Secured:  false,
-			}
-		} else if dnsErr != nil {
-			// local-env fallback: bind to localhost on the canonical
-			// port for the API kind.
-			dns = &basev0.DNS{
-				Name:     service.Unique(),
-				Module:   service.Module,
-				Service:  service.Name,
-				Endpoint: endpoint.Name,
-				Host:     "localhost",
-				Port:     uint32(port),
-				Secured:  false,
-			}
-		}
-		if dns != nil {
+		if dnsErr == nil && dns != nil {
 			nm.Instances = []*basev0.NetworkInstance{
-				PublicInstance(DNS(service, endpoint, dns)),
+				ContainerInstance(DNS(service, endpoint, dns)),
 			}
-			w.Debug("will expose public endpoint to load balancer", wool.Field("dns", dns))
+			out = append(out, nm)
+			continue
 		}
 
 		namespace, err := m.GetNamespace(ctx, env, workspace, service)

--- a/network/remote_manager_test.go
+++ b/network/remote_manager_test.go
@@ -4,8 +4,18 @@ import (
 	"context"
 	"testing"
 
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
 	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/standards"
 )
+
+type remoteDNSManager struct {
+	dns *basev0.DNS
+}
+
+func (manager remoteDNSManager) GetDNS(context.Context, *resources.ServiceIdentity, string) (*basev0.DNS, error) {
+	return manager.dns, nil
+}
 
 func TestRemoteManagerUsesDeclaredEnvironmentNamespace(t *testing.T) {
 	manager := &RemoteManager{}
@@ -45,5 +55,73 @@ func TestRemoteManagerSynthesizesLegacyNamespaceWhenUndeclared(t *testing.T) {
 		if namespace != test.want {
 			t.Fatalf("layout %s namespace = %q, want %q", test.layout, namespace, test.want)
 		}
+	}
+}
+
+func TestRemoteManagerUsesDeclaredInternalDNSForContainerAccess(t *testing.T) {
+	manager, err := NewRemoteManager(context.Background(), remoteDNSManager{
+		dns: &basev0.DNS{
+			Host:    "store.platform.svc.cluster.local",
+			Port:    5432,
+			Secured: false,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	environment := &resources.Environment{Name: "aws", Namespace: "platform"}
+	workspace := &resources.Workspace{Name: "mind", Layout: resources.LayoutKindModules}
+	service := &resources.ServiceIdentity{Module: "users", Name: "store"}
+	endpoint := &basev0.Endpoint{
+		Module:  "users",
+		Service: "store",
+		Name:    "tcp",
+		Api:     standards.TCP,
+	}
+
+	mappings, err := manager.GenerateNetworkMappings(context.Background(), environment, workspace, service, []*basev0.Endpoint{endpoint})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mappings) != 1 || len(mappings[0].Instances) != 1 {
+		t.Fatalf("mappings = %#v, want one mapping with one instance", mappings)
+	}
+	instance := mappings[0].Instances[0]
+	if instance.GetAccess().GetKind() != resources.NetworkAccessContainer {
+		t.Fatalf("access = %q, want %q", instance.GetAccess().GetKind(), resources.NetworkAccessContainer)
+	}
+	if instance.GetHostname() != "store.platform.svc.cluster.local" || instance.GetPort() != 5432 {
+		t.Fatalf("instance = %s:%d, want store.platform.svc.cluster.local:5432", instance.GetHostname(), instance.GetPort())
+	}
+}
+
+func TestRemoteManagerSynthesizesInternalDNSWhenUndeclared(t *testing.T) {
+	manager, err := NewRemoteManager(context.Background(), remoteDNSManager{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	environment := &resources.Environment{Name: "aws", Namespace: "platform"}
+	workspace := &resources.Workspace{Name: "mind", Layout: resources.LayoutKindModules}
+	service := &resources.ServiceIdentity{Module: "users", Name: "accounts"}
+	endpoint := &basev0.Endpoint{
+		Module:  "users",
+		Service: "accounts",
+		Name:    "grpc",
+		Api:     standards.GRPC,
+	}
+
+	mappings, err := manager.GenerateNetworkMappings(context.Background(), environment, workspace, service, []*basev0.Endpoint{endpoint})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mappings) != 1 || len(mappings[0].Instances) != 1 {
+		t.Fatalf("mappings = %#v, want one mapping with one instance", mappings)
+	}
+	instance := mappings[0].Instances[0]
+	if instance.GetAccess().GetKind() != resources.NetworkAccessContainer {
+		t.Fatalf("access = %q, want %q", instance.GetAccess().GetKind(), resources.NetworkAccessContainer)
+	}
+	if instance.GetHostname() != "accounts.platform.svc.cluster.local" || instance.GetPort() != uint32(standards.Port(standards.GRPC)) {
+		t.Fatalf("instance = %s:%d, want accounts.platform.svc.cluster.local:%d", instance.GetHostname(), instance.GetPort(), standards.Port(standards.GRPC))
 	}
 }


### PR DESCRIPTION
Closes #120.

## Summary

- Treat declared internal DNS records as the authoritative container-access mapping so Kubernetes consumers retain environment-specific ports.
- Synthesize cluster service discovery only when no internal DNS record is declared.

## Test plan

- [x] `go test ./network`
- [x] `go test ./runners/golang ./sdk`
- [x] Full suite completed with unrelated timing failures, which passed when rerun in their packages.