### PR TITLE
Release core v0.2.56

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.55
+version: 0.2.56


### PR DESCRIPTION
## Summary

- Publish authoritative internal DNS mappings for Kubernetes GitOps consumers.

## Test plan

- [x] Network and affected runner/SDK tests pass on the feature branch.
- [ ] Required pull request checks pass.