### PR TITLE
Carry environment fixtures into deployments (#131)

### DIFF
--- a/agents/services/base_builder.go
+++ b/agents/services/base_builder.go
@@ -656,6 +656,7 @@ func (s *BuilderWrapper) DeployKustomize(ctx context.Context, req *builderv0.Dep
 
 	s.LogDeployRequest(req, s.Wool.Debug)
 	manager := deployment.EnvironmentVariables.DeploymentScope()
+	manager.SetEnvironment(req.GetEnvironment())
 	manager.SetRunning()
 
 	if deployment.Inputs.OwnEndpoints {

--- a/agents/services/deployment_test.go
+++ b/agents/services/deployment_test.go
@@ -42,7 +42,7 @@ func TestDeployKustomizeCollectsInputsAndRunsPreparation(t *testing.T) {
 
 	destination := t.TempDir()
 	req := &builderv0.DeploymentRequest{
-		Environment: &basev0.Environment{Name: "test"},
+		Environment: &basev0.Environment{Name: "test", Fixture: "dev-admin"},
 		Deployment: &builderv0.Deployment{Kind: &builderv0.Deployment_Kubernetes{
 			Kubernetes: &builderv0.KubernetesDeployment{
 				Namespace:   "codefly",
@@ -87,6 +87,8 @@ func TestDeployKustomizeCollectsInputsAndRunsPreparation(t *testing.T) {
 	manifest := string(configMapManifest)
 	for _, expected := range []string{
 		`CODEFLY__RUNNING: "true"`,
+		`CODEFLY__ENVIRONMENT: "test"`,
+		`CODEFLY__FIXTURE: "dev-admin"`,
 		`CODEFLY__SERVICE_CONFIGURATION__MODULE__SERVICE__APPLICATION__PLAIN: "value"`,
 		`CODEFLY__SERVICE_CONFIGURATION__MODULE__SERVICE__CONNECTION__URL: "redis://service"`,
 		`EXTRA: "config"`,

--- a/generated/go/codefly/base/v0/environment.pb.go
+++ b/generated/go/codefly/base/v0/environment.pb.go
@@ -32,7 +32,9 @@ type Environment struct {
 	// A brief description of the environment.
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
 	// naming_scope distinguishes otherwise similar test or ephemeral environments.
-	NamingScope   string `protobuf:"bytes,3,opt,name=naming_scope,json=namingScope,proto3" json:"naming_scope,omitempty"`
+	NamingScope string `protobuf:"bytes,3,opt,name=naming_scope,json=namingScope,proto3" json:"naming_scope,omitempty"`
+	// fixture selects an explicit development data and authentication profile.
+	Fixture       string `protobuf:"bytes,4,opt,name=fixture,proto3" json:"fixture,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -88,6 +90,13 @@ func (x *Environment) GetNamingScope() string {
 	return ""
 }
 
+func (x *Environment) GetFixture() string {
+	if x != nil {
+		return x.Fixture
+	}
+	return ""
+}
+
 // ManagedEnvironment is the platform-managed representation of an environment.
 type ManagedEnvironment struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -138,11 +147,12 @@ var File_codefly_base_v0_environment_proto protoreflect.FileDescriptor
 
 const file_codefly_base_v0_environment_proto_rawDesc = "" +
 	"\n" +
-	"!codefly/base/v0/environment.proto\x12\x0fcodefly.base.v0\x1a\x1bbuf/validate/validate.proto\"f\n" +
+	"!codefly/base/v0/environment.proto\x12\x0fcodefly.base.v0\x1a\x1bbuf/validate/validate.proto\"\x80\x01\n" +
 	"\vEnvironment\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12!\n" +
-	"\fnaming_scope\x18\x03 \x01(\tR\vnamingScope\"8\n" +
+	"\fnaming_scope\x18\x03 \x01(\tR\vnamingScope\x12\x18\n" +
+	"\afixture\x18\x04 \x01(\tR\afixture\"8\n" +
 	"\x12ManagedEnvironment\x12\"\n" +
 	"\x02id\x18\x01 \x01(\tB\x12\xbaH\x0fr\r2\v^[a-z]{10}$R\x02idB\xbf\x01\n" +
 	"\x13com.codefly.base.v0B\x10EnvironmentProtoP\x01Z8github.com/codefly-dev/core/generated/go/codefly/base/v0\xa2\x02\x03CBV\xaa\x02\x0fCodefly.Base.V0\xca\x02\x0fCodefly\\Base\\V0\xe2\x02\x1bCodefly\\Base\\V0\\GPBMetadata\xea\x02\x11Codefly::Base::V0b\x06proto3"

--- a/proto/codefly/base/v0/environment.proto
+++ b/proto/codefly/base/v0/environment.proto
@@ -20,6 +20,8 @@ message Environment {
     string description = 2;
     // naming_scope distinguishes otherwise similar test or ephemeral environments.
     string naming_scope = 3;
+    // fixture selects an explicit development data and authentication profile.
+    string fixture = 4;
 }
 
 // ManagedEnvironment is the platform-managed representation of an environment.

--- a/resources/environment.go
+++ b/resources/environment.go
@@ -112,6 +112,7 @@ type Environment struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`
 	NamingScope string `yaml:"naming-scope,omitempty"`
+	Fixture     string `yaml:"fixture,omitempty"`
 
 	// ConfigurationProfile selects the checked-in configuration directory
 	// independently from the environment identity sent to service agents.
@@ -149,6 +150,7 @@ func (env *Environment) Proto() (*basev0.Environment, error) {
 		Name:        env.Name,
 		Description: env.Description,
 		NamingScope: env.NamingScope,
+		Fixture:     env.Fixture,
 	}
 	err := Validate(proto)
 	if err != nil {
@@ -177,6 +179,7 @@ func EnvironmentFromProto(env *basev0.Environment) *Environment {
 		Name:        env.Name,
 		Description: env.Description,
 		NamingScope: env.NamingScope,
+		Fixture:     env.Fixture,
 	}
 }
 

--- a/resources/environment_variables_manager.go
+++ b/resources/environment_variables_manager.go
@@ -114,8 +114,12 @@ func (holder *EnvironmentVariableManager) getBase() ([]*EnvironmentVariable, err
 		envs = append(envs, Env(RunningPrefix, true))
 	}
 
-	if holder.fixture != "" {
-		envs = append(envs, FixtureAsEnvironmentVariable(holder.fixture))
+	fixture := holder.fixture
+	if fixture == "" && holder.environment != nil {
+		fixture = holder.environment.GetFixture()
+	}
+	if fixture != "" {
+		envs = append(envs, FixtureAsEnvironmentVariable(fixture))
 	}
 
 	envs = append(envs, holder.overrides...)

--- a/resources/environment_variables_manager_runtime_test.go
+++ b/resources/environment_variables_manager_runtime_test.go
@@ -12,12 +12,14 @@ func TestEnvironmentVariableManagerExposesNamingScopeAsRuntimeIdentity(t *testin
 	holder.SetEnvironment(&basev0.Environment{
 		Name:        "production",
 		NamingScope: "stable-eu",
+		Fixture:     "dev-admin",
 	})
 
 	variables, err := holder.getBase()
 	require.NoError(t, err)
 	require.Contains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__ENVIRONMENT=production")
 	require.Contains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__NAMING_SCOPE=stable-eu")
+	require.Contains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__FIXTURE=dev-admin")
 }
 
 func TestEnvironmentVariableManagerOmitsEmptyNamingScope(t *testing.T) {
@@ -27,4 +29,16 @@ func TestEnvironmentVariableManagerOmitsEmptyNamingScope(t *testing.T) {
 	variables, err := holder.getBase()
 	require.NoError(t, err)
 	require.NotContains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__NAMING_SCOPE=")
+	require.NotContains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__FIXTURE=")
+}
+
+func TestEnvironmentVariableManagerExplicitFixtureOverridesEnvironmentFixture(t *testing.T) {
+	holder := NewEnvironmentVariableManager()
+	holder.SetEnvironment(&basev0.Environment{Name: "local", Fixture: "workspace-fixture"})
+	holder.SetFixture("invocation-fixture")
+
+	variables, err := holder.getBase()
+	require.NoError(t, err)
+	require.Contains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__FIXTURE=invocation-fixture")
+	require.NotContains(t, EnvironmentVariableAsStrings(variables), "CODEFLY__FIXTURE=workspace-fixture")
 }

--- a/version/info.codefly.yaml
+++ b/version/info.codefly.yaml
@@ -1,1 +1,1 @@
-version: 0.2.58
+version: 0.2.59


### PR DESCRIPTION
Closes #131.

## Summary

- Make environment identity and explicit fixture selection part of generated workload configuration.
- Preserve invocation-level fixture precedence while keeping empty selections absent.
- Release the additive contract as core 0.2.59.

## Test plan

- [x] `codefly generate proto --proto ./proto --output ./generated --local`
- [x] `GOWORK=off go test ./resources ./agents/services`