### PR TITLE
Make Kubernetes plugin output transport-neutral and manifest-only (#110)

### DIFF
--- a/agents/services/base_builder.go
+++ b/agents/services/base_builder.go
@@ -444,7 +444,11 @@ type DeploymentBase struct {
 	Image       *resources.DockerImage
 	Replicas    int
 	Profile     builderv0.KubernetesOutputProfile
-	GitOps      bool
+	// Restricted is true when the selected profile forbids inline Secret values
+	// and requires digest-pinned, policy-restricted manifests. It is a security
+	// property of the output, not a statement about how the manifests are
+	// transported, reconciled, or promoted.
+	Restricted bool
 
 	// Specialization
 	Parameters any
@@ -606,7 +610,8 @@ func (s *BuilderWrapper) KubernetesDeploymentRequest(_ context.Context, req *bui
 		}
 		switch v.Kubernetes.GetProfile() {
 		case builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1,
-			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1:
+			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1:
 		default:
 			return nil, s.Wool.Wrapf(fmt.Errorf("kubernetes output profile is required"), "cannot deploy")
 		}
@@ -643,8 +648,8 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 	fail := func(err error) (*builderv0.DeploymentResponse, error) {
 		return s.deployError(err, output)
 	}
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
-		if err = validateGitOpsDeploymentRequest(req, kubernetes.GetSecretReferences()); err != nil {
+	if IsRestrictedOutputProfile(profile) {
+		if err = validateRestrictedDeploymentRequest(req, kubernetes.GetSecretReferences()); err != nil {
 			return fail(err)
 		}
 	}
@@ -696,13 +701,13 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 		return fail(err)
 	}
 	configurations = append(configurations, deploymentContext.ConfigMap...)
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+	if IsRestrictedOutputProfile(profile) {
 		if len(manager.Secrets()) > 0 || len(deploymentContext.Secrets) > 0 {
-			return fail(fmt.Errorf("promotable GitOps rendering cannot receive secret values"))
+			return fail(fmt.Errorf("restricted rendering cannot receive secret values"))
 		}
 		for _, configuration := range configurations {
 			if credentialLikeEnvironmentKey(configuration.Key) {
-				return fail(fmt.Errorf("promotable GitOps rendering cannot receive credential-like value %q", configuration.Key))
+				return fail(fmt.Errorf("restricted rendering cannot receive credential-like value %q", configuration.Key))
 			}
 		}
 	}
@@ -744,10 +749,23 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 		return fail(fmt.Errorf("generated Kubernetes manifests violate %s: %s",
 			KubernetesManifestContractVersion, strings.Join(validation.GetViolations(), "; ")))
 	}
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 &&
-		!validation.GetPromotable() {
-		return fail(fmt.Errorf("promotable GitOps rendering requires successful validation"))
+	if IsRestrictedOutputProfile(profile) && !validation.GetRestricted() {
+		return fail(fmt.Errorf("restricted rendering requires successful validation"))
 	}
+	// The bundle describes a deliverable manifest tree, so it is emitted only
+	// once validation has passed. A failed deployment carries validation
+	// evidence but no bundle a consumer could mistake for applyable output.
+	bundle, bundleErr := BuildKubernetesManifestBundle(
+		kubernetes.GetDestination(),
+		req.GetEnvironment().GetName(),
+		profile,
+		validation,
+		kubernetes.GetSecretReferences(),
+	)
+	if bundleErr != nil {
+		return fail(bundleErr)
+	}
+	output.GetKubernetes().Bundle = bundle
 	return s.DeployResponse(deploymentContext.exportedConfiguration, output)
 }
 
@@ -771,7 +789,7 @@ func (s *BuilderWrapper) KustomizeDeploy(ctx context.Context, env *basev0.Enviro
 		return s.Wool.Wrapf(err, "cannot create base")
 	}
 	b.Profile = req.GetProfile()
-	b.GitOps = req.GetProfile() == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1
+	b.Restricted = IsRestrictedOutputProfile(req.GetProfile())
 	err = s.Builder.GenerateGenericKustomize(ctx, fsys, req, b, params)
 	if err != nil {
 		return err
@@ -846,25 +864,25 @@ func (s *BuilderWrapper) GenerateGenericKustomize(ctx context.Context, fsys fs.F
 	return nil
 }
 
-func validateGitOpsDeploymentRequest(
+func validateRestrictedDeploymentRequest(
 	req *builderv0.DeploymentRequest,
 	references map[string]*builderv0.KubernetesSecretKeyReference,
 ) error {
 	for _, configuration := range append([]*basev0.Configuration{req.GetConfiguration()}, req.GetDependenciesConfigurations()...) {
 		for _, information := range configuration.GetInfos() {
 			if data := information.GetData(); data.GetSecret() && len(data.GetContent()) > 0 {
-				return fmt.Errorf("promotable GitOps rendering cannot receive secret data %q", information.GetName())
+				return fmt.Errorf("restricted rendering cannot receive secret data %q", information.GetName())
 			}
 			for _, value := range information.GetConfigurationValues() {
 				if value.GetValue() != "" && (value.GetSecret() || resources.IsSensitiveKey(value.GetKey())) {
-					return fmt.Errorf("promotable GitOps rendering cannot receive secret value %q", value.GetKey())
+					return fmt.Errorf("restricted rendering cannot receive secret value %q", value.GetKey())
 				}
 			}
 		}
 	}
 	for environmentVariable, reference := range references {
 		if environmentVariable == "" || reference.GetName() == "" || reference.GetKey() == "" {
-			return fmt.Errorf("promotable GitOps secret references require environment variable, Secret name, and key")
+			return fmt.Errorf("restricted rendering secret references require environment variable, Secret name, and key")
 		}
 	}
 	return nil

--- a/agents/services/deployment_test.go
+++ b/agents/services/deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -112,7 +113,7 @@ func TestDeployKustomizeCollectsInputsAndRunsPreparation(t *testing.T) {
 	require.Contains(t, string(deploymentManifest), `codefly.dev/test-parameter: "prepared"`)
 }
 
-func TestDeployKustomizeRejectsSecretBytesForGitOps(t *testing.T) {
+func TestDeployKustomizeRejectsSecretBytesForRestricted(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")
 	require.NoError(t, err)
@@ -139,7 +140,7 @@ func TestDeployKustomizeRejectsSecretBytesForGitOps(t *testing.T) {
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: destination,
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			},
 		}},
 		Configuration: configuration("module/service", "application", "TOKEN", "must-not-render", true),
@@ -161,7 +162,7 @@ func TestDeployKustomizeRejectsSecretBytesForGitOps(t *testing.T) {
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: t.TempDir(),
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			},
 		}},
 	}, KustomizeDeployment{
@@ -177,7 +178,7 @@ func TestDeployKustomizeRejectsSecretBytesForGitOps(t *testing.T) {
 	require.Contains(t, response.GetState().GetMessage(), "cannot receive secret values")
 }
 
-func TestDeployKustomizeRejectsSecretConfigurationDataForGitOps(t *testing.T) {
+func TestDeployKustomizeRejectsSecretConfigurationDataForRestricted(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")
 	require.NoError(t, err)
@@ -205,7 +206,7 @@ func TestDeployKustomizeRejectsSecretConfigurationDataForGitOps(t *testing.T) {
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: destination,
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			},
 		}},
 		Configuration: &basev0.Configuration{
@@ -237,7 +238,7 @@ func TestDeployKustomizeRejectsSecretConfigurationDataForGitOps(t *testing.T) {
 	require.Empty(t, entries)
 }
 
-func TestDeployKustomizeRendersPromotableSecretFreeGitOpsTreeWithoutClusterAccess(t *testing.T) {
+func TestDeployKustomizeRendersRestrictedSecretFreeTreeWithoutClusterAccess(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")
 	require.NoError(t, err)
@@ -264,7 +265,7 @@ func TestDeployKustomizeRendersPromotableSecretFreeGitOpsTreeWithoutClusterAcces
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: destination,
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 				SecretReferences: map[string]*builderv0.KubernetesSecretKeyReference{
 					"DATABASE_PASSWORD": {Name: "service-secrets", Key: "database-password"},
 				},
@@ -283,10 +284,12 @@ func TestDeployKustomizeRendersPromotableSecretFreeGitOpsTreeWithoutClusterAcces
 	require.NoError(t, err)
 	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState())
 	output := response.GetDeployment().GetKubernetes()
-	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1, output.GetProfile())
+	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1, output.GetProfile())
 	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_PASSED, output.GetValidation().GetStaticValidation())
 	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_NOT_RUN, output.GetValidation().GetServerSideValidation())
-	require.True(t, output.GetValidation().GetPromotable())
+	require.True(t, output.GetValidation().GetRestricted())
+	require.Equal(t, output.GetValidation().GetRestricted(), output.GetValidation().GetPromotable(), //nolint:staticcheck // deprecated field must mirror restricted for the migration window
+		"deprecated promotable field must mirror restricted for the neutral profile")
 	secretManifest, err := os.ReadFile(filepath.Join(destination, "base", "secret.yaml"))
 	require.NoError(t, err)
 	require.Empty(t, strings.TrimSpace(string(secretManifest)))
@@ -367,7 +370,7 @@ func TestDeployKustomizeDoesNotRetainSecretsBetweenRequests(t *testing.T) {
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: gitOpsDestination,
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 				SecretReferences: map[string]*builderv0.KubernetesSecretKeyReference{
 					"TOKEN": {Name: "service-secrets", Key: "token"},
 				},
@@ -447,7 +450,7 @@ func TestDeployKustomizeKeepsConcurrentOutputsRequestScoped(t *testing.T) {
 				Kubernetes: &builderv0.KubernetesDeployment{
 					Namespace:   "codefly",
 					Destination: gitOpsDestination,
-					Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+					Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 					BuildContext: &builderv0.DockerBuildContext{
 						ImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					},
@@ -479,7 +482,7 @@ func TestDeployKustomizeKeepsConcurrentOutputsRequestScoped(t *testing.T) {
 	)
 	require.NoError(t, gitOps.err)
 	require.Equal(t,
-		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 		gitOps.response.GetDeployment().GetKubernetes().GetProfile(),
 	)
 }
@@ -535,7 +538,7 @@ func TestDeployKustomizeReturnsValidationEvidenceOnFailure(t *testing.T) {
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
 				Destination: t.TempDir(),
-				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				Profile:     builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			},
 		}},
 	}, KustomizeDeployment{EnvironmentVariables: manager, Templates: templates})
@@ -543,9 +546,11 @@ func TestDeployKustomizeReturnsValidationEvidenceOnFailure(t *testing.T) {
 	require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
 	output := response.GetDeployment().GetKubernetes()
 	require.Equal(t, KubernetesManifestContractVersion, output.GetContractVersion())
-	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1, output.GetProfile())
+	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1, output.GetProfile())
 	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_FAILED, output.GetValidation().GetStaticValidation())
 	require.Contains(t, strings.Join(output.GetValidation().GetViolations(), "\n"), "emits a Secret resource")
+	require.Contains(t, response.GetState().GetMessage(), "emits a Secret resource")
+	require.Nil(t, output.GetBundle(), "a failed deployment must not emit a deliverable manifest bundle")
 }
 
 func TestDeployKustomizeRejectsMissingDependencies(t *testing.T) {
@@ -604,6 +609,96 @@ func TestApplicationDeploymentInputs(t *testing.T) {
 	require.True(t, inputs.DependencyEndpoints)
 	require.True(t, inputs.OwnConfiguration)
 	require.True(t, inputs.DependencyConfigurations)
+}
+
+func restrictedDeployBuilder(ctx context.Context, t *testing.T) (*BuilderWrapper, *resources.EnvironmentVariableManager) {
+	t.Helper()
+	manager := resources.NewEnvironmentVariableManager()
+	identity := &resources.ServiceIdentity{Workspace: "workspace", Module: "module", Name: "service", Version: "1.2.3"}
+	base := &Base{
+		Wool:                 wool.Get(ctx),
+		Identity:             identity,
+		Information:          &Information{Service: resources.ToServiceWithCase(identity)},
+		EnvironmentVariables: manager,
+		loaded:               true,
+	}
+	base.SetDockerImage(&resources.DockerImage{
+		Name:   "example/service",
+		Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	builder := &BuilderWrapper{Base: base}
+	base.Builder = builder
+	return builder, manager
+}
+
+func renderRestricted(ctx context.Context, t *testing.T, profile builderv0.KubernetesOutputProfile) *builderv0.KubernetesDeploymentOutput {
+	t.Helper()
+	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")
+	require.NoError(t, err)
+	builder, manager := restrictedDeployBuilder(ctx, t)
+	response, err := builder.DeployKustomize(ctx, &builderv0.DeploymentRequest{
+		Environment: &basev0.Environment{Name: "test"},
+		Deployment: &builderv0.Deployment{Kind: &builderv0.Deployment_Kubernetes{
+			Kubernetes: &builderv0.KubernetesDeployment{
+				Namespace:   "codefly",
+				Destination: t.TempDir(),
+				Profile:     profile,
+				SecretReferences: map[string]*builderv0.KubernetesSecretKeyReference{
+					"DATABASE_PASSWORD": {Name: "service-secrets", Key: "database-password"},
+				},
+			},
+		}},
+	}, KustomizeDeployment{
+		EnvironmentVariables: manager,
+		Templates:            templates,
+		Parameters:           struct{ Name string }{Name: "restricted"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState())
+	return response.GetDeployment().GetKubernetes()
+}
+
+func TestDeployKustomizeEmitsDeterministicManifestBundle(t *testing.T) {
+	ctx := context.Background()
+	output := renderRestricted(ctx, t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1)
+	bundle := output.GetBundle()
+	require.NotNil(t, bundle)
+	require.Equal(t, builderv0.KubernetesDeploymentOutput_KUSTOMIZE, bundle.GetFormat())
+	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1, bundle.GetProfile())
+	require.Equal(t, KubernetesManifestContractVersion, bundle.GetContractVersion())
+	require.Equal(t, []string{"overlays/test"}, bundle.GetEntryPoints())
+	require.NotEmpty(t, bundle.GetFiles())
+	require.True(t, bundle.GetValidation().GetRestricted())
+	require.Contains(t, bundle.GetSecretReferences(), "DATABASE_PASSWORD")
+
+	paths := make([]string, 0, len(bundle.GetFiles()))
+	for _, file := range bundle.GetFiles() {
+		require.True(t, strings.HasPrefix(file.GetDigest(), "sha256:"), "file %s digest %q", file.GetPath(), file.GetDigest())
+		require.NotContains(t, file.GetPath(), `\`, "file inventory must use POSIX paths")
+		paths = append(paths, file.GetPath())
+	}
+	require.True(t, sort.StringsAreSorted(paths), "file inventory must be sorted: %v", paths)
+	require.Contains(t, paths, "base/deployment.yaml")
+	require.True(t, strings.HasPrefix(bundle.GetDigest(), "sha256:"))
+
+	// The same inputs rendered into a different destination yield an identical
+	// bundle digest: the bundle is a deterministic function of the inputs, not
+	// of the caller-supplied destination path.
+	again := renderRestricted(ctx, t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1)
+	require.Equal(t, bundle.GetDigest(), again.GetBundle().GetDigest())
+}
+
+func TestDeployKustomizeAcceptsDeprecatedPromotableGitOpsProfile(t *testing.T) {
+	ctx := context.Background()
+	//nolint:staticcheck // deprecated profile retained for the migration window
+	deprecated := renderRestricted(ctx, t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1)
+	require.True(t, deprecated.GetValidation().GetRestricted())
+	require.True(t, deprecated.GetValidation().GetPromotable(), "deprecated promotable flag mirrors restricted for existing clients")
+
+	// The deprecated profile renders the identical restricted bundle as its
+	// neutral successor: a supported migration path, not a reinterpretation.
+	neutral := renderRestricted(ctx, t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1)
+	require.Equal(t, neutral.GetBundle().GetDigest(), deprecated.GetBundle().GetDigest())
 }
 
 func configuration(origin, name, key, value string, secret bool) *basev0.Configuration {

--- a/agents/services/kubernetes_contract_test.go
+++ b/agents/services/kubernetes_contract_test.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// deliverySystemTerms names transport, reconciliation, and promotion mechanisms
+// a manifest-producing plugin must never encode in its contract. A plugin emits
+// a deterministic manifest bundle; a separate deployment component decides how
+// that bundle is delivered.
+var deliverySystemTerms = []string{
+	"gitops",
+	"git",
+	"github",
+	"gitlab",
+	"argo",
+	"flux",
+	"repository",
+	"repo",
+	"reconcile",
+	"reconciler",
+	"promotable",
+	"promotion",
+	"promote",
+	"branch",
+	"commit",
+	"pullrequest",
+	"pull_request",
+}
+
+func bannedDeliveryTerm(name string) string {
+	lowered := strings.ToLower(name)
+	for _, term := range deliverySystemTerms {
+		if strings.Contains(lowered, term) {
+			return term
+		}
+	}
+	return ""
+}
+
+// TestKubernetesPluginContractHasNoDeliverySystemTerms proves the active
+// plugin-facing deployment contract names no delivery mechanism. Legacy
+// identifiers are permitted only while explicitly marked deprecated, which
+// scopes them to the documented migration window.
+func TestKubernetesPluginContractHasNoDeliverySystemTerms(t *testing.T) {
+	file := builderv0.File_codefly_services_builder_v0_deployment_proto
+
+	enums := file.Enums()
+	for i := 0; i < enums.Len(); i++ {
+		assertEnumNeutral(t, enums.Get(i))
+	}
+	messages := file.Messages()
+	for i := 0; i < messages.Len(); i++ {
+		assertMessageNeutral(t, messages.Get(i))
+	}
+}
+
+func assertMessageNeutral(t *testing.T, message protoreflect.MessageDescriptor) {
+	t.Helper()
+	deprecated := false
+	if options, ok := message.Options().(*descriptorpb.MessageOptions); ok {
+		deprecated = options.GetDeprecated()
+	}
+	if !deprecated {
+		if term := bannedDeliveryTerm(string(message.Name())); term != "" {
+			t.Errorf("message %s names delivery mechanism %q in the active contract", message.FullName(), term)
+		}
+	}
+	fields := message.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		fieldDeprecated := deprecated
+		if options, ok := field.Options().(*descriptorpb.FieldOptions); ok && options.GetDeprecated() {
+			fieldDeprecated = true
+		}
+		if fieldDeprecated {
+			continue
+		}
+		if term := bannedDeliveryTerm(string(field.Name())); term != "" {
+			t.Errorf("field %s names delivery mechanism %q in the active contract", field.FullName(), term)
+		}
+	}
+	nested := message.Messages()
+	for i := 0; i < nested.Len(); i++ {
+		assertMessageNeutral(t, nested.Get(i))
+	}
+	nestedEnums := message.Enums()
+	for i := 0; i < nestedEnums.Len(); i++ {
+		assertEnumNeutral(t, nestedEnums.Get(i))
+	}
+}
+
+func assertEnumNeutral(t *testing.T, enum protoreflect.EnumDescriptor) {
+	t.Helper()
+	values := enum.Values()
+	for i := 0; i < values.Len(); i++ {
+		value := values.Get(i)
+		if options, ok := value.Options().(*descriptorpb.EnumValueOptions); ok && options.GetDeprecated() {
+			continue
+		}
+		if term := bannedDeliveryTerm(string(value.Name())); term != "" {
+			t.Errorf("enum value %s.%s names delivery mechanism %q in the active contract", enum.FullName(), value.Name(), term)
+		}
+	}
+}
+
+// TestKubernetesRenderingInputsHaveNoDeliverySystemFields proves the shared
+// rendering inputs handed to plugin templates expose no delivery-system flag.
+func TestKubernetesRenderingInputsHaveNoDeliverySystemFields(t *testing.T) {
+	for _, target := range []reflect.Type{
+		reflect.TypeFor[DeploymentBase](),
+		reflect.TypeFor[DeploymentWrapper](),
+		reflect.TypeFor[DeploymentParameters](),
+	} {
+		for i := 0; i < target.NumField(); i++ {
+			field := target.Field(i)
+			if term := bannedDeliveryTerm(field.Name); term != "" {
+				t.Errorf("%s.%s names delivery mechanism %q in a plugin-facing rendering input", target.Name(), field.Name, term)
+			}
+		}
+	}
+}
+
+// TestRestrictedProfileHasNoDeliverySystemDependencies asserts the restricted
+// contract is a self-contained enum property with no companion transport type.
+func TestRestrictedProfileHasNoDeliverySystemDependencies(t *testing.T) {
+	require.True(t, IsRestrictedOutputProfile(builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1))
+	require.True(t, IsRestrictedOutputProfile(builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1)) //nolint:staticcheck // migration compatibility
+	require.False(t, IsRestrictedOutputProfile(builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1))
+	require.False(t, IsRestrictedOutputProfile(builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED))
+}

--- a/agents/services/kubernetes_manifest.go
+++ b/agents/services/kubernetes_manifest.go
@@ -3,10 +3,13 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -21,6 +24,86 @@ import (
 
 // KubernetesManifestContractVersion identifies the policy recorded in deployment output.
 const KubernetesManifestContractVersion = "codefly.dev/kubernetes-manifest/v1"
+
+// IsRestrictedOutputProfile reports whether a profile selects the secret-free,
+// digest-pinned, policy-restricted contract. It accepts the transport-neutral
+// RESTRICTED_PORTABLE_V1 profile and its deprecated PROMOTABLE_GITOPS_V1
+// predecessor, which render the identical restricted bundle during migration.
+func IsRestrictedOutputProfile(profile builderv0.KubernetesOutputProfile) bool {
+	switch profile {
+	case builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
+		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1:
+		return true
+	default:
+		return false
+	}
+}
+
+// BuildKubernetesManifestBundle inventories the rendered tree at destination and
+// returns a mechanism-neutral manifest-bundle description: the applied entry
+// point, the canonical sorted file inventory with per-file sha256 digests, and
+// an aggregate digest that is a deterministic function of that inventory.
+func BuildKubernetesManifestBundle(
+	destination string,
+	environment string,
+	profile builderv0.KubernetesOutputProfile,
+	validation *builderv0.KubernetesManifestValidation,
+	secretReferences map[string]*builderv0.KubernetesSecretKeyReference,
+) (*builderv0.KubernetesManifestBundle, error) {
+	files, err := inventoryManifestFiles(destination)
+	if err != nil {
+		return nil, fmt.Errorf("inventory rendered tree: %w", err)
+	}
+	return &builderv0.KubernetesManifestBundle{
+		Format:           builderv0.KubernetesDeploymentOutput_KUSTOMIZE,
+		Profile:          profile,
+		ContractVersion:  KubernetesManifestContractVersion,
+		EntryPoints:      []string{path.Join("overlays", environment)},
+		Files:            files,
+		Digest:           aggregateManifestDigest(files),
+		Validation:       validation,
+		SecretReferences: secretReferences,
+	}, nil
+}
+
+func inventoryManifestFiles(destination string) ([]*builderv0.KubernetesManifestFile, error) {
+	var files []*builderv0.KubernetesManifestFile
+	err := filepath.WalkDir(destination, func(entryPath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(entryPath)
+		if readErr != nil {
+			return readErr
+		}
+		relative, relErr := filepath.Rel(destination, entryPath)
+		if relErr != nil {
+			return relErr
+		}
+		sum := sha256.Sum256(content)
+		files = append(files, &builderv0.KubernetesManifestFile{
+			Path:   filepath.ToSlash(relative),
+			Digest: "sha256:" + hex.EncodeToString(sum[:]),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].GetPath() < files[j].GetPath() })
+	return files, nil
+}
+
+func aggregateManifestDigest(files []*builderv0.KubernetesManifestFile) string {
+	hasher := sha256.New()
+	for _, file := range files {
+		fmt.Fprintf(hasher, "%s\x00%s\n", file.GetPath(), file.GetDigest())
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
 
 var unresolvedManifestValue = regexp.MustCompile(`\{\{|\}\}|\$\{[^}]+\}|(?i)\b(?:CHANGE_ME|REPLACE_ME)\b`)
 var pinnedImage = regexp.MustCompile(`@sha256:[a-fA-F0-9]{64}$`)
@@ -107,10 +190,8 @@ func ValidateKubernetesManifestTree(
 		StaticValidation:     builderv0.KubernetesManifestValidation_STATUS_PASSED,
 		ServerSideValidation: builderv0.KubernetesManifestValidation_STATUS_NOT_RUN,
 	}
-	switch profile {
-	case builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1,
-		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1:
-	default:
+	if profile != builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1 &&
+		!IsRestrictedOutputProfile(profile) {
 		result.StaticValidation = builderv0.KubernetesManifestValidation_STATUS_FAILED
 		result.Violations = []string{"unsupported Kubernetes output profile"}
 		return result
@@ -142,10 +223,11 @@ func ValidateKubernetesManifestTree(
 		result.ValidatedContext = validationContext
 	}
 
-	result.Promotable = profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 &&
+	result.Restricted = IsRestrictedOutputProfile(profile) &&
 		result.StaticValidation == builderv0.KubernetesManifestValidation_STATUS_PASSED &&
 		(!validateServerSide ||
 			result.ServerSideValidation == builderv0.KubernetesManifestValidation_STATUS_PASSED)
+	result.Promotable = result.Restricted
 	return result
 }
 
@@ -174,7 +256,7 @@ func buildKustomizeManifest(
 			}
 			violations = append(violations, fmt.Sprintf("%s contains an unresolved placeholder", relative))
 		}
-		if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+		if IsRestrictedOutputProfile(profile) {
 			decoder := yaml.NewDecoder(bytes.NewReader(content))
 			for {
 				var value map[string]any
@@ -306,7 +388,7 @@ func (object *kubernetesManifestObject) validate(namespace string, profile build
 	if strings.Contains(strings.ToLower(object.kind), "secret") {
 		violations = append(violations, object.validateSecretContract(profile)...)
 	}
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 && object.kind == "ConfigMap" {
+	if IsRestrictedOutputProfile(profile) && object.kind == "ConfigMap" {
 		violations = append(violations, object.validateConfigMap()...)
 	}
 	if object.apiVersion == "rbac.authorization.k8s.io/v1" {
@@ -335,7 +417,7 @@ func (object *kubernetesManifestObject) isCodeflyOwned() bool {
 }
 
 func (object *kubernetesManifestObject) validateSecretContract(profile builderv0.KubernetesOutputProfile) []string {
-	if profile != builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+	if !IsRestrictedOutputProfile(profile) {
 		return nil
 	}
 	ref := object.reference()
@@ -572,13 +654,13 @@ func (object *kubernetesManifestObject) validateContainer(
 	image := stringValue(container, "image")
 	if image == "" {
 		violations = append(violations, fmt.Sprintf("%s has no image", ref))
-	} else if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 && !pinnedImage.MatchString(image) {
+	} else if IsRestrictedOutputProfile(profile) && !pinnedImage.MatchString(image) {
 		violations = append(violations, fmt.Sprintf("%s image %q is not pinned by sha256 digest", ref, image))
 	}
 	violations = append(violations, validateContainerSecurity(container, ref)...)
 	violations = append(violations, validateContainerResources(container, ref)...)
 	violations = append(violations, validateContainerPorts(container, ref)...)
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+	if IsRestrictedOutputProfile(profile) {
 		violations = append(violations, validateContainerSecretReferences(container, ref)...)
 	}
 	violations = append(violations, validateContainerHealth(container, ref, requireProbes)...)

--- a/agents/services/testdata/deployment/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/agents/services/testdata/deployment/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
           livenessProbe:
             exec:
               command: ["true"]
-{{- if not .GitOps }}
+{{- if not .Restricted }}
           envFrom:
             - secretRef:
                 name: {{ .Name }}

--- a/agents/services/testdata/deployment/templates/deployment/kustomize/base/kustomization.yaml.tmpl
+++ b/agents/services/testdata/deployment/templates/deployment/kustomize/base/kustomization.yaml.tmpl
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - config-map.yaml
   - deployment.yaml
-{{- if not .GitOps }}
+{{- if not .Restricted }}
   - secret.yaml
 {{- end }}

--- a/agents/services/testdata/deployment/templates/deployment/kustomize/base/secret.yaml.tmpl
+++ b/agents/services/testdata/deployment/templates/deployment/kustomize/base/secret.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/agents/testing/composition.go
+++ b/agents/testing/composition.go
@@ -93,8 +93,11 @@ func MissingField(field string) string {
 	return fmt.Sprintf("%s not populated (intentional for agents without this setting)", field)
 }
 
-// AssertKustomizeTemplates runs both v1 output profiles and the shared hostile
-// contract suite against a plugin's embedded deployment templates.
+// AssertKustomizeTemplates runs every supported output profile and the shared
+// hostile contract suite against a plugin's embedded deployment templates. The
+// restricted contract is exercised through the transport-neutral
+// RESTRICTED_PORTABLE_V1 profile and, for the migration window, through its
+// deprecated PROMOTABLE_GITOPS_V1 predecessor, which must render identically.
 //
 // The returned directory can be used for plugin-specific assertions:
 //
@@ -113,7 +116,13 @@ func AssertKustomizeTemplates(t *testing.T, templates fs.FS, parameters any) str
 		t,
 		templates,
 		parameters,
-		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
+	)
+	assertKustomizeProfile(
+		t,
+		templates,
+		parameters,
+		builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1, //nolint:staticcheck // migration compatibility
 	)
 	return ephemeral
 }
@@ -137,7 +146,7 @@ func assertKustomizeProfile(
 		Identity:    identity,
 		Information: &services.Information{Service: resources.ToServiceWithCase(identity), Module: resources.ToModuleWithCase(identity)},
 	}
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+	if services.IsRestrictedOutputProfile(profile) {
 		base.SetDockerImage(&resources.DockerImage{
 			Name:   "example/service",
 			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -173,7 +182,7 @@ func assertKustomizeProfile(
 	if validation.GetStaticValidation() != builderv0.KubernetesManifestValidation_STATUS_PASSED {
 		t.Fatalf("%s static conformance failed:\n%s", profile, strings.Join(validation.GetViolations(), "\n"))
 	}
-	if profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+	if services.IsRestrictedOutputProfile(profile) {
 		err := filepath.WalkDir(destination, func(path string, entry fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
@@ -475,7 +484,7 @@ func assertInvalidKustomization(t *testing.T) {
 			destination,
 			"test",
 			"codefly-test",
-			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			false,
 			"",
 			"",
@@ -529,7 +538,7 @@ resources:
 			destination,
 			"test",
 			"codefly-test",
-			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			false,
 			"",
 			"",
@@ -584,7 +593,7 @@ resources:
 			destination,
 			"test",
 			"codefly-test",
-			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+			builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1,
 			false,
 			"",
 			"",

--- a/docs/agent-development.md
+++ b/docs/agent-development.md
@@ -133,16 +133,27 @@ structured response.
 
 ## Deployment golden paths
 
-The deployment request must select one versioned Kubernetes output profile:
+The deployment request must select one versioned Kubernetes output profile. A
+profile describes only the security properties of the rendered manifests; it
+never names how they are later transported, reconciled, or promoted.
 
 - `KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1` may embed Kubernetes
   `Secret` data for a tightly scoped local apply.
-- `KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1` rejects secret-bearing
+- `KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1` produces secret-free,
+  digest-pinned, policy-restricted manifests. It rejects secret-bearing
   configuration input and exposes only identifier-only `secret_references` to
   templates.
+- `KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1` is **deprecated**. It named a
+  delivery mechanism in a plugin-facing contract; it is retained only so
+  existing callers keep rendering the identical restricted bundle during the
+  migration window. See [Migration and compatibility](#migration-and-compatibility).
 
 An unspecified profile fails before rendering. The profile is selected by the
 CLI, so the standard plugin `Deploy` methods below do not hard-code it.
+
+A plugin renders this bundle deterministically from its inputs alone. It needs
+no Git, GitHub, Argo CD, Flux, network access, kubeconfig, or cluster
+credentials to produce a restricted bundle.
 
 ### Application
 
@@ -201,7 +212,7 @@ func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) 
 The preparation context can also set `deployment.Parameters`, call
 `deployment.AddConfigMap(...)`, or call `deployment.AddSecrets(...)`.
 `AddSecrets` is valid only for the ephemeral profile; core rejects it for a
-GitOps render.
+restricted render.
 
 Generic resource plugins own the portable self-hosted workload only.
 Provider-specific managed database, object-store, or secret-manager adapters
@@ -251,18 +262,21 @@ Core exposes stable shallow fields for common templates:
 | `.Sha` | deployment change marker |
 | `.Replicas` | default replica count |
 | `.Profile` | selected versioned output profile |
-| `.GitOps` | true for the promotable GitOps v1 profile |
+| `.Restricted` | true when the profile forbids inline `Secret` values and requires digest-pinned, policy-restricted manifests |
 | `.ConfigMap` | non-secret environment map |
 | `.SecretMap` | base64-encoded secret map; populated only for ephemeral local apply |
 | `.SecretReferences` | environment variable to Secret name/key references; contains no values |
 | `.Deployment.Parameters` | plugin-specific parameter object |
 
-Secret templates must render no Kubernetes object for GitOps. Conditional
-resource lists alone are insufficient because an unreferenced file is still
-part of the generated tree:
+`.Restricted` is a security property, not a statement about transport. Branch on
+it — never on a delivery mechanism.
+
+Secret templates must render no Kubernetes object under a restricted profile.
+Conditional resource lists alone are insufficient because an unreferenced file
+is still part of the generated tree:
 
 ```gotemplate
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -275,11 +289,11 @@ data:
 {{- end }}
 ```
 
-GitOps workloads consume externally reconciled or pre-existing Secrets through
+Restricted workloads consume externally managed or pre-existing Secrets through
 the identifier-only references:
 
 ```gotemplate
-{{- if .GitOps }}
+{{- if .Restricted }}
 env:
 {{- range $environmentVariable, $reference := .SecretReferences }}
   - name: {{ $environmentVariable }}
@@ -295,7 +309,7 @@ env:
 The v1 contract permits `external-secrets.io/v1` `ExternalSecret` resources
 that reference a namespaced `SecretStore`. It rejects inline target templates,
 cluster stores, provider credentials, and all Kubernetes `Secret` objects in a
-GitOps tree.
+restricted tree.
 
 ## Kubernetes manifest contract
 
@@ -308,19 +322,60 @@ cluster-internal. Namespace, ServiceAccount, Role, and RoleBinding resources
 must carry `app.kubernetes.io/managed-by: codefly`; cluster-scoped resources are
 rejected.
 
-The GitOps profile additionally requires every image to use a full
+The restricted profile additionally requires every image to use a full
 `@sha256:<64 hex characters>` digest. The CLI supplies an application image
 digest through `DockerBuildContext.image_digest`; stock-image plugins set
 `resources.DockerImage.Digest`.
 
 Core records `codefly.dev/kubernetes-manifest/v1`, the selected profile, static
-validation, server-side validation, violations, and the final `promotable`
+validation, server-side validation, violations, and the final `restricted`
 decision in `KubernetesDeploymentOutput`. When
 `KubernetesDeployment.validate_server_side` is true, core runs
 `kubectl apply --server-side --dry-run=server` so the active cluster performs
-schema, admission, and webhook checks. A GitOps tree is promotable only when
-both static and server-side validation pass; core returns a deployment error
-for every other GitOps result, and callers must preserve that failure.
+schema, admission, and webhook checks. That server-side dry-run is an optional,
+explicitly targeted pre-flight — the restricted bundle itself renders without a
+cluster. A restricted tree is `restricted` only when both static and requested
+server-side validation pass; core returns a deployment error for every other
+restricted result, and callers must preserve that failure.
+
+### Manifest bundle
+
+Core also emits a mechanism-neutral `KubernetesManifestBundle` on
+`KubernetesDeploymentOutput.bundle`. It is a deterministic description of the
+rendered tree that a separate deployment component consumes to choose local
+apply, repository publication, review, and reconciliation:
+
+- `format` and `profile` — the artifact format and the security profile applied.
+- `contract_version` — the validator contract recorded above.
+- `entry_points` — destination-relative directories to apply, in order (the
+  environment overlay).
+- `files` — the canonical, sorted inventory of owned files, each with a
+  `sha256:<hex>` content digest.
+- `digest` — an aggregate `sha256:<hex>` over that inventory. Identical inputs
+  yield an identical digest regardless of the caller-supplied destination path.
+- `validation` — the conformance evidence above.
+- `secret_references` — externally managed Secret identifiers, never values.
+
+The bundle contains no Git, repository, reconciler, cluster, or credential
+type. CLI and server consumers read the same contract.
+
+## Migration and compatibility
+
+Issue #110 made this contract transport-neutral. During the compatibility
+window:
+
+- Prefer `KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1`. The deprecated
+  `KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1` (enum value `2`) still renders
+  the **identical** restricted bundle — a supported migration path, not a
+  silent reinterpretation. New enum values are added, never repurposed.
+- Replace the removed `.GitOps` template field with `.Restricted`. Both selected
+  the same behavior; only the name changed.
+- `KubernetesManifestValidation.restricted` supersedes the deprecated
+  `promotable` field. Core keeps both populated with the same value; migrate
+  reads to `restricted`.
+- Deprecated identifiers are retained only for this window. Core's contract test
+  enforces that every non-deprecated message, field, and enum value stays free
+  of delivery-system terminology, so no new surface may reintroduce it.
 
 ## Runtime
 
@@ -371,12 +426,13 @@ func TestDeploymentTemplates(t *testing.T) {
 }
 ```
 
-It renders both v1 profiles with representative config, secret references,
-image data, and plugin parameters. It builds each overlay with the Kustomize
-library, applies the complete restricted policy, verifies that the GitOps tree
-does not contain the secret sentinel, and runs the shared positive and hostile
-contract suite. Optional server-side validation belongs in a cluster-backed
-integration test.
+It renders every supported profile — ephemeral, restricted/portable, and the
+deprecated GitOps profile for migration coverage — with representative config,
+secret references, image data, and plugin parameters. It builds each overlay
+with the Kustomize library, applies the complete restricted policy, verifies
+that a restricted tree does not contain the secret sentinel, and runs the shared
+positive and hostile contract suite. Optional server-side validation belongs in
+a cluster-backed integration test.
 
 Add focused assertions for conditional resources such as migration Jobs.
 

--- a/generated/go/codefly/services/builder/v0/deployment.pb.go
+++ b/generated/go/codefly/services/builder/v0/deployment.pb.go
@@ -68,6 +68,9 @@ func (DeploymentKind) EnumDescriptor() ([]byte, []int) {
 }
 
 // KubernetesOutputProfile selects a versioned Kubernetes manifest contract.
+// A profile describes only the security properties of the rendered manifests.
+// It never names how the manifests are later transported, reconciled, or
+// promoted: that is the concern of a separate deployment component.
 type KubernetesOutputProfile int32
 
 const (
@@ -75,8 +78,18 @@ const (
 	KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED KubernetesOutputProfile = 0
 	// KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1 permits inline Secret data for a local apply.
 	KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1 KubernetesOutputProfile = 1
-	// KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 produces secret-free, restricted manifests.
+	// KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 is superseded by
+	// KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1. It names a delivery
+	// mechanism in a plugin-facing contract and is retained only so existing
+	// callers keep rendering the identical restricted bundle during migration.
+	//
+	// Deprecated: Marked as deprecated in codefly/services/builder/v0/deployment.proto.
 	KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 KubernetesOutputProfile = 2
+	// KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1 produces secret-free,
+	// digest-pinned, policy-restricted manifests that carry no dependency on any
+	// delivery mechanism. It is the transport-neutral successor to
+	// KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1.
+	KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1 KubernetesOutputProfile = 3
 )
 
 // Enum value maps for KubernetesOutputProfile.
@@ -85,11 +98,13 @@ var (
 		0: "KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED",
 		1: "KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1",
 		2: "KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1",
+		3: "KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1",
 	}
 	KubernetesOutputProfile_value = map[string]int32{
 		"KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED":              0,
 		"KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1": 1,
 		"KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1":     2,
+		"KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1":   3,
 	}
 )
 
@@ -542,14 +557,21 @@ type KubernetesManifestValidation struct {
 	StaticValidation KubernetesManifestValidation_Status `protobuf:"varint,1,opt,name=static_validation,json=staticValidation,proto3,enum=codefly.services.builder.v0.KubernetesManifestValidation_Status" json:"static_validation,omitempty"`
 	// server_side_validation covers Kubernetes schema and admission through dry-run apply.
 	ServerSideValidation KubernetesManifestValidation_Status `protobuf:"varint,2,opt,name=server_side_validation,json=serverSideValidation,proto3,enum=codefly.services.builder.v0.KubernetesManifestValidation_Status" json:"server_side_validation,omitempty"`
-	// promotable is true only for a GitOps profile that passed every required stage.
+	// promotable is superseded by restricted. It names a delivery decision in a
+	// plugin-facing contract and is retained only for existing consumers during
+	// migration; it always carries the same value as restricted.
+	//
+	// Deprecated: Marked as deprecated in codefly/services/builder/v0/deployment.proto.
 	Promotable bool `protobuf:"varint,3,opt,name=promotable,proto3" json:"promotable,omitempty"`
 	// violations contains stable, human-readable rejection reasons.
 	Violations []string `protobuf:"bytes,4,rep,name=violations,proto3" json:"violations,omitempty"`
 	// validated_context is the exact kubeconfig context used for server-side validation.
 	ValidatedContext string `protobuf:"bytes,5,opt,name=validated_context,json=validatedContext,proto3" json:"validated_context,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// restricted is true only for a restricted/portable profile that passed every
+	// required stage. It reports a security property, never a delivery decision.
+	Restricted    bool `protobuf:"varint,6,opt,name=restricted,proto3" json:"restricted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *KubernetesManifestValidation) Reset() {
@@ -596,6 +618,7 @@ func (x *KubernetesManifestValidation) GetServerSideValidation() KubernetesManif
 	return KubernetesManifestValidation_STATUS_UNSPECIFIED
 }
 
+// Deprecated: Marked as deprecated in codefly/services/builder/v0/deployment.proto.
 func (x *KubernetesManifestValidation) GetPromotable() bool {
 	if x != nil {
 		return x.Promotable
@@ -617,6 +640,13 @@ func (x *KubernetesManifestValidation) GetValidatedContext() string {
 	return ""
 }
 
+func (x *KubernetesManifestValidation) GetRestricted() bool {
+	if x != nil {
+		return x.Restricted
+	}
+	return false
+}
+
 // KubernetesDeploymentOutput describes generated Kubernetes deployment artifacts.
 type KubernetesDeploymentOutput struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -626,8 +656,11 @@ type KubernetesDeploymentOutput struct {
 	Profile KubernetesOutputProfile `protobuf:"varint,2,opt,name=profile,proto3,enum=codefly.services.builder.v0.KubernetesOutputProfile" json:"profile,omitempty"`
 	// contract_version identifies the validator contract applied to the tree.
 	ContractVersion string `protobuf:"bytes,3,opt,name=contract_version,json=contractVersion,proto3" json:"contract_version,omitempty"`
-	// validation reports whether the tree is safe to promote.
-	Validation    *KubernetesManifestValidation `protobuf:"bytes,4,opt,name=validation,proto3" json:"validation,omitempty"`
+	// validation reports whether the tree satisfies the manifest contract.
+	Validation *KubernetesManifestValidation `protobuf:"bytes,4,opt,name=validation,proto3" json:"validation,omitempty"`
+	// bundle is the transport-neutral manifest-bundle description a deployment
+	// component consumes to apply, publish, or reconcile the rendered tree.
+	Bundle        *KubernetesManifestBundle `protobuf:"bytes,5,opt,name=bundle,proto3" json:"bundle,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -690,6 +723,183 @@ func (x *KubernetesDeploymentOutput) GetValidation() *KubernetesManifestValidati
 	return nil
 }
 
+func (x *KubernetesDeploymentOutput) GetBundle() *KubernetesManifestBundle {
+	if x != nil {
+		return x.Bundle
+	}
+	return nil
+}
+
+// KubernetesManifestFile records one owned file in a manifest bundle inventory.
+type KubernetesManifestFile struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// path is the destination-relative POSIX path of an owned file.
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	// digest is the content digest of the file, formatted as "sha256:<hex>".
+	Digest        string `protobuf:"bytes,2,opt,name=digest,proto3" json:"digest,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KubernetesManifestFile) Reset() {
+	*x = KubernetesManifestFile{}
+	mi := &file_codefly_services_builder_v0_deployment_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubernetesManifestFile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubernetesManifestFile) ProtoMessage() {}
+
+func (x *KubernetesManifestFile) ProtoReflect() protoreflect.Message {
+	mi := &file_codefly_services_builder_v0_deployment_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KubernetesManifestFile.ProtoReflect.Descriptor instead.
+func (*KubernetesManifestFile) Descriptor() ([]byte, []int) {
+	return file_codefly_services_builder_v0_deployment_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *KubernetesManifestFile) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *KubernetesManifestFile) GetDigest() string {
+	if x != nil {
+		return x.Digest
+	}
+	return ""
+}
+
+// KubernetesManifestBundle is a mechanism-neutral description of a rendered
+// Kubernetes manifest tree. A plugin emits it as a deterministic function of
+// its inputs; it never references Git, a reconciler, a cluster, or credentials.
+// A separate deployment component consumes it to choose local apply,
+// repository publication, review, and reconciliation.
+type KubernetesManifestBundle struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// format identifies the manifest artifact format.
+	Format KubernetesDeploymentOutput_Kind `protobuf:"varint,1,opt,name=format,proto3,enum=codefly.services.builder.v0.KubernetesDeploymentOutput_Kind" json:"format,omitempty"`
+	// profile is the versioned output profile used to render the tree.
+	Profile KubernetesOutputProfile `protobuf:"varint,2,opt,name=profile,proto3,enum=codefly.services.builder.v0.KubernetesOutputProfile" json:"profile,omitempty"`
+	// contract_version identifies the validator contract applied to the tree.
+	ContractVersion string `protobuf:"bytes,3,opt,name=contract_version,json=contractVersion,proto3" json:"contract_version,omitempty"`
+	// entry_points are the destination-relative directories a consumer applies,
+	// in the order they are applied.
+	EntryPoints []string `protobuf:"bytes,4,rep,name=entry_points,json=entryPoints,proto3" json:"entry_points,omitempty"`
+	// files is the canonical, sorted inventory of owned files with content digests.
+	Files []*KubernetesManifestFile `protobuf:"bytes,5,rep,name=files,proto3" json:"files,omitempty"`
+	// digest is the aggregate content digest over the canonical file inventory,
+	// formatted as "sha256:<hex>". Identical inputs yield an identical digest.
+	Digest string `protobuf:"bytes,6,opt,name=digest,proto3" json:"digest,omitempty"`
+	// validation reports conformance evidence for the rendered tree.
+	Validation *KubernetesManifestValidation `protobuf:"bytes,7,opt,name=validation,proto3" json:"validation,omitempty"`
+	// secret_references identifies externally managed Secrets, never secret values.
+	SecretReferences map[string]*KubernetesSecretKeyReference `protobuf:"bytes,8,rep,name=secret_references,json=secretReferences,proto3" json:"secret_references,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *KubernetesManifestBundle) Reset() {
+	*x = KubernetesManifestBundle{}
+	mi := &file_codefly_services_builder_v0_deployment_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubernetesManifestBundle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubernetesManifestBundle) ProtoMessage() {}
+
+func (x *KubernetesManifestBundle) ProtoReflect() protoreflect.Message {
+	mi := &file_codefly_services_builder_v0_deployment_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KubernetesManifestBundle.ProtoReflect.Descriptor instead.
+func (*KubernetesManifestBundle) Descriptor() ([]byte, []int) {
+	return file_codefly_services_builder_v0_deployment_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *KubernetesManifestBundle) GetFormat() KubernetesDeploymentOutput_Kind {
+	if x != nil {
+		return x.Format
+	}
+	return KubernetesDeploymentOutput_KUSTOMIZE
+}
+
+func (x *KubernetesManifestBundle) GetProfile() KubernetesOutputProfile {
+	if x != nil {
+		return x.Profile
+	}
+	return KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED
+}
+
+func (x *KubernetesManifestBundle) GetContractVersion() string {
+	if x != nil {
+		return x.ContractVersion
+	}
+	return ""
+}
+
+func (x *KubernetesManifestBundle) GetEntryPoints() []string {
+	if x != nil {
+		return x.EntryPoints
+	}
+	return nil
+}
+
+func (x *KubernetesManifestBundle) GetFiles() []*KubernetesManifestFile {
+	if x != nil {
+		return x.Files
+	}
+	return nil
+}
+
+func (x *KubernetesManifestBundle) GetDigest() string {
+	if x != nil {
+		return x.Digest
+	}
+	return ""
+}
+
+func (x *KubernetesManifestBundle) GetValidation() *KubernetesManifestValidation {
+	if x != nil {
+		return x.Validation
+	}
+	return nil
+}
+
+func (x *KubernetesManifestBundle) GetSecretReferences() map[string]*KubernetesSecretKeyReference {
+	if x != nil {
+		return x.SecretReferences
+	}
+	return nil
+}
+
 var File_codefly_services_builder_v0_deployment_proto protoreflect.FileDescriptor
 
 const file_codefly_services_builder_v0_deployment_proto_rawDesc = "" +
@@ -721,37 +931,59 @@ const file_codefly_services_builder_v0_deployment_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\x02 \x01(\v27.codefly.services.builder.v0.KubernetesDeploymentOutputH\x00R\n" +
 	"kubernetesB\x06\n" +
-	"\x04kind\"\xce\x03\n" +
+	"\x04kind\"\xf2\x03\n" +
 	"\x1cKubernetesManifestValidation\x12m\n" +
 	"\x11static_validation\x18\x01 \x01(\x0e2@.codefly.services.builder.v0.KubernetesManifestValidation.StatusR\x10staticValidation\x12v\n" +
-	"\x16server_side_validation\x18\x02 \x01(\x0e2@.codefly.services.builder.v0.KubernetesManifestValidation.StatusR\x14serverSideValidation\x12\x1e\n" +
+	"\x16server_side_validation\x18\x02 \x01(\x0e2@.codefly.services.builder.v0.KubernetesManifestValidation.StatusR\x14serverSideValidation\x12\"\n" +
 	"\n" +
-	"promotable\x18\x03 \x01(\bR\n" +
+	"promotable\x18\x03 \x01(\bB\x02\x18\x01R\n" +
 	"promotable\x12\x1e\n" +
 	"\n" +
 	"violations\x18\x04 \x03(\tR\n" +
 	"violations\x12+\n" +
-	"\x11validated_context\x18\x05 \x01(\tR\x10validatedContext\"Z\n" +
+	"\x11validated_context\x18\x05 \x01(\tR\x10validatedContext\x12\x1e\n" +
+	"\n" +
+	"restricted\x18\x06 \x01(\bR\n" +
+	"restricted\"Z\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSTATUS_PASSED\x10\x01\x12\x11\n" +
 	"\rSTATUS_FAILED\x10\x02\x12\x12\n" +
-	"\x0eSTATUS_NOT_RUN\x10\x03\"\xdb\x02\n" +
+	"\x0eSTATUS_NOT_RUN\x10\x03\"\xaa\x03\n" +
 	"\x1aKubernetesDeploymentOutput\x12P\n" +
 	"\x04kind\x18\x01 \x01(\x0e2<.codefly.services.builder.v0.KubernetesDeploymentOutput.KindR\x04kind\x12N\n" +
 	"\aprofile\x18\x02 \x01(\x0e24.codefly.services.builder.v0.KubernetesOutputProfileR\aprofile\x12)\n" +
 	"\x10contract_version\x18\x03 \x01(\tR\x0fcontractVersion\x12Y\n" +
 	"\n" +
 	"validation\x18\x04 \x01(\v29.codefly.services.builder.v0.KubernetesManifestValidationR\n" +
-	"validation\"\x15\n" +
+	"validation\x12M\n" +
+	"\x06bundle\x18\x05 \x01(\v25.codefly.services.builder.v0.KubernetesManifestBundleR\x06bundle\"\x15\n" +
 	"\x04Kind\x12\r\n" +
-	"\tKUSTOMIZE\x10\x00*\x1f\n" +
+	"\tKUSTOMIZE\x10\x00\"D\n" +
+	"\x16KubernetesManifestFile\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x16\n" +
+	"\x06digest\x18\x02 \x01(\tR\x06digest\"\xc6\x05\n" +
+	"\x18KubernetesManifestBundle\x12T\n" +
+	"\x06format\x18\x01 \x01(\x0e2<.codefly.services.builder.v0.KubernetesDeploymentOutput.KindR\x06format\x12N\n" +
+	"\aprofile\x18\x02 \x01(\x0e24.codefly.services.builder.v0.KubernetesOutputProfileR\aprofile\x12)\n" +
+	"\x10contract_version\x18\x03 \x01(\tR\x0fcontractVersion\x12!\n" +
+	"\fentry_points\x18\x04 \x03(\tR\ventryPoints\x12I\n" +
+	"\x05files\x18\x05 \x03(\v23.codefly.services.builder.v0.KubernetesManifestFileR\x05files\x12\x16\n" +
+	"\x06digest\x18\x06 \x01(\tR\x06digest\x12Y\n" +
+	"\n" +
+	"validation\x18\a \x01(\v29.codefly.services.builder.v0.KubernetesManifestValidationR\n" +
+	"validation\x12x\n" +
+	"\x11secret_references\x18\b \x03(\v2K.codefly.services.builder.v0.KubernetesManifestBundle.SecretReferencesEntryR\x10secretReferences\x1a~\n" +
+	"\x15SecretReferencesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
+	"\x05value\x18\x02 \x01(\v29.codefly.services.builder.v0.KubernetesSecretKeyReferenceR\x05value:\x028\x01*\x1f\n" +
 	"\x0eDeploymentKind\x12\r\n" +
-	"\tKUSTOMIZE\x10\x00*\xb0\x01\n" +
+	"\tKUSTOMIZE\x10\x00*\xea\x01\n" +
 	"\x17KubernetesOutputProfile\x12)\n" +
 	"%KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED\x10\x00\x126\n" +
-	"2KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1\x10\x01\x122\n" +
-	".KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1\x10\x02B\x88\x02\n" +
+	"2KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1\x10\x01\x126\n" +
+	".KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1\x10\x02\x1a\x02\b\x01\x124\n" +
+	"0KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1\x10\x03B\x88\x02\n" +
 	"\x1fcom.codefly.services.builder.v0B\x0fDeploymentProtoP\x01ZDgithub.com/codefly-dev/core/generated/go/codefly/services/builder/v0\xa2\x02\x04CSBV\xaa\x02\x1bCodefly.Services.Builder.V0\xca\x02\x1bCodefly\\Services\\Builder\\V0\xe2\x02'Codefly\\Services\\Builder\\V0\\GPBMetadata\xea\x02\x1eCodefly::Services::Builder::V0b\x06proto3"
 
 var (
@@ -767,7 +999,7 @@ func file_codefly_services_builder_v0_deployment_proto_rawDescGZIP() []byte {
 }
 
 var file_codefly_services_builder_v0_deployment_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_codefly_services_builder_v0_deployment_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_codefly_services_builder_v0_deployment_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_codefly_services_builder_v0_deployment_proto_goTypes = []any{
 	(DeploymentKind)(0),                      // 0: codefly.services.builder.v0.DeploymentKind
 	(KubernetesOutputProfile)(0),             // 1: codefly.services.builder.v0.KubernetesOutputProfile
@@ -779,26 +1011,36 @@ var file_codefly_services_builder_v0_deployment_proto_goTypes = []any{
 	(*DeploymentOutput)(nil),                 // 7: codefly.services.builder.v0.DeploymentOutput
 	(*KubernetesManifestValidation)(nil),     // 8: codefly.services.builder.v0.KubernetesManifestValidation
 	(*KubernetesDeploymentOutput)(nil),       // 9: codefly.services.builder.v0.KubernetesDeploymentOutput
-	nil,                                      // 10: codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry
-	(*DockerBuildContext)(nil),               // 11: codefly.services.builder.v0.DockerBuildContext
+	(*KubernetesManifestFile)(nil),           // 10: codefly.services.builder.v0.KubernetesManifestFile
+	(*KubernetesManifestBundle)(nil),         // 11: codefly.services.builder.v0.KubernetesManifestBundle
+	nil,                                      // 12: codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry
+	nil,                                      // 13: codefly.services.builder.v0.KubernetesManifestBundle.SecretReferencesEntry
+	(*DockerBuildContext)(nil),               // 14: codefly.services.builder.v0.DockerBuildContext
 }
 var file_codefly_services_builder_v0_deployment_proto_depIdxs = []int32{
 	6,  // 0: codefly.services.builder.v0.Deployment.kubernetes:type_name -> codefly.services.builder.v0.KubernetesDeployment
-	11, // 1: codefly.services.builder.v0.KubernetesDeployment.build_context:type_name -> codefly.services.builder.v0.DockerBuildContext
+	14, // 1: codefly.services.builder.v0.KubernetesDeployment.build_context:type_name -> codefly.services.builder.v0.DockerBuildContext
 	1,  // 2: codefly.services.builder.v0.KubernetesDeployment.profile:type_name -> codefly.services.builder.v0.KubernetesOutputProfile
-	10, // 3: codefly.services.builder.v0.KubernetesDeployment.secret_references:type_name -> codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry
+	12, // 3: codefly.services.builder.v0.KubernetesDeployment.secret_references:type_name -> codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry
 	9,  // 4: codefly.services.builder.v0.DeploymentOutput.kubernetes:type_name -> codefly.services.builder.v0.KubernetesDeploymentOutput
 	2,  // 5: codefly.services.builder.v0.KubernetesManifestValidation.static_validation:type_name -> codefly.services.builder.v0.KubernetesManifestValidation.Status
 	2,  // 6: codefly.services.builder.v0.KubernetesManifestValidation.server_side_validation:type_name -> codefly.services.builder.v0.KubernetesManifestValidation.Status
 	3,  // 7: codefly.services.builder.v0.KubernetesDeploymentOutput.kind:type_name -> codefly.services.builder.v0.KubernetesDeploymentOutput.Kind
 	1,  // 8: codefly.services.builder.v0.KubernetesDeploymentOutput.profile:type_name -> codefly.services.builder.v0.KubernetesOutputProfile
 	8,  // 9: codefly.services.builder.v0.KubernetesDeploymentOutput.validation:type_name -> codefly.services.builder.v0.KubernetesManifestValidation
-	5,  // 10: codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry.value:type_name -> codefly.services.builder.v0.KubernetesSecretKeyReference
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	11, // 10: codefly.services.builder.v0.KubernetesDeploymentOutput.bundle:type_name -> codefly.services.builder.v0.KubernetesManifestBundle
+	3,  // 11: codefly.services.builder.v0.KubernetesManifestBundle.format:type_name -> codefly.services.builder.v0.KubernetesDeploymentOutput.Kind
+	1,  // 12: codefly.services.builder.v0.KubernetesManifestBundle.profile:type_name -> codefly.services.builder.v0.KubernetesOutputProfile
+	10, // 13: codefly.services.builder.v0.KubernetesManifestBundle.files:type_name -> codefly.services.builder.v0.KubernetesManifestFile
+	8,  // 14: codefly.services.builder.v0.KubernetesManifestBundle.validation:type_name -> codefly.services.builder.v0.KubernetesManifestValidation
+	13, // 15: codefly.services.builder.v0.KubernetesManifestBundle.secret_references:type_name -> codefly.services.builder.v0.KubernetesManifestBundle.SecretReferencesEntry
+	5,  // 16: codefly.services.builder.v0.KubernetesDeployment.SecretReferencesEntry.value:type_name -> codefly.services.builder.v0.KubernetesSecretKeyReference
+	5,  // 17: codefly.services.builder.v0.KubernetesManifestBundle.SecretReferencesEntry.value:type_name -> codefly.services.builder.v0.KubernetesSecretKeyReference
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_codefly_services_builder_v0_deployment_proto_init() }
@@ -819,7 +1061,7 @@ func file_codefly_services_builder_v0_deployment_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_codefly_services_builder_v0_deployment_proto_rawDesc), len(file_codefly_services_builder_v0_deployment_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/codefly/services/builder/v0/deployment.proto
+++ b/proto/codefly/services/builder/v0/deployment.proto
@@ -10,13 +10,24 @@ enum DeploymentKind {
 }
 
 // KubernetesOutputProfile selects a versioned Kubernetes manifest contract.
+// A profile describes only the security properties of the rendered manifests.
+// It never names how the manifests are later transported, reconciled, or
+// promoted: that is the concern of a separate deployment component.
 enum KubernetesOutputProfile {
   // KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED does not authorize manifest rendering.
   KUBERNETES_OUTPUT_PROFILE_UNSPECIFIED = 0;
   // KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1 permits inline Secret data for a local apply.
   KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1 = 1;
-  // KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 produces secret-free, restricted manifests.
-  KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 = 2;
+  // KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 is superseded by
+  // KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1. It names a delivery
+  // mechanism in a plugin-facing contract and is retained only so existing
+  // callers keep rendering the identical restricted bundle during migration.
+  KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 = 2 [deprecated = true];
+  // KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1 produces secret-free,
+  // digest-pinned, policy-restricted manifests that carry no dependency on any
+  // delivery mechanism. It is the transport-neutral successor to
+  // KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1.
+  KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1 = 3;
 }
 
 // Deployment selects the deployment target and input format.
@@ -84,12 +95,17 @@ message KubernetesManifestValidation {
   Status static_validation = 1;
   // server_side_validation covers Kubernetes schema and admission through dry-run apply.
   Status server_side_validation = 2;
-  // promotable is true only for a GitOps profile that passed every required stage.
-  bool promotable = 3;
+  // promotable is superseded by restricted. It names a delivery decision in a
+  // plugin-facing contract and is retained only for existing consumers during
+  // migration; it always carries the same value as restricted.
+  bool promotable = 3 [deprecated = true];
   // violations contains stable, human-readable rejection reasons.
   repeated string violations = 4;
   // validated_context is the exact kubeconfig context used for server-side validation.
   string validated_context = 5;
+  // restricted is true only for a restricted/portable profile that passed every
+  // required stage. It reports a security property, never a delivery decision.
+  bool restricted = 6;
 }
 
 // KubernetesDeploymentOutput describes generated Kubernetes deployment artifacts.
@@ -105,6 +121,43 @@ message KubernetesDeploymentOutput {
   KubernetesOutputProfile profile = 2;
   // contract_version identifies the validator contract applied to the tree.
   string contract_version = 3;
-  // validation reports whether the tree is safe to promote.
+  // validation reports whether the tree satisfies the manifest contract.
   KubernetesManifestValidation validation = 4;
+  // bundle is the transport-neutral manifest-bundle description a deployment
+  // component consumes to apply, publish, or reconcile the rendered tree.
+  KubernetesManifestBundle bundle = 5;
+}
+
+// KubernetesManifestFile records one owned file in a manifest bundle inventory.
+message KubernetesManifestFile {
+  // path is the destination-relative POSIX path of an owned file.
+  string path = 1;
+  // digest is the content digest of the file, formatted as "sha256:<hex>".
+  string digest = 2;
+}
+
+// KubernetesManifestBundle is a mechanism-neutral description of a rendered
+// Kubernetes manifest tree. A plugin emits it as a deterministic function of
+// its inputs; it never references Git, a reconciler, a cluster, or credentials.
+// A separate deployment component consumes it to choose local apply,
+// repository publication, review, and reconciliation.
+message KubernetesManifestBundle {
+  // format identifies the manifest artifact format.
+  KubernetesDeploymentOutput.Kind format = 1;
+  // profile is the versioned output profile used to render the tree.
+  KubernetesOutputProfile profile = 2;
+  // contract_version identifies the validator contract applied to the tree.
+  string contract_version = 3;
+  // entry_points are the destination-relative directories a consumer applies,
+  // in the order they are applied.
+  repeated string entry_points = 4;
+  // files is the canonical, sorted inventory of owned files with content digests.
+  repeated KubernetesManifestFile files = 5;
+  // digest is the aggregate content digest over the canonical file inventory,
+  // formatted as "sha256:<hex>". Identical inputs yield an identical digest.
+  string digest = 6;
+  // validation reports conformance evidence for the rendered tree.
+  KubernetesManifestValidation validation = 7;
+  // secret_references identifies externally managed Secrets, never secret values.
+  map<string, KubernetesSecretKeyReference> secret_references = 8;
 }


### PR DESCRIPTION
Closes #110.

## Summary
- A Codefly plugin must be a deterministic manifest producer that never knows how its output is transported. This removes GitOps/promotion terminology from the plugin-facing contract and adds a mechanism-neutral `RESTRICTED_PORTABLE_V1` profile plus a typed `KubernetesManifestBundle` that a separate deployment component consumes.
- Protobuf compatibility is preserved by deprecating — not repurposing — the existing enum value and validation field; the deprecated `PROMOTABLE_GITOPS_V1` profile renders the identical restricted bundle during the migration window.
- Core proves the invariant: a contract test enforces that every non-deprecated message, field, and enum value (and the shared rendering inputs) name no delivery mechanism.

## What changed
- **Proto** (`deployment.proto`, regenerated with `codefly generate proto --local`): deprecate `KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1`, add `KUBERNETES_OUTPUT_PROFILE_RESTRICTED_PORTABLE_V1`; deprecate validation `promotable`, add `restricted`; add `KubernetesManifestFile` + `KubernetesManifestBundle` and wire `KubernetesDeploymentOutput.bundle`.
- **Rendering**: remove the plugin-facing `GitOps` flag in favor of a `Restricted` security property (templates branch on `.Restricted`); add exported `IsRestrictedOutputProfile` and `BuildKubernetesManifestBundle` (destination-independent, deterministic digest). The bundle is emitted only after validation passes, so a failed deployment carries validation evidence but no deliverable bundle.
- **Tests**: new contract test proving no delivery-system types/flags; bundle-determinism and deprecated-profile compatibility tests; extended shared conformance harness to run ephemeral + restricted-portable + deprecated profiles.
- **Docs**: `docs/agent-development.md` updated with the neutral profile, `.Restricted`, the manifest bundle, and a migration/compatibility section.

Repository-specific migration issues (CLI/server promotion driver, service plugins, docs, CI enforcement) are tracked from the umbrella issue and are out of scope for this core contract PR.

## Test plan
- [x] `go test ./...` — all 60 packages pass
- [x] `go vet ./agents/...` — clean
- [x] Proto regeneration is reproducible (`codefly generate proto --local` yields no further diff)
- [x] Contract test fails if a non-deprecated proto/struct surface names a delivery mechanism
- [x] Failure-path test fails against the old ordering (bundle must not be emitted on validation failure)