### PR TITLE
Isolate GitOps server-side validation (#127)

### DIFF
--- a/agents/services/deployment_test.go
+++ b/agents/services/deployment_test.go
@@ -323,6 +323,44 @@ func TestServerSideValidationRequiresExplicitClusterTarget(t *testing.T) {
 	require.EqualError(t, err, "server-side validation requires an explicit Kubernetes context")
 }
 
+func TestServerSideValidationUsesIsolatedResourceNames(t *testing.T) {
+	manifest := []byte(`apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: store
+  namespace: platform
+spec:
+  serviceName: store
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seed
+  namespace: platform
+spec:
+  template:
+    spec:
+      containers:
+        - name: seed
+          env:
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: store
+                  key: token
+`)
+
+	isolated, err := isolateServerSideValidationResources(manifest, "12345678")
+	require.NoError(t, err)
+	require.Contains(t, string(isolated), "name: store-codefly-validation-12345678")
+	require.Contains(t, string(isolated), "name: seed-codefly-validation-12345678")
+	require.Contains(t, string(isolated), "serviceName: store")
+	require.Regexp(t, `secretKeyRef:\n\s+key: token\n\s+name: store`, string(isolated))
+
+	longName := strings.Repeat("a", 63)
+	require.Len(t, isolatedValidationResourceName(longName, "12345678"), 63)
+}
+
 func TestDeployKustomizeDoesNotRetainSecretsBetweenRequests(t *testing.T) {
 	ctx := context.Background()
 	templates, err := fs.Sub(deploymentTestFS, "testdata/deployment")

--- a/agents/services/kubernetes_manifest.go
+++ b/agents/services/kubernetes_manifest.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -817,6 +818,14 @@ func validateKubernetesManifestServerSide(
 	if err != nil {
 		return fmt.Errorf("server-side validation requires kubectl: %w", err)
 	}
+	validationToken := make([]byte, 8)
+	if _, err := rand.Read(validationToken); err != nil {
+		return fmt.Errorf("create server-side validation identity: %w", err)
+	}
+	validationManifest, err := isolateServerSideValidationResources(manifest, hex.EncodeToString(validationToken))
+	if err != nil {
+		return fmt.Errorf("prepare server-side validation manifest: %w", err)
+	}
 	command := exec.CommandContext(
 		ctx,
 		kubectl,
@@ -829,12 +838,49 @@ func validateKubernetesManifestServerSide(
 		"--namespace", namespace,
 		"-f", "-",
 	)
-	command.Stdin = bytes.NewReader(manifest)
+	command.Stdin = bytes.NewReader(validationManifest)
 	output, err := command.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("server-side schema/admission validation failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func isolateServerSideValidationResources(manifest []byte, token string) ([]byte, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(manifest))
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	defer encoder.Close()
+
+	for {
+		var value map[string]any
+		err := decoder.Decode(&value)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(value) == 0 {
+			continue
+		}
+		metadata, _ := mapValue(value, "metadata")
+		name, _ := metadata["name"].(string)
+		metadata["name"] = isolatedValidationResourceName(name, token)
+		if err := encoder.Encode(value); err != nil {
+			return nil, err
+		}
+	}
+	return output.Bytes(), nil
+}
+
+func isolatedValidationResourceName(name, token string) string {
+	suffix := "-codefly-validation-" + token
+	prefixLength := 63 - len(suffix)
+	if len(name) > prefixLength {
+		name = strings.TrimRight(name[:prefixLength], "-.")
+	}
+	return name + suffix
 }
 
 func hasRestrictedSeccomp(security map[string]any) bool {

--- a/docs/agent-development.md
+++ b/docs/agent-development.md
@@ -331,12 +331,14 @@ Core records `codefly.dev/kubernetes-manifest/v1`, the selected profile, static
 validation, server-side validation, violations, and the final `restricted`
 decision in `KubernetesDeploymentOutput`. When
 `KubernetesDeployment.validate_server_side` is true, core runs
-`kubectl apply --server-side --dry-run=server` so the active cluster performs
-schema, admission, and webhook checks. That server-side dry-run is an optional,
-explicitly targeted pre-flight — the restricted bundle itself renders without a
-cluster. A restricted tree is `restricted` only when both static and requested
-server-side validation pass; core returns a deployment error for every other
-restricted result, and callers must preserve that failure.
+`kubectl apply --server-side --dry-run=server` with isolated resource names so
+the active cluster performs schema, admission, and webhook checks without
+depending on same-named resources already reconciled by another field manager.
+That server-side dry-run is an optional, explicitly targeted pre-flight — the
+restricted bundle itself renders without a cluster. A restricted tree is
+`restricted` only when both static and requested server-side validation pass;
+core returns a deployment error for every other restricted result, and callers
+must preserve that failure.
 
 ### Manifest bundle
 


### PR DESCRIPTION
Closes #127.

## Summary

- Validate candidate manifests with ephemeral resource identities so Argo-managed objects and immutable update rules cannot corrupt the preflight result.
- Preserve the candidate specifications and references while retaining real cluster schema, admission, and webhook validation.

## Test plan

- [x] `go test ./agents/services -count=1`
- [x] `go test ./...`