### PR TITLE
Release isolated GitOps validation (#129)

### DIFF
--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.57
+version: 0.2.58


### PR DESCRIPTION
Closes #129.

## Summary

- Publishes isolated server-side manifest validation so GitOps rendering remains independent of live Argo ownership.
- Preserves strict cluster schema and admission checks without evaluating candidates as immutable updates.

## Test plan

- [x] `go test ./agents/services`
- [x] Core CI passed on #128
- [x] `git diff --check`
- [x] Signed release commit verified with `git verify-commit`
